### PR TITLE
test: set up Vitest and add unit tests for core modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,12 +18,21 @@
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
         "@tailwindcss/vite": "^4",
         "@tauri-apps/cli": "^2",
+        "@testing-library/jest-dom": "^6.9.1",
         "svelte": "^5.0.0",
         "svelte-check": "^4.0.0",
         "tailwindcss": "^4",
         "typescript": "~5.6.2",
-        "vite": "^6.0.3"
+        "vite": "^6.0.3",
+        "vitest": "^4.1.2"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
@@ -1557,10 +1566,48 @@
         "@tauri-apps/api": "^2.8.0"
       }
     },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1592,6 +1639,119 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.2",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1615,6 +1775,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -1623,6 +1793,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chokidar": {
@@ -1651,6 +1831,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
@@ -1660,6 +1847,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1706,6 +1900,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
@@ -1719,6 +1920,13 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -1780,6 +1988,26 @@
         "@typescript-eslint/types": "^8.2.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1819,6 +2047,16 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/is-reference": {
       "version": "3.0.3",
@@ -2140,6 +2378,16 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -2185,6 +2433,24 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2247,6 +2513,20 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/rollup": {
@@ -2314,6 +2594,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sirv": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
@@ -2337,6 +2624,33 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/svelte": {
@@ -2412,6 +2726,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2427,6 +2758,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/totalist": {
@@ -2546,6 +2887,105 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.2",
+        "@vitest/mocker": "4.1.2",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/runner": "4.1.2",
+        "@vitest/snapshot": "4.1.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.2",
+        "@vitest/browser-preview": "4.1.2",
+        "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/ui": "4.1.2",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/zimmerframe": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "echo 'No linter configured yet'",
-    "test": "echo 'No tests configured yet'",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "tauri": "tauri"
   },
   "license": "MIT",
@@ -23,12 +24,14 @@
     "@sveltejs/adapter-static": "^3.0.6",
     "@sveltejs/kit": "^2.9.0",
     "@sveltejs/vite-plugin-svelte": "^5.0.0",
+    "@tailwindcss/vite": "^4",
+    "@tauri-apps/cli": "^2",
+    "@testing-library/jest-dom": "^6.9.1",
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.0",
     "tailwindcss": "^4",
-    "@tailwindcss/vite": "^4",
     "typescript": "~5.6.2",
     "vite": "^6.0.3",
-    "@tauri-apps/cli": "^2"
+    "vitest": "^4.1.2"
   }
 }

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+globalThis.fetch = mockFetch;
+
+describe('api', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  function mockFetchSuccess(data: unknown) {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(data),
+      status: 200,
+      statusText: 'OK',
+    });
+  }
+
+  function mockFetchError(status: number, statusText: string) {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status,
+      statusText,
+    });
+  }
+
+  describe('getStatus', () => {
+    it('fetches relay status', async () => {
+      const { getStatus } = await import('./api');
+      const mockStatus = { status: 'ok', uptime_seconds: 100, endpoint_count: 2, healthy_count: 2 };
+      mockFetchSuccess(mockStatus);
+
+      const result = await getStatus();
+      expect(result).toEqual(mockStatus);
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/status'),
+        expect.objectContaining({ headers: expect.objectContaining({ 'Content-Type': 'application/json' }) }),
+      );
+    });
+  });
+
+  describe('getEndpoints', () => {
+    it('fetches endpoints list', async () => {
+      const { getEndpoints } = await import('./api');
+      const mockEndpoints = [{ name: 'ep1', transport: 'stdio', health: 'healthy', tool_count: 3, last_activity: null }];
+      mockFetchSuccess(mockEndpoints);
+
+      const result = await getEndpoints();
+      expect(result).toEqual(mockEndpoints);
+    });
+  });
+
+  describe('getEndpointTools', () => {
+    it('fetches tools for endpoint', async () => {
+      const { getEndpointTools } = await import('./api');
+      const mockTools = [{ name: 'tool1', description: 'A tool' }];
+      mockFetchSuccess(mockTools);
+
+      const result = await getEndpointTools('my-ep');
+      expect(result).toEqual(mockTools);
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/endpoints/my-ep/tools'),
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('addEndpoint', () => {
+    it('calls invoke with correct command and params', async () => {
+      const { addEndpoint } = await import('./api');
+      const mockInvoke = vi.mocked(invoke);
+      mockInvoke.mockResolvedValue(undefined);
+      // Mock reloadConfig fetch (best-effort, may fail)
+      mockFetch.mockRejectedValue(new Error('relay not running'));
+
+      const params = { name: 'new-ep', transport: 'stdio' as const, command: '/usr/bin/my-mcp' };
+      await addEndpoint(params);
+
+      expect(mockInvoke).toHaveBeenCalledWith('add_endpoint', { args: params });
+    });
+  });
+
+  describe('removeEndpoint', () => {
+    it('calls invoke with correct command and name', async () => {
+      const { removeEndpoint } = await import('./api');
+      const mockInvoke = vi.mocked(invoke);
+      mockInvoke.mockResolvedValue(undefined);
+      mockFetch.mockRejectedValue(new Error('relay not running'));
+
+      await removeEndpoint('old-ep');
+
+      expect(mockInvoke).toHaveBeenCalledWith('remove_endpoint', { name: 'old-ep' });
+    });
+  });
+
+  describe('error handling', () => {
+    it('retries on fetch failure and eventually throws', async () => {
+      const { getStatus } = await import('./api');
+      mockFetch.mockRejectedValue(new Error('Network error'));
+
+      await expect(getStatus()).rejects.toThrow('Network error');
+      // Should have retried: 1 initial + 2 retries = 3 calls
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('throws on HTTP error status after retries', async () => {
+      const { getConfig } = await import('./api');
+      mockFetchError(500, 'Internal Server Error');
+
+      await expect(getConfig()).rejects.toThrow('HTTP 500: Internal Server Error');
+    });
+  });
+});
+

--- a/src/lib/logListener.test.ts
+++ b/src/lib/logListener.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { listen } from '@tauri-apps/api/event';
+import { get } from 'svelte/store';
+
+describe('logListener', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  describe('initRelayLogListener', () => {
+    it('sets up three event listeners', async () => {
+      const mockListen = vi.mocked(listen);
+      mockListen.mockResolvedValue(vi.fn());
+
+      const { initRelayLogListener } = await import('./logListener');
+      initRelayLogListener();
+
+      // Should register listeners for relay-log, relay-health, relay-sidecar-status
+      expect(mockListen).toHaveBeenCalledTimes(3);
+      expect(mockListen).toHaveBeenCalledWith('relay-log', expect.any(Function));
+      expect(mockListen).toHaveBeenCalledWith('relay-health', expect.any(Function));
+      expect(mockListen).toHaveBeenCalledWith('relay-sidecar-status', expect.any(Function));
+    });
+
+    it('only initializes once', async () => {
+      const mockListen = vi.mocked(listen);
+      mockListen.mockResolvedValue(vi.fn());
+
+      const { initRelayLogListener } = await import('./logListener');
+      initRelayLogListener();
+      initRelayLogListener(); // second call should be no-op
+
+      expect(mockListen).toHaveBeenCalledTimes(3); // still 3, not 6
+    });
+
+    it('adds log entries to relayLogLines store on relay-log event', async () => {
+      const mockListen = vi.mocked(listen);
+      let relayLogCallback: ((event: { payload: { level: string; message: string } }) => void) | undefined;
+
+      mockListen.mockImplementation(async (eventName: string, handler: any) => {
+        if (eventName === 'relay-log') {
+          relayLogCallback = handler;
+        }
+        return (() => {}) as () => void;
+      });
+
+      const { initRelayLogListener } = await import('./logListener');
+      const { relayLogLines } = await import('./stores');
+      initRelayLogListener();
+
+      expect(relayLogCallback).toBeDefined();
+      relayLogCallback!({ payload: { level: 'info', message: 'test message' } });
+
+      const lines = get(relayLogLines);
+      expect(lines).toHaveLength(1);
+      expect(lines[0].message).toBe('test message');
+      expect(lines[0].level).toBe('info');
+    });
+
+    it('updates relayLastError on relay-health error event', async () => {
+      const mockListen = vi.mocked(listen);
+      let healthCallback: ((event: { payload: { status: string; message: string | null } }) => void) | undefined;
+
+      mockListen.mockImplementation(async (eventName: string, handler: any) => {
+        if (eventName === 'relay-health') {
+          healthCallback = handler;
+        }
+        return (() => {}) as () => void;
+      });
+
+      const { initRelayLogListener } = await import('./logListener');
+      const { relayLastError } = await import('./stores');
+      initRelayLogListener();
+
+      healthCallback!({ payload: { status: 'error', message: 'connection failed' } });
+      expect(get(relayLastError)).toBe('connection failed');
+
+      healthCallback!({ payload: { status: 'connected', message: null } });
+      expect(get(relayLastError)).toBeNull();
+    });
+
+    it('updates sidecar status on relay-sidecar-status event', async () => {
+      const mockListen = vi.mocked(listen);
+      let sidecarCallback: ((event: { payload: { status: string; error?: string | null } }) => void) | undefined;
+
+      mockListen.mockImplementation(async (eventName: string, handler: any) => {
+        if (eventName === 'relay-sidecar-status') {
+          sidecarCallback = handler;
+        }
+        return (() => {}) as () => void;
+      });
+
+      const { initRelayLogListener } = await import('./logListener');
+      const { relaySidecarStatus, relaySidecarError } = await import('./stores');
+      initRelayLogListener();
+
+      sidecarCallback!({ payload: { status: 'running' } });
+      expect(get(relaySidecarStatus)).toBe('running');
+      expect(get(relaySidecarError)).toBeNull();
+
+      sidecarCallback!({ payload: { status: 'failed', error: 'crash' } });
+      expect(get(relaySidecarStatus)).toBe('failed');
+      expect(get(relaySidecarError)).toBe('crash');
+    });
+  });
+});
+

--- a/src/lib/stores.test.ts
+++ b/src/lib/stores.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+
+describe('stores', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    // Clear localStorage mock
+    (localStorage.getItem as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    (localStorage.setItem as ReturnType<typeof vi.fn>).mockClear();
+  });
+
+  async function importStores() {
+    return await import('./stores');
+  }
+
+  describe('endpoints store', () => {
+    it('starts with empty array', async () => {
+      const { endpoints } = await importStores();
+      expect(get(endpoints)).toEqual([]);
+    });
+
+    it('can set and read endpoints', async () => {
+      const { endpoints } = await importStores();
+      const mockEndpoints = [
+        { name: 'test', transport: 'stdio' as const, health: 'healthy' as const, tool_count: 3, last_activity: null },
+      ];
+      endpoints.set(mockEndpoints);
+      expect(get(endpoints)).toEqual(mockEndpoints);
+    });
+  });
+
+  describe('selectedEndpoint store', () => {
+    it('starts as null', async () => {
+      const { selectedEndpoint } = await importStores();
+      expect(get(selectedEndpoint)).toBeNull();
+    });
+
+    it('can select an endpoint', async () => {
+      const { selectedEndpoint } = await importStores();
+      selectedEndpoint.set('my-endpoint');
+      expect(get(selectedEndpoint)).toBe('my-endpoint');
+    });
+
+    it('can deselect', async () => {
+      const { selectedEndpoint } = await importStores();
+      selectedEndpoint.set('my-endpoint');
+      selectedEndpoint.set(null);
+      expect(get(selectedEndpoint)).toBeNull();
+    });
+  });
+
+  describe('jsExecutionMode store', () => {
+    it('defaults to false', async () => {
+      const { jsExecutionMode } = await importStores();
+      expect(get(jsExecutionMode)).toBe(false);
+    });
+
+    it('can toggle to true', async () => {
+      const { jsExecutionMode } = await importStores();
+      jsExecutionMode.set(true);
+      expect(get(jsExecutionMode)).toBe(true);
+    });
+  });
+
+  describe('theme store', () => {
+    it('defaults to system when no localStorage value', async () => {
+      const { theme } = await importStores();
+      expect(get(theme)).toBe('system');
+    });
+
+    it('persists to localStorage on change', async () => {
+      const { theme } = await importStores();
+      theme.set('dark');
+      expect(localStorage.setItem).toHaveBeenCalledWith('endara-theme', 'dark');
+    });
+
+    it('can be set to light', async () => {
+      const { theme } = await importStores();
+      theme.set('light');
+      expect(get(theme)).toBe('light');
+      expect(localStorage.setItem).toHaveBeenCalledWith('endara-theme', 'light');
+    });
+  });
+
+  describe('searchQuery store', () => {
+    it('defaults to empty string', async () => {
+      const { searchQuery } = await importStores();
+      expect(get(searchQuery)).toBe('');
+    });
+  });
+
+  describe('filteredEndpoints derived store', () => {
+    it('returns all endpoints when no search query', async () => {
+      const { endpoints, searchQuery, filteredEndpoints } = await importStores();
+      const mockEps = [
+        { name: 'alpha', transport: 'stdio' as const, health: 'healthy' as const, tool_count: 1, last_activity: null },
+        { name: 'beta', transport: 'sse' as const, health: 'offline' as const, tool_count: 0, last_activity: null },
+      ];
+      endpoints.set(mockEps);
+      searchQuery.set('');
+      expect(get(filteredEndpoints)).toEqual(mockEps);
+    });
+
+    it('filters by name', async () => {
+      const { endpoints, searchQuery, filteredEndpoints } = await importStores();
+      const mockEps = [
+        { name: 'alpha', transport: 'stdio' as const, health: 'healthy' as const, tool_count: 1, last_activity: null },
+        { name: 'beta', transport: 'sse' as const, health: 'offline' as const, tool_count: 0, last_activity: null },
+      ];
+      endpoints.set(mockEps);
+      searchQuery.set('alpha');
+      expect(get(filteredEndpoints)).toHaveLength(1);
+      expect(get(filteredEndpoints)[0].name).toBe('alpha');
+    });
+  });
+
+  describe('showOnboarding derived store', () => {
+    it('shows when no endpoints and not dismissed', async () => {
+      const { endpoints, onboardingDismissed, showOnboarding } = await importStores();
+      endpoints.set([]);
+      onboardingDismissed.set(false);
+      expect(get(showOnboarding)).toBe(true);
+    });
+
+    it('hides when dismissed', async () => {
+      const { endpoints, onboardingDismissed, showOnboarding } = await importStores();
+      endpoints.set([]);
+      onboardingDismissed.set(true);
+      expect(get(showOnboarding)).toBe(false);
+    });
+  });
+
+  describe('selectedEndpointData derived store', () => {
+    it('returns null when nothing selected', async () => {
+      const { selectedEndpointData } = await importStores();
+      expect(get(selectedEndpointData)).toBeNull();
+    });
+
+    it('returns matching endpoint data', async () => {
+      const { endpoints, selectedEndpoint, selectedEndpointData } = await importStores();
+      const ep = { name: 'test-ep', transport: 'stdio' as const, health: 'healthy' as const, tool_count: 2, last_activity: null };
+      endpoints.set([ep]);
+      selectedEndpoint.set('test-ep');
+      expect(get(selectedEndpointData)).toEqual(ep);
+    });
+  });
+
+  describe('relayPort store', () => {
+    it('defaults to 9400', async () => {
+      const { relayPort } = await importStores();
+      expect(get(relayPort)).toBe(9400);
+    });
+  });
+});
+

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,81 @@
+import { vi } from 'vitest';
+
+// Mock @tauri-apps/api/core
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+// Mock @tauri-apps/api/event
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn().mockResolvedValue(vi.fn()),
+  emit: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock localStorage
+const localStorageStore: Record<string, string> = {};
+const localStorageMock: Storage = {
+  getItem: vi.fn((key: string) => localStorageStore[key] ?? null),
+  setItem: vi.fn((key: string, value: string) => {
+    localStorageStore[key] = value;
+  }),
+  removeItem: vi.fn((key: string) => {
+    delete localStorageStore[key];
+  }),
+  clear: vi.fn(() => {
+    Object.keys(localStorageStore).forEach((key) => delete localStorageStore[key]);
+  }),
+  length: 0,
+  key: vi.fn(() => null),
+};
+
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true });
+
+// Mock document.documentElement
+if (typeof document === 'undefined') {
+  const classList = new Set<string>();
+  const documentElement = {
+    classList: {
+      add: vi.fn((cls: string) => classList.add(cls)),
+      remove: vi.fn((cls: string) => classList.delete(cls)),
+      toggle: vi.fn((cls: string, force?: boolean) => {
+        if (force === undefined) {
+          if (classList.has(cls)) classList.delete(cls);
+          else classList.add(cls);
+        } else if (force) {
+          classList.add(cls);
+        } else {
+          classList.delete(cls);
+        }
+      }),
+      contains: vi.fn((cls: string) => classList.has(cls)),
+    },
+  };
+
+  Object.defineProperty(globalThis, 'document', {
+    value: { documentElement },
+    writable: true,
+  });
+}
+
+// Mock window.matchMedia
+const matchMediaMock = vi.fn().mockImplementation((query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+}));
+
+Object.defineProperty(globalThis, 'matchMedia', { value: matchMediaMock, writable: true });
+
+// Make sure window is defined with needed properties
+if (typeof globalThis.window === 'undefined') {
+  Object.defineProperty(globalThis, 'window', {
+    value: globalThis,
+    writable: true,
+  });
+}
+

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      $lib: path.resolve(__dirname, './src/lib'),
+      '$app': path.resolve(__dirname, './.svelte-kit/runtime/app'),
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    setupFiles: ['src/test-setup.ts'],
+  },
+});
+


### PR DESCRIPTION
Sets up Vitest as the test runner and adds unit tests for stores.ts, api.ts, and logListener.ts with mocked Tauri APIs.

## Changes
- Added `vitest` and `@testing-library/jest-dom` as dev dependencies
- Created `vitest.config.ts` with SvelteKit path alias support
- Created `src/test-setup.ts` with mocks for Tauri APIs, localStorage, and matchMedia
- Added 30 unit tests across 3 test files:
  - `stores.test.ts` — endpoints, selectedEndpoint, jsExecutionMode, theme, searchQuery, filteredEndpoints, showOnboarding, selectedEndpointData, relayPort
  - `api.test.ts` — getStatus, getEndpoints, getEndpointTools, addEndpoint, removeEndpoint, error handling with retries
  - `logListener.test.ts` — event listener setup, idempotent init, relay-log/health/sidecar-status event handling
- Updated `package.json` test scripts: `test` → `vitest run`, added `test:watch` → `vitest`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author