### PR TITLE
feat: freeform endpoint names, tool_prefix field, port conflict detection

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,13 @@ use tauri::{
 use tauri_plugin_shell::{process::CommandEvent, ShellExt};
 use tokio::sync::Mutex;
 
+/// Check if a port is already in use by attempting a TCP connection.
+/// Returns `true` if the port is occupied.
+fn is_port_in_use(port: u16) -> bool {
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+    std::net::TcpStream::connect_timeout(&addr, std::time::Duration::from_millis(500)).is_ok()
+}
+
 /// Strip ANSI escape sequences from text.
 fn strip_ansi(s: &str) -> String {
     let mut result = String::with_capacity(s.len());
@@ -303,6 +310,13 @@ async fn start_relay(
     *state.auto_restart_enabled.lock().await = true;
     *state.restart_count.lock().await = 0;
     let port = *state.port.lock().await;
+    if is_port_in_use(port) {
+        let _ = app.emit("relay-sidecar-status", RelaySidecarStatusPayload {
+            status: "failed".to_string(),
+            error: Some(format!("Port {} is already in use by another process. Close the other process or change the relay port in Settings.", port)),
+        });
+        return Err(format!("Port {} is already in use", port));
+    }
     let child = spawn_relay(&app, port)?;
     *child_guard = Some(child);
     *state.running.lock().await = true;
@@ -342,6 +356,13 @@ async fn restart_relay(
     *state.auto_restart_enabled.lock().await = true;
     *state.restart_count.lock().await = 0;
     let port = *state.port.lock().await;
+    if is_port_in_use(port) {
+        let _ = app.emit("relay-sidecar-status", RelaySidecarStatusPayload {
+            status: "failed".to_string(),
+            error: Some(format!("Port {} is already in use by another process. Close the other process or change the relay port in Settings.", port)),
+        });
+        return Err(format!("Port {} is already in use", port));
+    }
     let child = spawn_relay(&app, port)?;
     *state.child.lock().await = Some(child);
     *state.running.lock().await = true;
@@ -406,6 +427,8 @@ struct AddEndpointArgs {
     description: Option<String>,
     env: Option<HashMap<String, String>>,
     headers: Option<HashMap<String, String>>,
+    #[serde(rename = "toolPrefix")]
+    tool_prefix: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -418,6 +441,8 @@ struct EndpointConfig {
     description: Option<String>,
     env: Option<HashMap<String, String>>,
     headers: Option<HashMap<String, String>>,
+    #[serde(rename = "toolPrefix", skip_serializing_if = "Option::is_none")]
+    tool_prefix: Option<String>,
 }
 
 #[tauri::command]
@@ -453,6 +478,7 @@ async fn get_endpoint_config(name: String) -> Result<EndpointConfig, String> {
                 let headers = ep.get("headers").and_then(|v| v.as_table()).map(|t| {
                     t.iter().map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string())).collect()
                 });
+                let tool_prefix = ep.get("tool_prefix").and_then(|v| v.as_str()).map(|s| s.to_string());
 
                 return Ok(EndpointConfig {
                     name: name.clone(),
@@ -463,6 +489,7 @@ async fn get_endpoint_config(name: String) -> Result<EndpointConfig, String> {
                     description,
                     env,
                     headers,
+                    tool_prefix,
                 });
             }
         }
@@ -483,6 +510,8 @@ struct UpdateEndpointArgs {
     description: Option<String>,
     env: Option<HashMap<String, String>>,
     headers: Option<HashMap<String, String>>,
+    #[serde(rename = "toolPrefix")]
+    tool_prefix: Option<String>,
 }
 
 #[tauri::command]
@@ -555,6 +584,9 @@ async fn update_endpoint(args: UpdateEndpointArgs) -> Result<(), String> {
                         }
                         table.insert("headers".to_string(), toml::Value::Table(headers_table));
                     }
+                }
+                if let Some(tool_prefix) = &args.tool_prefix {
+                    table.insert("tool_prefix".to_string(), toml::Value::String(tool_prefix.clone()));
                 }
                 break;
             }
@@ -643,6 +675,9 @@ async fn add_endpoint(args: AddEndpointArgs) -> Result<(), String> {
             }).collect();
             contents.push_str(&format!("headers = {{ {} }}\n", pairs.join(", ")));
         }
+    }
+    if let Some(tool_prefix) = args.tool_prefix {
+        contents.push_str(&format!("tool_prefix = {}\n", toml::Value::String(tool_prefix).to_string()));
     }
 
     std::fs::write(&config_path, &contents)
@@ -770,6 +805,14 @@ pub fn run() {
                 } else {
                     9400
                 };
+                if is_port_in_use(port) {
+                    eprintln!("[relay] port {} is already in use, not spawning relay", port);
+                    let _ = app_handle.emit("relay-sidecar-status", RelaySidecarStatusPayload {
+                        status: "failed".to_string(),
+                        error: Some(format!("Port {} is already in use by another process. Close the other process or change the relay port in Settings.", port)),
+                    });
+                    return;
+                }
                 match spawn_relay(&app_handle, port) {
                     Ok(child) => {
                         if let Some(state) = app_handle.try_state::<RelayState>() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -47,11 +47,19 @@ pub struct RelayState {
     auto_restart_enabled: Arc<Mutex<bool>>,
     port: Arc<Mutex<u16>>,
     restart_count: Arc<Mutex<u32>>,
+    port_conflict: Arc<Mutex<bool>>,
 }
 
 #[derive(Serialize, Clone)]
 pub struct RelayStatusInfo {
     pub running: bool,
+}
+
+#[derive(Serialize, Clone)]
+pub struct SidecarStatusResponse {
+    pub running: bool,
+    pub port_conflict: bool,
+    pub port: u16,
 }
 
 #[derive(Serialize, Clone)]
@@ -147,9 +155,10 @@ fn spawn_relay(
                             status: "running".to_string(),
                             error: None,
                         });
-                        // Reset restart count on successful start
+                        // Reset restart count and clear port conflict on successful start
                         if let Some(state) = app_handle.try_state::<RelayState>() {
                             *state.restart_count.lock().await = 0;
+                            *state.port_conflict.lock().await = false;
                         }
                     }
                     let _ = app_handle.emit("relay-log", RelayLogPayload {
@@ -172,9 +181,10 @@ fn spawn_relay(
                             status: "running".to_string(),
                             error: None,
                         });
-                        // Reset restart count on successful start
+                        // Reset restart count and clear port conflict on successful start
                         if let Some(state) = app_handle.try_state::<RelayState>() {
                             *state.restart_count.lock().await = 0;
+                            *state.port_conflict.lock().await = false;
                         }
                     }
                     let _ = app_handle.emit("relay-log", RelayLogPayload {
@@ -309,8 +319,10 @@ async fn start_relay(
     }
     *state.auto_restart_enabled.lock().await = true;
     *state.restart_count.lock().await = 0;
+    *state.port_conflict.lock().await = false;
     let port = *state.port.lock().await;
     if is_port_in_use(port) {
+        *state.port_conflict.lock().await = true;
         let _ = app.emit("relay-sidecar-status", RelaySidecarStatusPayload {
             status: "failed".to_string(),
             error: Some(format!("Port {} is already in use by another process. Close the other process or change the relay port in Settings.", port)),
@@ -355,8 +367,10 @@ async fn restart_relay(
     // Start new — re-enable auto-restart
     *state.auto_restart_enabled.lock().await = true;
     *state.restart_count.lock().await = 0;
+    *state.port_conflict.lock().await = false;
     let port = *state.port.lock().await;
     if is_port_in_use(port) {
+        *state.port_conflict.lock().await = true;
         let _ = app.emit("relay-sidecar-status", RelaySidecarStatusPayload {
             status: "failed".to_string(),
             error: Some(format!("Port {} is already in use by another process. Close the other process or change the relay port in Settings.", port)),
@@ -373,6 +387,14 @@ async fn restart_relay(
 async fn relay_status(state: State<'_, RelayState>) -> Result<RelayStatusInfo, String> {
     let running = *state.running.lock().await;
     Ok(RelayStatusInfo { running })
+}
+
+#[tauri::command]
+async fn get_sidecar_status(state: State<'_, RelayState>) -> Result<SidecarStatusResponse, String> {
+    let running = *state.running.lock().await;
+    let port_conflict = *state.port_conflict.lock().await;
+    let port = *state.port.lock().await;
+    Ok(SidecarStatusResponse { running, port_conflict, port })
 }
 
 #[tauri::command]
@@ -735,6 +757,7 @@ pub fn run() {
         auto_restart_enabled: Arc::new(Mutex::new(true)),
         port: Arc::new(Mutex::new(9400)),
         restart_count: Arc::new(Mutex::new(0)),
+        port_conflict: Arc::new(Mutex::new(false)),
     };
 
     let child_handle = relay_state.child.clone();
@@ -753,6 +776,7 @@ pub fn run() {
             stop_relay,
             restart_relay,
             relay_status,
+            get_sidecar_status,
             get_build_info,
             add_endpoint,
             remove_endpoint,
@@ -807,6 +831,9 @@ pub fn run() {
                 };
                 if is_port_in_use(port) {
                     eprintln!("[relay] port {} is already in use, not spawning relay", port);
+                    if let Some(state) = app_handle.try_state::<RelayState>() {
+                        *state.port_conflict.lock().await = true;
+                    }
                     let _ = app_handle.emit("relay-sidecar-status", RelaySidecarStatusPayload {
                         status: "failed".to_string(),
                         error: Some(format!("Port {} is already in use by another process. Close the other process or change the relay port in Settings.", port)),

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -105,6 +105,7 @@ export interface AddEndpointParams {
   description?: string;
   env?: Record<string, string>;
   headers?: Record<string, string>;
+  toolPrefix?: string;
 }
 
 export async function addEndpoint(params: AddEndpointParams): Promise<void> {
@@ -154,6 +155,7 @@ export interface EndpointConfig {
   description?: string;
   env?: Record<string, string>;
   headers?: Record<string, string>;
+  toolPrefix?: string;
 }
 
 export async function getEndpointConfig(name: string): Promise<EndpointConfig> {
@@ -170,6 +172,7 @@ export interface UpdateEndpointParams {
   description?: string;
   env?: Record<string, string>;
   headers?: Record<string, string>;
+  toolPrefix?: string;
 }
 
 export async function updateEndpoint(params: UpdateEndpointParams): Promise<void> {

--- a/src/lib/components/AddEndpointModal.svelte
+++ b/src/lib/components/AddEndpointModal.svelte
@@ -2,6 +2,7 @@
   import { addEndpoint, getEndpoints, testConnection, type AddEndpointParams, type TestConnectionParams } from '$lib/api';
   import { endpoints, selectedEndpoint } from '$lib/stores';
   import { CATALOG_SERVERS, type CatalogServer } from '$lib/catalog';
+  import { sanitizeName, isValidToolPrefix } from '$lib/utils';
 
   type TransportType = 'stdio' | 'sse' | 'http';
   type Step = 'browse' | 'configure';
@@ -28,16 +29,24 @@
   let testing = $state(false);
   let testResult: { success: boolean; toolCount?: number; error?: string } | null = $state(null);
 
-  /** Validate an endpoint instance name: must match ^[a-z0-9][a-z0-9_-]*$ */
-  export function isValidEndpointName(value: string): boolean {
-    return /^[a-z0-9][a-z0-9_-]*$/.test(value);
-  }
+  // Tool prefix fields
+  let toolPrefix = $state('');
+  let toolPrefixManual = $state(false);
 
-  let nameError: string = $derived.by(() => {
-    const trimmed = name.trim();
-    if (trimmed.length === 0) return '';
-    if (!isValidEndpointName(trimmed)) {
-      return 'Name must start with a lowercase letter or digit, and contain only lowercase letters, digits, hyphens, or underscores.';
+  let autoToolPrefix: string | null = $derived(sanitizeName(name.trim()));
+
+  /** Compute effective tool prefix: manual value if set, otherwise auto-computed */
+  let effectiveToolPrefix: string | null = $derived.by(() => {
+    if (toolPrefixManual && toolPrefix.trim()) return toolPrefix.trim();
+    return autoToolPrefix;
+  });
+
+  let toolPrefixError: string = $derived.by(() => {
+    if (toolPrefixManual && toolPrefix.trim() && !isValidToolPrefix(toolPrefix.trim())) {
+      return 'Must start with a lowercase letter or digit, and contain only lowercase letters, digits, hyphens, or underscores.';
+    }
+    if (name.trim() && !effectiveToolPrefix) {
+      return 'Name produces an empty tool prefix. Please set a tool prefix manually.';
     }
     return '';
   });
@@ -69,6 +78,8 @@
     userArgValues = server.userArgs ? server.userArgs.map(() => '') : [];
     envVars = [];
     headerVars = [];
+    toolPrefix = '';
+    toolPrefixManual = false;
     error = '';
     step = 'configure';
   }
@@ -85,6 +96,8 @@
     headerVars = [];
     catalogEnvValues = {};
     userArgValues = [];
+    toolPrefix = '';
+    toolPrefixManual = false;
     error = '';
     step = 'configure';
   }
@@ -168,12 +181,18 @@
   async function handleSubmit() {
     error = '';
     if (!name.trim()) { error = 'Name is required'; return; }
-    if (!isValidEndpointName(name.trim())) { error = 'Invalid name: must start with a lowercase letter or digit, and contain only lowercase letters, digits, hyphens, or underscores.'; return; }
+    if (toolPrefixError) { error = toolPrefixError; return; }
+    if (!effectiveToolPrefix) { error = 'Tool prefix cannot be empty'; return; }
 
     const params: AddEndpointParams = {
       name: name.trim(),
       transport,
     };
+
+    // Only pass tool_prefix when it differs from auto-sanitized name
+    if (toolPrefixManual && toolPrefix.trim() && toolPrefix.trim() !== autoToolPrefix) {
+      params.toolPrefix = toolPrefix.trim();
+    }
 
     if (description.trim()) {
       params.description = description.trim();
@@ -356,10 +375,19 @@
 
         <div>
           <label for="modal-ep-name" class="block text-xs font-medium mb-1 text-(--color-text-secondary)">Name</label>
-          <input id="modal-ep-name" type="text" bind:value={name} placeholder="my-server"
-            class="w-full text-sm px-3 py-1.5 rounded-lg border {nameError ? 'border-(--color-offline)' : 'border-(--color-border)'} bg-(--color-surface) text-(--color-text) placeholder:text-(--color-text-secondary)/50 focus:outline-none focus:border-(--color-accent)" />
-          {#if nameError}
-            <p class="text-[11px] text-(--color-offline) mt-0.5">{nameError}</p>
+          <input id="modal-ep-name" type="text" bind:value={name} placeholder="My Cool Server"
+            class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--color-border) bg-(--color-surface) text-(--color-text) placeholder:text-(--color-text-secondary)/50 focus:outline-none focus:border-(--color-accent)" />
+        </div>
+
+        <div>
+          <label for="modal-ep-tool-prefix" class="block text-xs font-medium mb-1 text-(--color-text-secondary)">Tool Prefix</label>
+          <input id="modal-ep-tool-prefix" type="text" bind:value={toolPrefix} placeholder={autoToolPrefix ?? ''}
+            oninput={() => { toolPrefixManual = true; }}
+            class="w-full text-sm px-3 py-1.5 rounded-lg border {toolPrefixError ? 'border-(--color-offline)' : 'border-(--color-border)'} bg-(--color-surface) text-(--color-text) placeholder:text-(--color-text-secondary)/50 focus:outline-none focus:border-(--color-accent) font-mono" />
+          {#if toolPrefixError}
+            <p class="text-[11px] text-(--color-offline) mt-0.5">{toolPrefixError}</p>
+          {:else}
+            <p class="text-[11px] text-(--color-text-secondary)/60 mt-0.5">Used for tool naming. Auto-generated from name.</p>
           {/if}
         </div>
 

--- a/src/lib/components/AddEndpointModal.test.ts
+++ b/src/lib/components/AddEndpointModal.test.ts
@@ -1,15 +1,51 @@
 import { describe, it, expect } from 'vitest';
+import { sanitizeName, isValidToolPrefix } from '$lib/utils';
 
-/**
- * Endpoint name validation: must match ^[a-z0-9][a-z0-9_-]*$
- * This mirrors the regex exported from AddEndpointModal.svelte.
- */
-function isValidEndpointName(value: string): boolean {
-  return /^[a-z0-9][a-z0-9_-]*$/.test(value);
-}
+describe('sanitizeName', () => {
+  it('handles basic lowercase name', () => {
+    expect(sanitizeName('echo-mcp')).toBe('echo-mcp');
+  });
 
-describe('AddEndpointModal name validation', () => {
-  describe('valid names', () => {
+  it('converts spaces to underscores', () => {
+    expect(sanitizeName('My MCP Server')).toBe('my_mcp_server');
+  });
+
+  it('strips special characters', () => {
+    expect(sanitizeName('server@v2.0!')).toBe('serverv20');
+  });
+
+  it('converts uppercase to lowercase', () => {
+    expect(sanitizeName('MyServer')).toBe('myserver');
+  });
+
+  it('returns null for empty string', () => {
+    expect(sanitizeName('')).toBeNull();
+  });
+
+  it('returns null for only special characters', () => {
+    expect(sanitizeName('@#$%^&*')).toBeNull();
+  });
+
+  it('strips unicode characters', () => {
+    expect(sanitizeName('café')).toBe('caf');
+    expect(sanitizeName('日本語')).toBeNull();
+  });
+
+  it('handles mixed input', () => {
+    expect(sanitizeName('My Server - v2.0 (beta)')).toBe('my_server_-_v20_beta');
+  });
+
+  it('preserves hyphens and underscores', () => {
+    expect(sanitizeName('my-server_name')).toBe('my-server_name');
+  });
+
+  it('preserves digits', () => {
+    expect(sanitizeName('server123')).toBe('server123');
+  });
+});
+
+describe('isValidToolPrefix', () => {
+  describe('valid prefixes', () => {
     it.each([
       'echo',
       'my-server',
@@ -19,24 +55,21 @@ describe('AddEndpointModal name validation', () => {
       'abc-123',
       'a-b_c',
       '9lives',
-    ])('accepts "%s"', (name) => {
-      expect(isValidEndpointName(name)).toBe(true);
+    ])('accepts "%s"', (prefix) => {
+      expect(isValidToolPrefix(prefix)).toBe(true);
     });
   });
 
-  describe('invalid names', () => {
+  describe('invalid prefixes', () => {
     it.each([
       ['', 'empty string'],
-      ['MyServer', 'uppercase letters'],
       ['-bad', 'starts with hyphen'],
       ['_bad', 'starts with underscore'],
       ['my server', 'contains space'],
       ['hello!', 'contains special character'],
-      ['café', 'contains non-ASCII'],
-      ['my.server', 'contains dot'],
-      ['MY-SERVER', 'all uppercase'],
-    ])('rejects "%s" (%s)', (name) => {
-      expect(isValidEndpointName(name)).toBe(false);
+      ['MY-SERVER', 'uppercase letters'],
+    ])('rejects "%s" (%s)', (prefix) => {
+      expect(isValidToolPrefix(prefix)).toBe(false);
     });
   });
 });

--- a/src/lib/components/ConfigTab.svelte
+++ b/src/lib/components/ConfigTab.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { getEndpointConfig, updateEndpoint, getEndpoints, type UpdateEndpointParams } from '$lib/api';
   import { selectedEndpoint, endpoints } from '$lib/stores';
+  import { sanitizeName, isValidToolPrefix } from '$lib/utils';
 
   type TransportType = 'stdio' | 'sse' | 'http';
 
@@ -19,6 +20,27 @@
   let url = $state('');
   let envVars: { key: string; value: string }[] = $state([]);
   let headerVars: { key: string; value: string }[] = $state([]);
+
+  // Tool prefix fields
+  let toolPrefix = $state('');
+  let toolPrefixManual = $state(false);
+
+  let autoToolPrefix: string | null = $derived(sanitizeName(name.trim()));
+
+  let effectiveToolPrefix: string | null = $derived.by(() => {
+    if (toolPrefixManual && toolPrefix.trim()) return toolPrefix.trim();
+    return autoToolPrefix;
+  });
+
+  let toolPrefixError: string = $derived.by(() => {
+    if (toolPrefixManual && toolPrefix.trim() && !isValidToolPrefix(toolPrefix.trim())) {
+      return 'Must start with a lowercase letter or digit, and contain only lowercase letters, digits, hyphens, or underscores.';
+    }
+    if (name.trim() && !effectiveToolPrefix) {
+      return 'Name produces an empty tool prefix. Please set a tool prefix manually.';
+    }
+    return '';
+  });
 
   $effect(() => {
     const epName = $selectedEndpoint;
@@ -41,6 +63,14 @@
         headerVars = config.headers
           ? Object.entries(config.headers).map(([key, value]) => ({ key, value }))
           : [];
+        // Load tool_prefix: if config has one, set it as manual; otherwise auto-compute
+        if (config.toolPrefix) {
+          toolPrefix = config.toolPrefix;
+          toolPrefixManual = true;
+        } else {
+          toolPrefix = '';
+          toolPrefixManual = false;
+        }
       })
       .catch(() => {
         error = 'Unable to load endpoint configuration';
@@ -52,12 +82,19 @@
     error = '';
     success = '';
     if (!name.trim()) { error = 'Name is required'; return; }
+    if (toolPrefixError) { error = toolPrefixError; return; }
+    if (!effectiveToolPrefix) { error = 'Tool prefix cannot be empty'; return; }
 
     const params: UpdateEndpointParams = {
       originalName,
       name: name.trim(),
       transport,
     };
+
+    // Only pass tool_prefix when it differs from auto-sanitized name
+    if (toolPrefixManual && toolPrefix.trim() && toolPrefix.trim() !== autoToolPrefix) {
+      params.toolPrefix = toolPrefix.trim();
+    }
 
     if (description.trim()) {
       params.description = description.trim();
@@ -157,8 +194,20 @@
 
         <div>
           <label for="config-ep-name" class="block text-xs font-medium mb-1 text-(--color-text-secondary)">Name</label>
-          <input id="config-ep-name" type="text" bind:value={name} placeholder="my-server"
+          <input id="config-ep-name" type="text" bind:value={name} placeholder="My Cool Server"
             class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--color-border) bg-(--color-surface) text-(--color-text) placeholder:text-(--color-text-secondary)/50 focus:outline-none focus:border-(--color-accent)" />
+        </div>
+
+        <div>
+          <label for="config-ep-tool-prefix" class="block text-xs font-medium mb-1 text-(--color-text-secondary)">Tool Prefix</label>
+          <input id="config-ep-tool-prefix" type="text" bind:value={toolPrefix} placeholder={autoToolPrefix ?? ''}
+            oninput={() => { toolPrefixManual = true; }}
+            class="w-full text-sm px-3 py-1.5 rounded-lg border {toolPrefixError ? 'border-(--color-offline)' : 'border-(--color-border)'} bg-(--color-surface) text-(--color-text) placeholder:text-(--color-text-secondary)/50 focus:outline-none focus:border-(--color-accent) font-mono" />
+          {#if toolPrefixError}
+            <p class="text-[11px] text-(--color-offline) mt-0.5">{toolPrefixError}</p>
+          {:else}
+            <p class="text-[11px] text-(--color-text-secondary)/60 mt-0.5">Used for tool naming. Auto-generated from name.</p>
+          {/if}
         </div>
 
         <div>

--- a/src/lib/components/Onboarding.svelte
+++ b/src/lib/components/Onboarding.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { addEndpoint, getEndpoints, type AddEndpointParams } from '$lib/api';
   import { onboardingDismissed, endpoints, relayPort, selectedEndpoint } from '$lib/stores';
+  import { sanitizeName, isValidToolPrefix } from '$lib/utils';
 
   type TransportType = 'stdio' | 'sse' | 'http';
 
@@ -13,17 +14,45 @@
   let submitting = $state(false);
   let error = $state('');
 
+  // Tool prefix fields
+  let toolPrefix = $state('');
+  let toolPrefixManual = $state(false);
+
+  let autoToolPrefix: string | null = $derived(sanitizeName(name.trim()));
+
+  let effectiveToolPrefix: string | null = $derived.by(() => {
+    if (toolPrefixManual && toolPrefix.trim()) return toolPrefix.trim();
+    return autoToolPrefix;
+  });
+
+  let toolPrefixError: string = $derived.by(() => {
+    if (toolPrefixManual && toolPrefix.trim() && !isValidToolPrefix(toolPrefix.trim())) {
+      return 'Must start with a lowercase letter or digit, and contain only lowercase letters, digits, hyphens, or underscores.';
+    }
+    if (name.trim() && !effectiveToolPrefix) {
+      return 'Name produces an empty tool prefix. Please set a tool prefix manually.';
+    }
+    return '';
+  });
+
   const RELAY_MCP_URL = $derived(`http://localhost:${$relayPort}/mcp`);
   const RELAY_SSE_URL = $derived(`http://localhost:${$relayPort}/mcp/sse`);
 
   async function handleSubmit() {
     error = '';
     if (!name.trim()) { error = 'Name is required'; return; }
+    if (toolPrefixError) { error = toolPrefixError; return; }
+    if (!effectiveToolPrefix) { error = 'Tool prefix cannot be empty'; return; }
 
     const params: AddEndpointParams = {
       name: name.trim(),
       transport,
     };
+
+    // Only pass tool_prefix when it differs from auto-sanitized name
+    if (toolPrefixManual && toolPrefix.trim() && toolPrefix.trim() !== autoToolPrefix) {
+      params.toolPrefix = toolPrefix.trim();
+    }
 
     if (transport === 'stdio') {
       if (!command.trim()) { error = 'Command is required for stdio'; return; }
@@ -163,8 +192,20 @@
 
       <div>
         <label for="ep-name" class="block text-xs font-medium mb-1 text-(--color-text-secondary)">Name</label>
-        <input id="ep-name" type="text" bind:value={name} placeholder="my-server"
+        <input id="ep-name" type="text" bind:value={name} placeholder="My Cool Server"
           class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--color-border) bg-(--color-surface) text-(--color-text) placeholder:text-(--color-text-secondary)/50 focus:outline-none focus:border-(--color-accent)" />
+      </div>
+
+      <div>
+        <label for="ep-tool-prefix" class="block text-xs font-medium mb-1 text-(--color-text-secondary)">Tool Prefix</label>
+        <input id="ep-tool-prefix" type="text" bind:value={toolPrefix} placeholder={autoToolPrefix ?? ''}
+          oninput={() => { toolPrefixManual = true; }}
+          class="w-full text-sm px-3 py-1.5 rounded-lg border {toolPrefixError ? 'border-(--color-offline)' : 'border-(--color-border)'} bg-(--color-surface) text-(--color-text) placeholder:text-(--color-text-secondary)/50 focus:outline-none focus:border-(--color-accent) font-mono" />
+        {#if toolPrefixError}
+          <p class="text-[11px] text-(--color-offline) mt-0.5">{toolPrefixError}</p>
+        {:else}
+          <p class="text-[11px] text-(--color-text-secondary)/60 mt-0.5">Used for tool naming. Auto-generated from name.</p>
+        {/if}
       </div>
 
       {#if transport === 'stdio'}

--- a/src/lib/components/RelayError.svelte
+++ b/src/lib/components/RelayError.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+  import { relaySidecarError, activeTopLevelTab } from '$lib/stores';
+  import { invoke } from '@tauri-apps/api/core';
+
+  let retrying = $state(false);
+
+  async function handleRetry() {
+    retrying = true;
+    try {
+      await invoke('restart_relay');
+    } catch (e) {
+      console.error('Failed to restart relay:', e);
+    } finally {
+      retrying = false;
+    }
+  }
+
+  function viewRelayLogs() {
+    activeTopLevelTab.set('relay-logs');
+  }
+</script>
+
+<div class="h-full overflow-y-auto p-8">
+  <div class="max-w-lg mx-auto space-y-6">
+    <div class="text-center space-y-2">
+      <div class="text-4xl mb-4">⚠️</div>
+      <h1 class="text-2xl font-bold text-(--color-text)">Relay failed to start</h1>
+      <p class="text-sm text-(--color-text-secondary)">
+        The Endara relay sidecar encountered an error and could not start.
+      </p>
+    </div>
+
+    {#if $relaySidecarError}
+      <div class="rounded-lg border border-red-500/30 bg-red-500/10 p-4 space-y-1">
+        <h3 class="text-sm font-semibold text-(--color-text)">Error details</h3>
+        <p class="text-xs font-mono text-red-400 whitespace-pre-wrap break-all">{$relaySidecarError}</p>
+      </div>
+    {/if}
+
+    {#if $relaySidecarError?.includes('already in use')}
+      <div class="rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-4 space-y-2">
+        <h3 class="text-sm font-semibold text-(--color-text)">Port conflict</h3>
+        <p class="text-xs text-(--color-text-secondary)">
+          Another process is using the relay port. This is usually a stale relay from a previous session.
+        </p>
+        <p class="text-xs text-(--color-text-secondary)">
+          Try closing any other applications that may be using this port, or change the relay port in Settings.
+        </p>
+      </div>
+    {/if}
+
+    {#if !$relaySidecarError?.includes('already in use')}
+      <div class="rounded-lg border border-(--color-border) bg-(--color-surface-alt) p-4 space-y-2">
+        <h3 class="text-sm font-semibold text-(--color-text)">Configuration</h3>
+        <p class="text-xs text-(--color-text-secondary)">
+          Check your relay configuration file for errors:
+        </p>
+        <code class="block text-xs font-mono bg-(--color-surface) border border-(--color-border) rounded px-2 py-1.5 text-(--color-accent)">
+          ~/.endara/config.toml
+        </code>
+      </div>
+    {/if}
+
+    <div class="flex gap-3">
+      <button
+        class="flex-1 px-3 py-2 text-sm rounded-lg border border-(--color-border) hover:bg-(--color-surface-hover) transition-colors"
+        onclick={viewRelayLogs}
+      >
+        View Relay Logs
+      </button>
+      <button
+        class="flex-1 px-3 py-2 text-sm rounded-lg bg-(--color-accent) text-white hover:bg-(--color-accent-hover) transition-colors disabled:opacity-50"
+        onclick={handleRetry}
+        disabled={retrying}
+      >
+        {retrying ? 'Retrying…' : 'Retry'}
+      </button>
+    </div>
+  </div>
+</div>
+

--- a/src/lib/stores.test.ts
+++ b/src/lib/stores.test.ts
@@ -138,6 +138,54 @@ describe('stores', () => {
       initialLoadComplete.set(false);
       expect(get(showOnboarding)).toBe(false);
     });
+
+    it('hides when relay sidecar has failed', async () => {
+      const { endpoints, onboardingDismissed, initialLoadComplete, relaySidecarStatus, showOnboarding } = await importStores();
+      endpoints.set([]);
+      onboardingDismissed.set(false);
+      initialLoadComplete.set(true);
+      relaySidecarStatus.set('failed');
+      expect(get(showOnboarding)).toBe(false);
+    });
+  });
+
+  describe('showRelayError derived store', () => {
+    it('shows when relay failed and initial load complete', async () => {
+      const { relaySidecarStatus, initialLoadComplete, showRelayError } = await importStores();
+      relaySidecarStatus.set('failed');
+      initialLoadComplete.set(true);
+      expect(get(showRelayError)).toBe(true);
+    });
+
+    it('hides before initial load completes', async () => {
+      const { relaySidecarStatus, initialLoadComplete, showRelayError } = await importStores();
+      relaySidecarStatus.set('failed');
+      initialLoadComplete.set(false);
+      expect(get(showRelayError)).toBe(false);
+    });
+
+    it('hides when relay is running', async () => {
+      const { relaySidecarStatus, initialLoadComplete, showRelayError } = await importStores();
+      relaySidecarStatus.set('running');
+      initialLoadComplete.set(true);
+      expect(get(showRelayError)).toBe(false);
+    });
+
+    it('hides when relay status is starting', async () => {
+      const { relaySidecarStatus, initialLoadComplete, showRelayError } = await importStores();
+      relaySidecarStatus.set('starting');
+      initialLoadComplete.set(true);
+      expect(get(showRelayError)).toBe(false);
+    });
+
+    it('hides when relay recovers from failed to running', async () => {
+      const { relaySidecarStatus, initialLoadComplete, showRelayError } = await importStores();
+      initialLoadComplete.set(true);
+      relaySidecarStatus.set('failed');
+      expect(get(showRelayError)).toBe(true);
+      relaySidecarStatus.set('running');
+      expect(get(showRelayError)).toBe(false);
+    });
   });
 
   describe('selectedEndpointData derived store', () => {

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -72,9 +72,16 @@ function createRelayPortStore() {
 export const relayPort = createRelayPortStore();
 
 export const showOnboarding = derived(
-  [endpoints, onboardingDismissed, initialLoadComplete],
-  ([$endpoints, $onboardingDismissed, $initialLoadComplete]) => {
-    return $initialLoadComplete && $endpoints.length === 0 && !$onboardingDismissed;
+  [endpoints, onboardingDismissed, initialLoadComplete, relaySidecarStatus],
+  ([$endpoints, $onboardingDismissed, $initialLoadComplete, $relaySidecarStatus]) => {
+    return $initialLoadComplete && $endpoints.length === 0 && !$onboardingDismissed && $relaySidecarStatus !== 'failed';
+  }
+);
+
+export const showRelayError = derived(
+  [relaySidecarStatus, initialLoadComplete],
+  ([$relaySidecarStatus, $initialLoadComplete]) => {
+    return $initialLoadComplete && $relaySidecarStatus === 'failed';
   }
 );
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,25 @@
+/**
+ * Sanitize an MCP server name for use as an identifier.
+ *
+ * Mirrors the Rust `sanitize_name()` logic in `packages/relay/src/prefix.rs`:
+ * - Converts to lowercase
+ * - Replaces spaces with underscores
+ * - Strips characters not matching [a-z0-9_-]
+ * - Returns null if the result is empty
+ */
+export function sanitizeName(name: string): string | null {
+  const sanitized = name
+    .toLowerCase()
+    .split('')
+    .map((c) => (c === ' ' ? '_' : c))
+    .filter((c) => /^[a-z0-9_-]$/.test(c))
+    .join('');
+
+  return sanitized.length === 0 ? null : sanitized;
+}
+
+/** Validate that a tool prefix matches the allowed pattern: [a-z0-9][a-z0-9_-]* */
+export function isValidToolPrefix(value: string): boolean {
+  return /^[a-z0-9][a-z0-9_-]*$/.test(value);
+}
+

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,7 +7,8 @@
   import RelayLogs from '$lib/components/RelayLogs.svelte';
   import UnifiedCatalog from '$lib/components/UnifiedCatalog.svelte';
   import Onboarding from '$lib/components/Onboarding.svelte';
-  import { endpoints, activeTopLevelTab, miniPlayerMode, relayConnected, relayLastError, showOnboarding, relayPort, relaySidecarStatus, relaySidecarError, initialLoadComplete } from '$lib/stores';
+  import RelayError from '$lib/components/RelayError.svelte';
+  import { endpoints, activeTopLevelTab, miniPlayerMode, relayConnected, relayLastError, showOnboarding, showRelayError, relayPort, relaySidecarStatus, relaySidecarError, initialLoadComplete } from '$lib/stores';
   import { getEndpoints } from '$lib/api';
   import { initRelayLogListener } from '$lib/logListener';
   import { invoke } from '@tauri-apps/api/core';
@@ -42,12 +43,18 @@
   ];
 
   async function pollEndpoints() {
+    const currentStatus = get(relaySidecarStatus);
+    // If sidecar failed (e.g., port conflict), don't poll — we're not managing what's on that port
+    if (currentStatus === 'failed') {
+      relayConnected.set(false);
+      endpoints.set([]);
+      return;
+    }
     try {
       const data = await getEndpoints();
       endpoints.set(data);
       relayConnected.set(true);
       // If sidecar status is still starting/unknown but API responds, infer running
-      const currentStatus = get(relaySidecarStatus);
       if (currentStatus === 'starting' || currentStatus === 'unknown') {
         relaySidecarStatus.set('running');
       }
@@ -61,7 +68,11 @@
     // Sync the configured relay port to the Rust backend
     invoke('set_relay_port', { port: get(relayPort) }).catch(() => {});
     initRelayLogListener();
-    pollEndpoints().then(() => initialLoadComplete.set(true));
+    // Small delay to let the Rust sidecar startup task complete its port check
+    // before we consider initial load complete
+    setTimeout(() => {
+      pollEndpoints().then(() => initialLoadComplete.set(true));
+    }, 1000);
     pollInterval = setInterval(pollEndpoints, 2000);
   });
 
@@ -122,8 +133,10 @@
 
     <!-- Tab content -->
     <div class="flex-1 overflow-hidden">
-      <div class="h-full" style:display={$activeTopLevelTab === 'servers' ? ($showOnboarding ? 'block' : 'flex') : 'none'}>
-        {#if $showOnboarding}
+      <div class="h-full" style:display={$activeTopLevelTab === 'servers' ? (($showOnboarding || $showRelayError) ? 'block' : 'flex') : 'none'}>
+        {#if $showRelayError}
+          <RelayError />
+        {:else if $showOnboarding}
           <Onboarding />
         {:else}
           <Sidebar bind:this={sidebar} />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -68,10 +68,21 @@
     // Sync the configured relay port to the Rust backend
     invoke('set_relay_port', { port: get(relayPort) }).catch(() => {});
     initRelayLogListener();
-    // Small delay to let the Rust sidecar startup task complete its port check
-    // before we consider initial load complete
-    setTimeout(() => {
-      pollEndpoints().then(() => initialLoadComplete.set(true));
+    // Query Rust for initial sidecar status after a brief delay
+    // to let the Rust async setup task complete its port check
+    setTimeout(async () => {
+      try {
+        const status = await invoke<{ running: boolean; port_conflict: boolean; port: number }>('get_sidecar_status');
+        if (status.port_conflict) {
+          relaySidecarStatus.set('failed');
+          relaySidecarError.set(`Port ${status.port} is already in use by another process. Close the other process or change the relay port in Settings.`);
+        }
+      } catch (e) {
+        console.error('Failed to get sidecar status:', e);
+      }
+      // Now poll endpoints and mark initial load complete
+      await pollEndpoints();
+      initialLoadComplete.set(true);
     }, 1000);
     pollInterval = setInterval(pollEndpoints, 2000);
   });


### PR DESCRIPTION
## Changes

- Allow freeform endpoint names in Add/Edit modals with optional tool_prefix field
- Add sanitizeName and isValidToolPrefix utilities
- Pre-flight port check before spawning relay sidecar
- Port conflict error screen with retry support
- Query sidecar status on mount to reliably detect port conflicts
- Poll skips when sidecar status is failed (prevents zombie relay usage)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author