### PR TITLE
feat: relay lifecycle improvements, port validation, and macOS Cmd-Tab fix

### DIFF
--- a/scripts/kill-relay.sh
+++ b/scripts/kill-relay.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Kill any running relay process before dev restart
+
+CONFIG="$HOME/.endara/config.toml"
+PORT=9400
+
+# Try to read port from config
+if [ -f "$CONFIG" ]; then
+  PARSED_PORT=$(grep -A5 '\[relay\]' "$CONFIG" | grep '^port' | head -1 | sed 's/.*= *//' | tr -d ' ')
+  if [ -n "$PARSED_PORT" ] && [ "$PARSED_PORT" -gt 0 ] 2>/dev/null; then
+    PORT=$PARSED_PORT
+  fi
+fi
+
+# Kill whatever is on that port
+PIDS=$(lsof -ti ":$PORT" 2>/dev/null)
+if [ -n "$PIDS" ]; then
+  echo "[dev] Killing existing relay on port $PORT (pids: $PIDS)"
+  echo "$PIDS" | xargs kill 2>/dev/null
+fi
+

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -311,6 +311,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,6 +582,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cocoa"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad36507aeb7e16159dfe68db81ccc27571c3ccd4b76fb2fb72fc59e7a4b1b64c"
+dependencies = [
+ "bitflags 2.11.0",
+ "block",
+ "cocoa-foundation",
+ "core-foundation",
+ "core-graphics 0.24.0",
+ "foreign-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa-foundation"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81411967c50ee9a1fc11365f8c585f863a22a9697c89239c452292c40ba79b0d"
+dependencies = [
+ "bitflags 2.11.0",
+ "block",
+ "core-foundation",
+ "core-graphics-types",
+ "objc",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,6 +660,19 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
 
 [[package]]
 name = "core-graphics"
@@ -1014,9 +1062,12 @@ dependencies = [
 name = "endara-desktop"
 version = "0.1.0"
 dependencies = [
+ "cocoa",
  "dirs 5.0.1",
  "hostname",
+ "libc",
  "log",
+ "objc",
  "serde",
  "serde_json",
  "tauri",
@@ -2198,9 +2249,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libloading"
@@ -2259,6 +2310,15 @@ name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "markup5ever"
@@ -2457,6 +2517,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]
@@ -4155,7 +4224,7 @@ dependencies = [
  "bitflags 2.11.0",
  "block2",
  "core-foundation",
- "core-graphics",
+ "core-graphics 0.25.0",
  "crossbeam-channel",
  "dispatch2",
  "dlopen2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,4 +26,7 @@ tokio = { version = "1", features = ["sync", "time"] }
 toml = "0.8"
 hostname = "0.4"
 tauri-plugin-log = "2.8.0"
+libc = "0.2.184"
+cocoa = "0.26"
+objc = "0.2"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,7 @@
+#[cfg(target_os = "macos")]
+#[macro_use]
+extern crate objc;
+
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -9,6 +13,45 @@ use tauri::{
 };
 use tauri_plugin_shell::{process::CommandEvent, ShellExt};
 use tokio::sync::Mutex;
+
+/// Workaround: In Tauri v2, `set_activation_policy` is only available on `App`,
+/// not on `AppHandle`, so it cannot be called from event handlers.
+/// See: https://github.com/tauri-apps/tauri/issues/9244
+/// This uses the cocoa crate to call NSApplication.setActivationPolicy directly.
+/// TODO: Remove this workaround once Tauri exposes set_activation_policy on AppHandle.
+#[cfg(target_os = "macos")]
+fn set_macos_activation_policy(regular: bool) {
+    use cocoa::appkit::NSApplicationActivationPolicy;
+    unsafe {
+        let app = cocoa::appkit::NSApp();
+        let policy = if regular {
+            NSApplicationActivationPolicy::NSApplicationActivationPolicyRegular
+        } else {
+            NSApplicationActivationPolicy::NSApplicationActivationPolicyAccessory
+        };
+        let _: () = msg_send![app, setActivationPolicy: policy];
+    }
+}
+
+/// Check if a port is already in use by attempting a TCP connection.
+fn is_port_in_use(port: u16) -> bool {
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+    std::net::TcpStream::connect_timeout(&addr, std::time::Duration::from_millis(500)).is_ok()
+}
+
+/// Read the relay port from ~/.endara/config.toml [relay] section.
+/// Returns None if the file doesn't exist, can't be parsed, or has no port setting.
+fn read_port_from_config() -> Option<u16> {
+    let config_path = dirs::home_dir()?.join(".endara").join("config.toml");
+    let contents = std::fs::read_to_string(&config_path).ok()?;
+    let parsed: toml::Table = contents.parse().ok()?;
+    parsed
+        .get("relay")?
+        .as_table()?
+        .get("port")?
+        .as_integer()
+        .and_then(|p| u16::try_from(p).ok())
+}
 
 /// Strip ANSI escape sequences from text.
 fn strip_ansi(s: &str) -> String {
@@ -33,9 +76,41 @@ fn strip_ansi(s: &str) -> String {
     result
 }
 
+/// Return the path to `~/.endara/config.toml`.
+fn config_path() -> Result<std::path::PathBuf, String> {
+    dirs::home_dir()
+        .map(|h| h.join(".endara").join("config.toml"))
+        .ok_or_else(|| "Could not determine home directory".to_string())
+}
+
+/// Read and parse `~/.endara/config.toml`, returning `Err` if the file is missing or invalid.
+fn read_config() -> Result<toml::Table, String> {
+    let path = config_path()?;
+    if !path.exists() {
+        return Err("Config file not found".to_string());
+    }
+    let contents = std::fs::read_to_string(&path)
+        .map_err(|e| format!("Failed to read config: {e}"))?;
+    contents
+        .parse()
+        .map_err(|e| format!("Failed to parse config: {e}"))
+}
+
+/// Serialize and write a `toml::Table` back to `~/.endara/config.toml`.
+fn write_config(table: &toml::Table) -> Result<(), String> {
+    let path = config_path()?;
+    let new_contents = toml::to_string_pretty(table)
+        .map_err(|e| format!("Failed to serialize config: {e}"))?;
+    std::fs::write(&path, &new_contents)
+        .map_err(|e| format!("Failed to write config: {e}"))
+}
+
 /// Holds the relay sidecar child process handle.
 pub struct RelayState {
     child: Arc<Mutex<Option<tauri_plugin_shell::process::CommandChild>>>,
+    /// Raw PID stored behind a std::sync::Mutex so it can be read without an async runtime
+    /// (e.g. in the synchronous `RunEvent::Exit` callback).
+    pid: Arc<std::sync::Mutex<Option<u32>>>,
     running: Arc<Mutex<bool>>,
     port: Arc<Mutex<u16>>,
     last_sidecar_status: Arc<Mutex<String>>,
@@ -106,9 +181,7 @@ async fn spawn_relay(
     app: &AppHandle,
     port: u16,
 ) -> Result<tauri_plugin_shell::process::CommandChild, String> {
-    let config_path = dirs::home_dir()
-        .map(|h| h.join(".endara").join("config.toml"))
-        .unwrap_or_default();
+    let config_file = config_path()?;
 
     // Ensure log directory exists for relay file logging
     if let Some(home) = dirs::home_dir() {
@@ -116,7 +189,15 @@ async fn spawn_relay(
         let _ = std::fs::create_dir_all(&log_dir);
     }
 
-    eprintln!("[relay] attempting to spawn sidecar with config: {:?}, port: {}", config_path, port);
+    eprintln!("[relay] attempting to spawn sidecar with config: {:?}, port: {}", config_file, port);
+
+    // Pre-flight port conflict check
+    if is_port_in_use(port) {
+        let err_msg = format!("Port {} is already in use by another process. Close the other process or change the relay port in Settings.", port);
+        eprintln!("[relay] pre-flight check failed: {}", err_msg);
+        emit_sidecar_status(app, "failed", Some(err_msg.clone())).await;
+        return Err(err_msg);
+    }
 
     // Emit sidecar lifecycle: starting
     emit_sidecar_status(app, "starting", None).await;
@@ -129,7 +210,7 @@ async fn spawn_relay(
             eprintln!("[relay] FAILED to create sidecar command: {e}");
             format!("Failed to create sidecar command: {e}")
         })?
-        .args(["start", "--config", &config_path.to_string_lossy(), "--port", &port_str])
+        .args(["start", "--config", &config_file.to_string_lossy(), "--port", &port_str])
         .spawn()
         .map_err(|e| {
             eprintln!("[relay] FAILED to spawn relay sidecar: {e}");
@@ -189,6 +270,9 @@ async fn spawn_relay(
                     eprintln!("[relay] process terminated, code: {code:?}, signal: {signal:?}");
                     // Update running state
                     if let Some(state) = app_handle.try_state::<RelayState>() {
+                        if let Ok(mut pid_guard) = state.pid.lock() {
+                            pid_guard.take();
+                        }
                         *state.running.lock().await = false;
                         *state.child.lock().await = None;
                     }
@@ -233,6 +317,9 @@ async fn start_relay(
 
     let port = *state.port.lock().await;
     let child = spawn_relay(&app, port).await?;
+    if let Ok(mut pid_guard) = state.pid.lock() {
+        *pid_guard = Some(child.pid());
+    }
     *state.child.lock().await = Some(child);
     *state.running.lock().await = true;
     Ok(RelayStatusInfo { running: true })
@@ -240,6 +327,9 @@ async fn start_relay(
 
 #[tauri::command]
 async fn stop_relay(state: State<'_, RelayState>) -> Result<RelayStatusInfo, String> {
+    if let Ok(mut pid_guard) = state.pid.lock() {
+        pid_guard.take();
+    }
     let mut child_guard = state.child.lock().await;
     if let Some(child) = child_guard.take() {
         child.kill().map_err(|e| format!("Failed to kill relay: {e}"))?;
@@ -254,6 +344,9 @@ async fn restart_relay(
     state: State<'_, RelayState>,
 ) -> Result<RelayStatusInfo, String> {
     {
+        if let Ok(mut pid_guard) = state.pid.lock() {
+            pid_guard.take();
+        }
         let mut child_guard = state.child.lock().await;
         if let Some(child) = child_guard.take() {
             let _ = child.kill();
@@ -266,6 +359,9 @@ async fn restart_relay(
 
     let port = *state.port.lock().await;
     let child = spawn_relay(&app, port).await?;
+    if let Ok(mut pid_guard) = state.pid.lock() {
+        *pid_guard = Some(child.pid());
+    }
     *state.child.lock().await = Some(child);
     *state.running.lock().await = true;
     Ok(RelayStatusInfo { running: true })
@@ -288,27 +384,33 @@ async fn get_sidecar_status(
 }
 
 #[tauri::command]
+async fn get_relay_port(state: State<'_, RelayState>) -> Result<u16, String> {
+    Ok(*state.port.lock().await)
+}
+
+#[tauri::command]
 async fn set_relay_port(port: u16, state: State<'_, RelayState>) -> Result<(), String> {
     *state.port.lock().await = port;
-    Ok(())
+
+    // Persist port to ~/.endara/config.toml
+    let mut table = read_config()?;
+
+    // Set port in the [relay] section
+    if let Some(relay) = table.get_mut("relay").and_then(|v| v.as_table_mut()) {
+        relay.insert(
+            "port".to_string(),
+            toml::Value::Integer(port as i64),
+        );
+    } else {
+        return Err("Missing [relay] section in config".to_string());
+    }
+
+    write_config(&table)
 }
 
 #[tauri::command]
 async fn set_js_execution_mode(enabled: bool) -> Result<(), String> {
-    let config_path = dirs::home_dir()
-        .map(|h| h.join(".endara").join("config.toml"))
-        .ok_or_else(|| "Could not determine home directory".to_string())?;
-
-    let contents = if config_path.exists() {
-        std::fs::read_to_string(&config_path)
-            .map_err(|e| format!("Failed to read config: {e}"))?
-    } else {
-        return Err("Config file does not exist".to_string());
-    };
-
-    let mut table: toml::Table = contents
-        .parse()
-        .map_err(|e| format!("Failed to parse config: {e}"))?;
+    let mut table = read_config()?;
 
     // Set local_js_execution in the [relay] section
     if let Some(relay) = table.get_mut("relay").and_then(|v| v.as_table_mut()) {
@@ -320,13 +422,7 @@ async fn set_js_execution_mode(enabled: bool) -> Result<(), String> {
         return Err("Missing [relay] section in config".to_string());
     }
 
-    let new_contents = toml::to_string_pretty(&table)
-        .map_err(|e| format!("Failed to serialize config: {e}"))?;
-
-    std::fs::write(&config_path, &new_contents)
-        .map_err(|e| format!("Failed to write config: {e}"))?;
-
-    Ok(())
+    write_config(&table)
 }
 
 #[derive(Deserialize)]
@@ -357,20 +453,7 @@ struct EndpointConfig {
 
 #[tauri::command]
 async fn get_endpoint_config(name: String) -> Result<EndpointConfig, String> {
-    let config_path = dirs::home_dir()
-        .map(|h| h.join(".endara").join("config.toml"))
-        .ok_or_else(|| "Could not determine home directory".to_string())?;
-
-    if !config_path.exists() {
-        return Err("Config file not found".to_string());
-    }
-
-    let contents = std::fs::read_to_string(&config_path)
-        .map_err(|e| format!("Failed to read config: {e}"))?;
-
-    let parsed: toml::Table = contents
-        .parse()
-        .map_err(|e| format!("Failed to parse config: {e}"))?;
+    let parsed = read_config()?;
 
     if let Some(toml::Value::Array(endpoints)) = parsed.get("endpoints") {
         for ep in endpoints {
@@ -424,20 +507,7 @@ struct UpdateEndpointArgs {
 
 #[tauri::command]
 async fn update_endpoint(args: UpdateEndpointArgs) -> Result<(), String> {
-    let config_path = dirs::home_dir()
-        .map(|h| h.join(".endara").join("config.toml"))
-        .ok_or_else(|| "Could not determine home directory".to_string())?;
-
-    if !config_path.exists() {
-        return Err("Config file not found".to_string());
-    }
-
-    let contents = std::fs::read_to_string(&config_path)
-        .map_err(|e| format!("Failed to read config: {e}"))?;
-
-    let mut parsed: toml::Table = contents
-        .parse()
-        .map_err(|e| format!("Failed to parse config: {e}"))?;
+    let mut parsed = read_config()?;
 
     // If name changed, check for duplicates
     if args.name != args.original_name {
@@ -505,28 +575,20 @@ async fn update_endpoint(args: UpdateEndpointArgs) -> Result<(), String> {
         return Err(format!("Endpoint '{}' not found", args.original_name));
     }
 
-    let new_contents = toml::to_string_pretty(&parsed)
-        .map_err(|e| format!("Failed to serialize config: {e}"))?;
-
-    std::fs::write(&config_path, &new_contents)
-        .map_err(|e| format!("Failed to write config: {e}"))?;
-
-    Ok(())
+    write_config(&parsed)
 }
 
 #[tauri::command]
 async fn add_endpoint(args: AddEndpointArgs) -> Result<(), String> {
-    let config_path = dirs::home_dir()
-        .map(|h| h.join(".endara").join("config.toml"))
-        .ok_or_else(|| "Could not determine home directory".to_string())?;
+    let path = config_path()?;
 
     // Read existing config or create default
-    let contents = if config_path.exists() {
-        std::fs::read_to_string(&config_path)
+    let contents = if path.exists() {
+        std::fs::read_to_string(&path)
             .map_err(|e| format!("Failed to read config: {e}"))?
     } else {
         // Create parent directory if needed
-        if let Some(parent) = config_path.parent() {
+        if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)
                 .map_err(|e| format!("Failed to create config directory: {e}"))?;
         }
@@ -599,31 +661,12 @@ async fn add_endpoint(args: AddEndpointArgs) -> Result<(), String> {
         .ok_or_else(|| "Invalid endpoints section in config".to_string())?;
     endpoints.push(toml::Value::Table(endpoint));
 
-    let new_contents = toml::to_string_pretty(&parsed)
-        .map_err(|e| format!("Failed to serialize config: {e}"))?;
-
-    std::fs::write(&config_path, &new_contents)
-        .map_err(|e| format!("Failed to write config: {e}"))?;
-
-    Ok(())
+    write_config(&parsed)
 }
 
 #[tauri::command]
 async fn remove_endpoint(name: String) -> Result<(), String> {
-    let config_path = dirs::home_dir()
-        .map(|h| h.join(".endara").join("config.toml"))
-        .ok_or_else(|| "Could not determine home directory".to_string())?;
-
-    if !config_path.exists() {
-        return Err("Config file not found".to_string());
-    }
-
-    let contents = std::fs::read_to_string(&config_path)
-        .map_err(|e| format!("Failed to read config: {e}"))?;
-
-    let mut parsed: toml::Table = contents
-        .parse()
-        .map_err(|e| format!("Failed to parse config: {e}"))?;
+    let mut parsed = read_config()?;
 
     if let Some(toml::Value::Array(endpoints)) = parsed.get_mut("endpoints") {
         let original_len = endpoints.len();
@@ -640,26 +683,22 @@ async fn remove_endpoint(name: String) -> Result<(), String> {
         return Err(format!("Endpoint '{}' not found", name));
     }
 
-    let new_contents = toml::to_string_pretty(&parsed)
-        .map_err(|e| format!("Failed to serialize config: {e}"))?;
-
-    std::fs::write(&config_path, &new_contents)
-        .map_err(|e| format!("Failed to write config: {e}"))?;
-
-    Ok(())
+    write_config(&parsed)
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let relay_state = RelayState {
         child: Arc::new(Mutex::new(None)),
+        pid: Arc::new(std::sync::Mutex::new(None)),
         running: Arc::new(Mutex::new(false)),
-        port: Arc::new(Mutex::new(9400)),
+        port: Arc::new(Mutex::new(read_port_from_config().unwrap_or(9400))),
         last_sidecar_status: Arc::new(Mutex::new("unknown".to_string())),
         last_sidecar_error: Arc::new(Mutex::new(None)),
     };
 
     let child_handle = relay_state.child.clone();
+    let pid_handle = relay_state.pid.clone();
 
     tauri::Builder::default()
         .plugin(tauri_plugin_log::Builder::new()
@@ -681,6 +720,7 @@ pub fn run() {
             remove_endpoint,
             get_endpoint_config,
             update_endpoint,
+            get_relay_port,
             set_relay_port,
             set_js_execution_mode,
         ])
@@ -696,10 +736,14 @@ pub fn run() {
 
             let _tray = TrayIconBuilder::new()
                 .icon(app.default_window_icon().unwrap().clone())
+                .icon_as_template(true)
                 .menu(&menu)
                 .show_menu_on_left_click(true)
                 .on_menu_event(|app, event| match event.id.as_ref() {
                     "open" => {
+                        // Show in Cmd-Tab and Dock
+                        #[cfg(target_os = "macos")]
+                        set_macos_activation_policy(true);
                         if let Some(window) = app.get_webview_window("main") {
                             let _ = window.show();
                             let _ = window.set_focus();
@@ -707,13 +751,33 @@ pub fn run() {
                     }
                     "check_update" => {
                         let _ = app.emit("check-for-update", ());
-                        // Also show the window so user can see the update UI
+                        // Show in Cmd-Tab and Dock
+                        #[cfg(target_os = "macos")]
+                        set_macos_activation_policy(true);
                         if let Some(window) = app.get_webview_window("main") {
                             let _ = window.show();
                             let _ = window.set_focus();
                         }
                     }
                     "quit" => {
+                        // Kill relay sidecar before exiting
+                        if let Some(state) = app.try_state::<RelayState>() {
+                            // Kill by PID first (synchronous, reliable)
+                            if let Ok(mut pid_guard) = state.pid.lock() {
+                                if let Some(pid) = pid_guard.take() {
+                                    eprintln!("[relay] killing sidecar pid {} on tray quit", pid);
+                                    unsafe { libc::kill(pid as i32, libc::SIGTERM); }
+                                }
+                            }
+                            // Also kill via child handle as fallback
+                            let child_handle = state.child.clone();
+                            tauri::async_runtime::block_on(async {
+                                let mut guard = child_handle.lock().await;
+                                if let Some(child) = guard.take() {
+                                    let _ = child.kill();
+                                }
+                            });
+                        }
                         app.exit(0);
                     }
                     _ => {}
@@ -731,6 +795,9 @@ pub fn run() {
                 match spawn_relay(&app_handle, port).await {
                     Ok(child) => {
                         if let Some(state) = app_handle.try_state::<RelayState>() {
+                            if let Ok(mut pid_guard) = state.pid.lock() {
+                                *pid_guard = Some(child.pid());
+                            }
                             *state.child.lock().await = Some(child);
                             *state.running.lock().await = true;
                         }
@@ -742,21 +809,49 @@ pub fn run() {
                 }
             });
 
+            // Ensure app appears in Cmd-Tab on startup
+            #[cfg(target_os = "macos")]
+            set_macos_activation_policy(true);
+
             Ok(())
+        })
+        .on_window_event(|window, event| {
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                // Prevent the window from being destroyed — hide it instead
+                api.prevent_close();
+                let _ = window.hide();
+                // Hide from Cmd-Tab and Dock, keep in menu bar tray
+                #[cfg(target_os = "macos")]
+                set_macos_activation_policy(false);
+            }
         })
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
         .run(move |_app, event| {
-            if let RunEvent::ExitRequested { .. } = event {
-                // Kill relay sidecar on app exit
-                let child_handle = child_handle.clone();
-                tauri::async_runtime::block_on(async {
-                    let mut guard = child_handle.lock().await;
-                    if let Some(child) = guard.take() {
-                        log::info!("[relay] killing sidecar on app exit");
-                        let _ = child.kill();
+            match event {
+                RunEvent::Exit => {
+                    // Kill relay by PID — no async runtime needed, avoids block_on deadlock
+                    if let Ok(mut guard) = pid_handle.try_lock() {
+                        if let Some(pid) = guard.take() {
+                            eprintln!("[relay] killing sidecar pid {} on app exit", pid);
+                            unsafe { libc::kill(pid as i32, libc::SIGTERM); }
+                        }
                     }
-                });
+                    // Also try the async child.kill() as fallback, in a separate thread
+                    // to avoid deadlocking on the tokio runtime during shutdown.
+                    let child_handle = child_handle.clone();
+                    let _ = std::thread::spawn(move || {
+                        if let Ok(rt) = tokio::runtime::Runtime::new() {
+                            rt.block_on(async {
+                                let mut guard = child_handle.lock().await;
+                                if let Some(child) = guard.take() {
+                                    let _ = child.kill();
+                                }
+                            });
+                        }
+                    }).join();
+                }
+                _ => {}
             }
         });
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "identifier": "ai.endara.desktop",
   "build": {
-    "beforeDevCommand": "npm run dev",
+    "beforeDevCommand": "bash scripts/kill-relay.sh; npm run dev",
     "devUrl": "http://localhost:1420",
     "beforeBuildCommand": "npm run build",
     "frontendDist": "../build"

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { theme, jsExecutionMode, relayPort, relayConnected, relayLastError, relaySidecarStatus, relaySidecarError, updateStatus, updateVersion, updateError } from '$lib/stores';
+  import { theme, jsExecutionMode, relayPort, relayConnected, relaySidecarStatus, relaySidecarError, updateStatus, updateVersion, updateError } from '$lib/stores';
   import type { Theme, RelayStatus } from '$lib/types';
   import { invoke } from '@tauri-apps/api/core';
   import { getStatus, getConfig, reloadConfig } from '$lib/api';
@@ -9,12 +9,23 @@
 
   let portInput: number = $state($relayPort);
   let portSaved = $state(false);
+  let portError = $state<string | null>(null);
 
-  function savePort() {
-    relayPort.set(portInput);
-    invoke('set_relay_port', { port: portInput }).catch(() => {});
-    portSaved = true;
-    setTimeout(() => { portSaved = false; }, 2000);
+  async function savePort() {
+    const port = Math.floor(portInput);
+    if (!Number.isFinite(port) || port < 1 || port > 65535) {
+      portError = 'Port must be an integer between 1 and 65535';
+      return;
+    }
+    portError = null;
+    try {
+      await invoke('set_relay_port', { port });
+      relayPort.set(port);
+      portSaved = true;
+      setTimeout(() => { portSaved = false; }, 2000);
+    } catch (e) {
+      portError = e instanceof Error ? e.message : String(e);
+    }
   }
 
   const connectionItems = $derived([
@@ -42,7 +53,7 @@
   let buildInfo: BuildInfo | null = $state(null);
   let relayStatus: RelayStatus | null = $state(null);
   let statusPollInterval: ReturnType<typeof setInterval> | undefined;
-	let retryingRelay = $state(false);
+  let retryingRelay = $state(false);
 
   function setTheme(t: Theme) {
     theme.set(t);
@@ -108,7 +119,7 @@
   const isAmber = $derived($relaySidecarStatus === 'failed' && $relayConnected);
   const isRed = $derived(($relaySidecarStatus === 'failed' || $relaySidecarStatus === 'stopped') && !$relayConnected);
   const isStarting = $derived($relaySidecarStatus === 'starting' || $relaySidecarStatus === 'unknown');
-	const showRetryRelayButton = $derived(canRetryRelay($relaySidecarStatus));
+  const showRetryRelayButton = $derived(canRetryRelay($relaySidecarStatus));
   const statusDotColor = $derived(isGreen ? 'bg-green-500' : isAmber ? 'bg-yellow-500' : isRed ? 'bg-red-500' : 'bg-gray-400');
   const statusBadgeClass = $derived(isGreen ? 'bg-green-500/10 text-green-600 dark:text-green-400'
     : isAmber ? 'bg-yellow-500/10 text-yellow-600 dark:text-yellow-400'
@@ -116,25 +127,25 @@
     : 'bg-gray-500/10 text-gray-600 dark:text-gray-400');
   const statusLabel = $derived(isGreen ? 'Running'
     : isAmber ? 'Port Conflict'
-	  : $relaySidecarStatus === 'stopped' ? 'Stopped'
+    : $relaySidecarStatus === 'stopped' ? 'Stopped'
     : isRed ? 'Failed'
     : isStarting ? 'Starting...'
     : 'Unknown');
 
-	async function handleRetryRelay() {
-	  if (retryingRelay) return;
+  async function handleRetryRelay() {
+    if (retryingRelay) return;
 
-	  retryingRelay = true;
+    retryingRelay = true;
 
-	  try {
-	    await restartRelay(invoke);
-	  } catch (error) {
-	    console.error('Failed to restart relay:', error);
-	    relaySidecarError.set(error instanceof Error ? error.message : String(error));
-	  } finally {
-	    retryingRelay = false;
-	  }
-	}
+    try {
+      await restartRelay(invoke);
+    } catch (error) {
+      console.error('Failed to restart relay:', error);
+      relaySidecarError.set(error instanceof Error ? error.message : String(error));
+    } finally {
+      retryingRelay = false;
+    }
+  }
 </script>
 
 <div class="h-full overflow-y-auto p-6">
@@ -174,9 +185,9 @@
 
       {#if isRed}
         <p class="text-xs text-(--color-text-secondary) mt-1">
-	          {$relaySidecarStatus === 'stopped'
-	            ? 'Relay is stopped. Click Retry to start it again.'
-	            : `Relay failed to start on port ${$relayPort}. Check Relay Logs for details.`}
+          {$relaySidecarStatus === 'stopped'
+            ? 'Relay is stopped. Click Retry to start it again.'
+            : `Relay failed to start on port ${$relayPort}. Check Relay Logs for details.`}
         </p>
         {#if $relaySidecarError}
           <div class="mt-2 p-2 rounded bg-red-500/10 border border-red-500/20">
@@ -191,17 +202,17 @@
         </p>
       {/if}
 
-		      {#if showRetryRelayButton}
-	        <div class="mt-3">
-	          <button
-	            class="px-3 py-1.5 text-xs rounded-lg bg-(--color-accent) text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
-	            onclick={handleRetryRelay}
-	            disabled={retryingRelay}
-	          >
-	            {retryingRelay ? 'Retrying…' : 'Retry'}
-	          </button>
-	        </div>
-	      {/if}
+      {#if showRetryRelayButton}
+        <div class="mt-3">
+          <button
+            class="px-3 py-1.5 text-xs rounded-lg bg-(--color-accent) text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+            onclick={handleRetryRelay}
+            disabled={retryingRelay}
+          >
+            {retryingRelay ? 'Retrying…' : 'Retry'}
+          </button>
+        </div>
+      {/if}
     </div>
 
     <fieldset class="border-none p-0">
@@ -257,7 +268,11 @@
               {portSaved ? '✓ Saved' : 'Save'}
             </button>
           </div>
-          <p class="text-xs text-(--color-text-secondary)/70 mt-1">Restart the app to apply port changes.</p>
+          {#if portError}
+            <p class="text-xs text-red-600 dark:text-red-400 mt-1">{portError}</p>
+          {:else}
+            <p class="text-xs text-(--color-text-secondary)/70 mt-1">Restart the app to apply port changes.</p>
+          {/if}
         </div>
       </div>
       <div class="space-y-1.5">

--- a/src/lib/components/Settings.test.ts
+++ b/src/lib/components/Settings.test.ts
@@ -15,6 +15,14 @@ describe('Settings relay retry behavior', () => {
     expect(canRetryRelay('running')).toBe(false);
   });
 
+  it('does not show the retry button when the sidecar is starting', () => {
+    expect(canRetryRelay('starting')).toBe(false);
+  });
+
+  it('does not show the retry button when the sidecar status is unknown', () => {
+    expect(canRetryRelay('unknown')).toBe(false);
+  });
+
   it('invokes restart_relay when retry is triggered', async () => {
     const invoke = vi.fn().mockResolvedValue(undefined);
 

--- a/src/lib/logListener.test.ts
+++ b/src/lib/logListener.test.ts
@@ -85,7 +85,7 @@ describe('logListener', () => {
       expect(lines[0].level).toBe('info');
     });
 
-    it('updates relayLastError on relay-health error event', async () => {
+    it('registers relay-health listener without error', async () => {
       const mockListen = vi.mocked(listen);
       let healthCallback: ((event: { payload: { status: string; message: string | null } }) => void) | undefined;
 
@@ -97,14 +97,10 @@ describe('logListener', () => {
       });
 
       const { initRelayLogListener } = await import('./logListener');
-      const { relayLastError } = await import('./stores');
       await initRelayLogListener();
 
-      healthCallback!({ payload: { status: 'error', message: 'connection failed' } });
-      expect(get(relayLastError)).toBe('connection failed');
-
-      healthCallback!({ payload: { status: 'connected', message: null } });
-      expect(get(relayLastError)).toBeNull();
+      // relay-health listener is registered but no longer updates relayLastError
+      expect(healthCallback).toBeDefined();
     });
 
     it('updates sidecar status on relay-sidecar-status event', async () => {

--- a/src/lib/logListener.ts
+++ b/src/lib/logListener.ts
@@ -1,6 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
-import { relayLogLines, relayLastError, relaySidecarStatus, relaySidecarError } from './stores';
+import { relayLogLines, relaySidecarStatus, relaySidecarError } from './stores';
 import type { RelayLogLine, RelaySidecarStatusType } from './stores';
 
 let initialized = false;
@@ -38,13 +38,8 @@ export async function initRelayLogListener() {
     console.error('Failed to listen for relay-log events:', e);
   }),
 
-    listen<{ status: string; message: string | null }>('relay-health', (event) => {
-    const { status, message } = event.payload;
-    if (status === 'error' && message) {
-      relayLastError.set(message);
-    } else if (status === 'connected') {
-      relayLastError.set(null);
-    }
+    listen<{ status: string; message: string | null }>('relay-health', () => {
+    // relay-health events are handled via relay-sidecar-status
   }).catch((e) => {
     console.error('Failed to listen for relay-health events:', e);
   }),

--- a/src/lib/relaySidecarUi.ts
+++ b/src/lib/relaySidecarUi.ts
@@ -30,6 +30,18 @@ export function canRetryRelay(status: RelaySidecarStatusType): boolean {
   return status === 'failed' || status === 'stopped';
 }
 
+export function shouldShowRelayStartupFailure(
+  sidecarStatus: RelaySidecarStatusType,
+  relayConnected: boolean,
+  dismissed: boolean
+): boolean {
+  return sidecarStatus === 'failed' && !relayConnected && !dismissed;
+}
+
+export function shouldSkipEndpointPolling(sidecarStatus: RelaySidecarStatusType): boolean {
+  return sidecarStatus === 'failed' || sidecarStatus === 'stopped';
+}
+
 export async function restartRelay(invokeFn: (command: string) => Promise<unknown>): Promise<void> {
   await invokeFn('restart_relay');
 }

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -39,7 +39,6 @@ function createThemeStore() {
 
 export const theme = createThemeStore();
 export const searchQuery = writable<string>('');
-export const isSettingsOpen = writable<boolean>(false);
 export const activeTab = writable<'tools' | 'logs' | 'config'>('tools');
 export const activeTopLevelTab = writable<'servers' | 'unified-catalog' | 'relay-logs' | 'settings'>('servers');
 
@@ -53,7 +52,6 @@ export const relayLogLines = writable<RelayLogLine[]>([]);
 export const miniPlayerMode = writable<boolean>(false);
 
 export const relayConnected = writable<boolean>(false);
-export const relayLastError = writable<string | null>(null);
 export const onboardingDismissed = writable<boolean>(false);
 export const initialLoadComplete = writable<boolean>(false);
 

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,8 +1,8 @@
-import { check } from '@tauri-apps/plugin-updater';
+import { check, Update } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
 import { updateStatus, updateVersion, updateError } from './stores';
 
-let updateInstance: any = null;
+let updateInstance: Update | null = null;
 
 export async function checkForUpdate() {
   updateStatus.set('checking');

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,10 +7,10 @@
   import RelayLogs from '$lib/components/RelayLogs.svelte';
   import UnifiedCatalog from '$lib/components/UnifiedCatalog.svelte';
   import Onboarding from '$lib/components/Onboarding.svelte';
-  import { endpoints, activeTopLevelTab, miniPlayerMode, relayConnected, relayLastError, showOnboarding, relayPort, relaySidecarStatus, relaySidecarError, initialLoadComplete } from '$lib/stores';
+  import { endpoints, activeTopLevelTab, miniPlayerMode, relayConnected, showOnboarding, relayPort, relaySidecarStatus, relaySidecarError, initialLoadComplete } from '$lib/stores';
   import { getEndpoints } from '$lib/api';
   import { initRelayLogListener } from '$lib/logListener';
-  import { getActiveTopLevelTab, getVisibleTopLevelTabs } from '$lib/relaySidecarUi';
+  import { getActiveTopLevelTab, getVisibleTopLevelTabs, shouldShowRelayStartupFailure, shouldSkipEndpointPolling } from '$lib/relaySidecarUi';
   import { invoke } from '@tauri-apps/api/core';
   import { get } from 'svelte/store';
 
@@ -31,19 +31,18 @@
     : ($relaySidecarStatus === 'stopped') ? 'Relay stopped'
     : 'Relay status unknown'
   );
-  const relayStartupFailureActive = $derived($relaySidecarStatus === 'failed' && !$relayConnected);
   const relayFailureMessage = $derived($relaySidecarError ?? 'Relay failed to start. Check Relay Logs for more details.');
 
   let pollInterval: ReturnType<typeof setInterval> | undefined;
   let sidebar: Sidebar | undefined = $state();
   let retryingRelay = $state(false);
   let relayStartupFailureDismissed = $state(false);
-  const showRelayStartupFailure = $derived(relayStartupFailureActive && !relayStartupFailureDismissed);
+  const showRelayStartupFailure = $derived(shouldShowRelayStartupFailure($relaySidecarStatus, $relayConnected, relayStartupFailureDismissed));
 
   const topLevelTabs = $derived(getVisibleTopLevelTabs($relaySidecarStatus));
 
   $effect(() => {
-    if (!relayStartupFailureActive) {
+    if (!($relaySidecarStatus === 'failed' && !$relayConnected)) {
       relayStartupFailureDismissed = false;
     }
   });
@@ -55,13 +54,20 @@
   });
 
   async function pollEndpoints() {
+    const currentStatus = get(relaySidecarStatus);
+    // If sidecar failed (e.g., port conflict), don't poll — we're not managing what's on that port
+    if (shouldSkipEndpointPolling(currentStatus)) {
+      relayConnected.set(false);
+      endpoints.set([]);
+      return;
+    }
     try {
       const data = await getEndpoints();
       endpoints.set(data);
       relayConnected.set(true);
       // If sidecar status is still starting/unknown but API responds, infer running
-      const currentStatus = get(relaySidecarStatus);
-      if (currentStatus === 'starting' || currentStatus === 'unknown') {
+      const inferredStatus = get(relaySidecarStatus);
+      if (inferredStatus === 'starting' || inferredStatus === 'unknown') {
         relaySidecarStatus.set('running');
       }
     } catch {
@@ -71,8 +77,12 @@
   }
 
   onMount(() => {
-    // Sync the configured relay port to the Rust backend
-    invoke('set_relay_port', { port: get(relayPort) }).catch(() => {});
+    // Sync the relay port FROM the Rust backend (config.toml is the source of truth)
+    invoke('get_relay_port').then((port: unknown) => {
+      if (typeof port === 'number' && port > 0) {
+        relayPort.set(port as number);
+      }
+    }).catch(() => {});
     initRelayLogListener();
     pollEndpoints().then(() => initialLoadComplete.set(true));
     pollInterval = setInterval(pollEndpoints, 2000);

--- a/src/routes/page-tabs.test.ts
+++ b/src/routes/page-tabs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { getActiveTopLevelTab, getVisibleTopLevelTabs } from '$lib/relaySidecarUi';
+import { getActiveTopLevelTab, getVisibleTopLevelTabs, relayTabsRestricted, shouldShowRelayStartupFailure, shouldSkipEndpointPolling } from '$lib/relaySidecarUi';
 
 describe('+page relay tab logic', () => {
   it('shows only relay logs and settings tabs when the relay sidecar failed', () => {
@@ -25,3 +25,64 @@ describe('+page relay tab logic', () => {
   });
 });
 
+describe('shouldShowRelayStartupFailure', () => {
+  it('returns true when sidecar failed, not connected, and not dismissed', () => {
+    expect(shouldShowRelayStartupFailure('failed', false, false)).toBe(true);
+  });
+
+  it('returns false when sidecar failed but relay is connected (port conflict)', () => {
+    expect(shouldShowRelayStartupFailure('failed', true, false)).toBe(false);
+  });
+
+  it('returns false when sidecar failed but user dismissed the modal', () => {
+    expect(shouldShowRelayStartupFailure('failed', false, true)).toBe(false);
+  });
+
+  it('returns false when sidecar is running', () => {
+    expect(shouldShowRelayStartupFailure('running', true, false)).toBe(false);
+  });
+
+  it('returns false when sidecar is starting', () => {
+    expect(shouldShowRelayStartupFailure('starting', false, false)).toBe(false);
+  });
+});
+
+describe('shouldSkipEndpointPolling', () => {
+  it('returns true when sidecar status is failed', () => {
+    expect(shouldSkipEndpointPolling('failed')).toBe(true);
+  });
+
+  it('returns false when sidecar status is running', () => {
+    expect(shouldSkipEndpointPolling('running')).toBe(false);
+  });
+
+  it('returns false when sidecar status is starting', () => {
+    expect(shouldSkipEndpointPolling('starting')).toBe(false);
+  });
+
+  it('returns false when sidecar status is unknown', () => {
+    expect(shouldSkipEndpointPolling('unknown')).toBe(false);
+  });
+
+  it('returns true when sidecar status is stopped', () => {
+    expect(shouldSkipEndpointPolling('stopped')).toBe(true);
+  });
+});
+
+describe('relayTabsRestricted', () => {
+  it('returns true when sidecar status is failed', () => {
+    expect(relayTabsRestricted('failed')).toBe(true);
+  });
+  it('returns true when sidecar status is stopped', () => {
+    expect(relayTabsRestricted('stopped')).toBe(true);
+  });
+  it('returns false when sidecar status is running', () => {
+    expect(relayTabsRestricted('running')).toBe(false);
+  });
+  it('returns false when sidecar status is starting', () => {
+    expect(relayTabsRestricted('starting')).toBe(false);
+  });
+  it('returns false when sidecar status is unknown', () => {
+    expect(relayTabsRestricted('unknown')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

This PR improves the desktop app's relay sidecar lifecycle management, adds port validation, fixes macOS Cmd-Tab visibility, and adds a dev cleanup script.

### Changes

#### Relay Sidecar Lifecycle & UI
- Track sidecar status (starting/running/failed/stopped) and guard endpoint polling accordingly
- Add port validation (1-65535) with inline error display in Settings
- Extract `shouldShowRelayStartupFailure` and `shouldSkipEndpointPolling` into testable helpers
- Read relay port from Rust backend on startup (config.toml as source of truth)
- Remove dead stores: `relayLastError`, `isSettingsOpen`
- Fix mixed tabs/spaces in Settings.svelte
- Type `updateInstance` properly (was `any`)

#### macOS Cmd-Tab Fix
- Add `set_macos_activation_policy()` helper using `cocoa`/`objc` crates
- Workaround for [tauri-apps/tauri#9244](https://github.com/tauri-apps/tauri/issues/9244)
- App appears in Cmd-Tab/Dock when window is open, hides when closed
- Tray icon always visible in menu bar

#### Dev Cleanup
- Add `kill-relay.sh` script to terminate stale relay processes
- Integrate into `beforeDevCommand` to prevent port conflicts

### Testing
- All 95 Vitest tests pass
- `cargo check` passes (5 deprecation warnings from `cocoa` crate — expected, temporary workaround)
- Manual testing: Cmd-Tab show/hide works correctly

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author