### PR TITLE
fix: make healthy dot static instead of pulsing

### DIFF
--- a/src/lib/components/HealthDot.svelte
+++ b/src/lib/components/HealthDot.svelte
@@ -41,7 +41,7 @@
   </span>
 {:else}
   <span
-    class="inline-block w-2.5 h-2.5 rounded-full {colorMap[health]} {health === 'healthy' ? 'animate-pulse-dot' : ''}"
+    class="inline-block w-2.5 h-2.5 rounded-full {colorMap[health]}"
     title={titleMap[health]}
   ></span>
 {/if}


### PR DESCRIPTION
Remove the `animate-pulse-dot` class from the healthy status dot in `HealthDot.svelte`. The dot is now a static solid green circle for healthy endpoints.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author