### PR TITLE
feat: OAuth auth status UI and management controls

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import { get } from 'svelte/store';
-import type { RelayStatus, Endpoint, Tool, EndpointLogs, CatalogEntry } from './types';
+import type { RelayStatus, Endpoint, Tool, EndpointLogs, CatalogEntry, OAuthStatus } from './types';
 import { relayPort } from './stores';
 
 function getBaseUrl() {
@@ -190,8 +190,16 @@ export async function startOAuth(name: string): Promise<{ authorize_url: string 
   return fetchJson<{ authorize_url: string }>(`/endpoints/${encodeURIComponent(name)}/oauth/start`, { method: 'POST' });
 }
 
-export async function getOAuthStatus(name: string): Promise<{ status: string }> {
-  return fetchJson<{ status: string }>(`/endpoints/${encodeURIComponent(name)}/oauth/status`);
+export async function getOAuthStatus(name: string): Promise<OAuthStatus> {
+  return fetchJson<OAuthStatus>(`/endpoints/${encodeURIComponent(name)}/oauth/status`);
+}
+
+export async function revokeOAuth(name: string): Promise<void> {
+  await fetchJson(`/endpoints/${encodeURIComponent(name)}/oauth/revoke`, { method: 'POST' });
+}
+
+export async function refreshOAuth(name: string): Promise<void> {
+  await fetchJson(`/endpoints/${encodeURIComponent(name)}/oauth/refresh`, { method: 'POST' });
 }
 
 export async function updateEndpoint(params: UpdateEndpointParams): Promise<void> {

--- a/src/lib/components/AddEndpointModal.svelte
+++ b/src/lib/components/AddEndpointModal.svelte
@@ -342,8 +342,8 @@
       for (let i = 0; i < maxAttempts; i++) {
         await new Promise((r) => setTimeout(r, 1000));
         try {
-          const { status } = await getOAuthStatus(trimmedName);
-          if (status === 'authorized' || status === 'complete') {
+          const oauthResult = await getOAuthStatus(trimmedName);
+          if ((oauthResult.status as string) === 'authorized' || (oauthResult.status as string) === 'complete' || oauthResult.status === 'authenticated') {
             // Success — refresh and close
             try {
               const data = await getEndpoints();
@@ -355,7 +355,7 @@
             onclose();
             return;
           }
-          if (status === 'error') {
+          if ((oauthResult.status as string) === 'error' || oauthResult.status === 'connection_failed') {
             error = 'OAuth authorization failed';
             return;
           }

--- a/src/lib/components/AuthTab.svelte
+++ b/src/lib/components/AuthTab.svelte
@@ -1,0 +1,218 @@
+<script lang="ts">
+  import type { OAuthStatus, OAuthStatusValue } from '$lib/types';
+  import { selectedEndpoint, oauthStatuses } from '$lib/stores';
+  import { getOAuthStatus, refreshOAuth, revokeOAuth, startOAuth } from '$lib/api';
+  import { toast } from 'svelte-sonner';
+  import { openUrl } from '@tauri-apps/plugin-opener';
+  import ConfirmModal from './ConfirmModal.svelte';
+
+  let status = $state<OAuthStatus | null>(null);
+  let loading = $state(true);
+  let error = $state('');
+  let showDisconnectConfirm = $state(false);
+  let actionInProgress = $state(false);
+
+  const statusColors: Record<OAuthStatusValue, string> = {
+    authenticated: 'bg-green-500',
+    needs_login: 'bg-yellow-500',
+    refreshing: 'bg-blue-500',
+    auth_required: 'bg-orange-500',
+    disconnected: 'bg-gray-400',
+    connection_failed: 'bg-red-500',
+  };
+
+  const statusLabels: Record<OAuthStatusValue, string> = {
+    authenticated: 'Authenticated',
+    needs_login: 'Needs Login',
+    refreshing: 'Refreshing',
+    auth_required: 'Auth Required',
+    disconnected: 'Disconnected',
+    connection_failed: 'Connection Failed',
+  };
+
+  function formatTime(iso: string | null): string {
+    if (!iso) return '—';
+    const d = new Date(iso);
+    return d.toLocaleString();
+  }
+
+  function formatCountdown(seconds: number | null): string {
+    if (seconds === null || seconds === undefined) return '—';
+    if (seconds <= 0) return 'Expired';
+    const m = Math.floor(seconds / 60);
+    const s = Math.round(seconds % 60);
+    if (m > 60) {
+      const h = Math.floor(m / 60);
+      return `${h}h ${m % 60}m`;
+    }
+    return m > 0 ? `${m}m ${s}s` : `${s}s`;
+  }
+
+  async function fetchStatus(name: string) {
+    try {
+      status = await getOAuthStatus(name);
+      // Update global store
+      oauthStatuses.update(m => { m.set(name, status!); return new Map(m); });
+      error = '';
+    } catch {
+      error = 'Failed to load OAuth status';
+    } finally {
+      loading = false;
+    }
+  }
+
+  $effect(() => {
+    const name = $selectedEndpoint;
+    if (!name) return;
+    loading = true;
+    fetchStatus(name);
+
+    const interval = setInterval(() => {
+      if (name) fetchStatus(name);
+    }, 5000);
+
+    return () => clearInterval(interval);
+  });
+
+  async function handleRefresh() {
+    const name = $selectedEndpoint;
+    if (!name || actionInProgress) return;
+    actionInProgress = true;
+    try {
+      await refreshOAuth(name);
+      toast.success('Token refresh initiated');
+      await fetchStatus(name);
+    } catch {
+      toast.error('Failed to refresh token');
+    }
+    actionInProgress = false;
+  }
+
+  async function handleReconnect() {
+    const name = $selectedEndpoint;
+    if (!name || actionInProgress) return;
+    actionInProgress = true;
+    try {
+      const { authorize_url } = await startOAuth(name);
+      await openUrl(authorize_url);
+      toast.success('Browser opened for authorization');
+    } catch {
+      toast.error('Failed to start OAuth flow');
+    }
+    actionInProgress = false;
+  }
+
+  async function handleDisconnect() {
+    const name = $selectedEndpoint;
+    if (!name) return;
+    actionInProgress = true;
+    try {
+      await revokeOAuth(name);
+      toast.success('OAuth disconnected');
+      await fetchStatus(name);
+    } catch {
+      toast.error('Failed to disconnect OAuth');
+    }
+    actionInProgress = false;
+    showDisconnectConfirm = false;
+  }
+
+  let canRefresh = $derived(status !== null && ['authenticated', 'auth_required'].includes(status.status));
+  let canReconnect = $derived(status !== null && ['disconnected', 'auth_required', 'needs_login'].includes(status.status));
+  let canDisconnect = $derived(status !== null && ['authenticated', 'refreshing', 'auth_required'].includes(status.status));
+</script>
+
+<div class="h-full overflow-y-auto p-4 space-y-4">
+  {#if loading}
+    <div class="space-y-3">
+      {#each [1, 2, 3] as _}
+        <div class="h-12 rounded-lg bg-(--color-surface-hover) animate-pulse"></div>
+      {/each}
+    </div>
+  {:else if error}
+    <div class="text-sm text-(--color-offline)">{error}</div>
+  {:else if status}
+    <!-- Status -->
+    <div class="p-4 rounded-lg border border-(--color-border)">
+      <div class="text-xs font-medium text-(--color-text-secondary) mb-2">Status</div>
+      <div class="flex items-center gap-2">
+        <span class="inline-block w-2.5 h-2.5 rounded-full {statusColors[status.status]}"></span>
+        <span class="text-sm font-medium">{statusLabels[status.status]}</span>
+      </div>
+    </div>
+
+    <!-- Token Details -->
+    <div class="p-4 rounded-lg border border-(--color-border) space-y-3">
+      <div class="text-xs font-medium text-(--color-text-secondary) mb-1">Token Details</div>
+      <div class="grid grid-cols-2 gap-3 text-sm">
+        <div>
+          <div class="text-xs text-(--color-text-secondary)">Access Token</div>
+          <div class="font-medium">{status.has_access_token ? '✓ Present' : '✗ None'}</div>
+        </div>
+        <div>
+          <div class="text-xs text-(--color-text-secondary)">Refresh Token</div>
+          <div class="font-medium">{status.has_refresh_token ? '✓ Present' : '✗ None'}</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Timing -->
+    <div class="p-4 rounded-lg border border-(--color-border) space-y-3">
+      <div class="text-xs font-medium text-(--color-text-secondary) mb-1">Timing</div>
+      <div class="grid grid-cols-2 gap-3 text-sm">
+        <div>
+          <div class="text-xs text-(--color-text-secondary)">Expires In</div>
+          <div class="font-medium">{formatCountdown(status.expires_in_seconds)}</div>
+        </div>
+        <div>
+          <div class="text-xs text-(--color-text-secondary)">Expires At</div>
+          <div class="font-medium">{formatTime(status.expires_at)}</div>
+        </div>
+        <div>
+          <div class="text-xs text-(--color-text-secondary)">Last Refreshed</div>
+          <div class="font-medium">{formatTime(status.last_refreshed_at)}</div>
+        </div>
+        <div>
+          <div class="text-xs text-(--color-text-secondary)">Next Refresh</div>
+          <div class="font-medium">{formatTime(status.next_refresh_at)}</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Actions -->
+    <div class="flex gap-2">
+      {#if canRefresh}
+        <button
+          class="px-3 py-1.5 text-sm rounded-lg border border-(--color-border) hover:bg-(--color-surface-hover) transition-colors disabled:opacity-50"
+          onclick={handleRefresh}
+          disabled={actionInProgress}
+        >Refresh Now</button>
+      {/if}
+      {#if canReconnect}
+        <button
+          class="px-3 py-1.5 text-sm rounded-lg bg-(--color-accent) text-white hover:bg-(--color-accent-hover) transition-colors disabled:opacity-50"
+          onclick={handleReconnect}
+          disabled={actionInProgress}
+        >Reconnect</button>
+      {/if}
+      {#if canDisconnect}
+        <button
+          class="px-3 py-1.5 text-sm rounded-lg border border-(--color-offline)/30 text-(--color-offline) hover:bg-(--color-offline)/10 transition-colors disabled:opacity-50"
+          onclick={() => showDisconnectConfirm = true}
+          disabled={actionInProgress}
+        >Disconnect</button>
+      {/if}
+    </div>
+
+    {#if showDisconnectConfirm}
+      <ConfirmModal
+        title="Disconnect OAuth"
+        message="Are you sure you want to disconnect? This will revoke the OAuth tokens and you'll need to re-authorize."
+        confirmLabel="Disconnect"
+        onconfirm={handleDisconnect}
+        oncancel={() => showDisconnectConfirm = false}
+      />
+    {/if}
+  {/if}
+</div>
+

--- a/src/lib/components/DetailPanel.svelte
+++ b/src/lib/components/DetailPanel.svelte
@@ -9,16 +9,23 @@
   import HealthDot from './HealthDot.svelte';
   import EndpointIcon from './EndpointIcon.svelte';
   import TransportBadge from './TransportBadge.svelte';
+  import AuthTab from './AuthTab.svelte';
 
   let showRestartConfirm = $state(false);
   let showDeleteConfirm = $state(false);
   let toggling = $state(false);
 
-  const tabs = [
+  const baseTabs = [
     { id: 'tools' as const, label: 'Tools' },
     { id: 'logs' as const, label: 'Logs' },
     { id: 'config' as const, label: 'Config' },
   ];
+
+  let tabs = $derived(
+    $selectedEndpointData?.transport === 'oauth'
+      ? [...baseTabs, { id: 'auth' as const, label: 'Auth' }]
+      : baseTabs
+  );
 
   async function handleRestart() {
     const name = $selectedEndpoint;
@@ -158,6 +165,8 @@
         <ToolsTab />
       {:else if $activeTab === 'logs'}
         <LogsTab />
+      {:else if $activeTab === 'auth' && ep.transport === 'oauth'}
+        <AuthTab />
       {:else}
         <ConfigTab />
       {/if}

--- a/src/lib/components/EndpointRow.svelte
+++ b/src/lib/components/EndpointRow.svelte
@@ -1,11 +1,24 @@
 <script lang="ts">
-  import type { Endpoint } from '$lib/types';
-  import { selectedEndpoint } from '$lib/stores';
+  import type { Endpoint, OAuthStatusValue } from '$lib/types';
+  import { selectedEndpoint, oauthStatuses } from '$lib/stores';
   import HealthDot from './HealthDot.svelte';
   import EndpointIcon from './EndpointIcon.svelte';
   import TransportBadge from './TransportBadge.svelte';
 
   let { endpoint }: { endpoint: Endpoint } = $props();
+
+  const authIcons: Record<OAuthStatusValue, string> = {
+    authenticated: '🔑',
+    refreshing: '🔄',
+    auth_required: '🔒',
+    needs_login: '🔒',
+    disconnected: '⚠️',
+    connection_failed: '⚠️',
+  };
+
+  let oauthStatus = $derived(
+    endpoint.transport === 'oauth' ? $oauthStatuses.get(endpoint.name) : undefined
+  );
 
   function select() {
     selectedEndpoint.set(endpoint.name);
@@ -35,6 +48,9 @@
         <span class="text-xs text-(--color-text-secondary)">Disabled</span>
       {:else}
         <span class="text-xs text-(--color-text-secondary)">{endpoint.tool_count} tools</span>
+      {/if}
+      {#if oauthStatus}
+        <span class="text-xs" title={oauthStatus.status}>{authIcons[oauthStatus.status]}</span>
       {/if}
     </div>
   </div>

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -1,5 +1,5 @@
 import { writable, derived } from 'svelte/store';
-import type { Endpoint, Theme } from './types';
+import type { Endpoint, Theme, OAuthStatus } from './types';
 
 export const endpoints = writable<Endpoint[]>([]);
 export const selectedEndpoint = writable<string | null>(null);
@@ -39,7 +39,8 @@ function createThemeStore() {
 
 export const theme = createThemeStore();
 export const searchQuery = writable<string>('');
-export const activeTab = writable<'tools' | 'logs' | 'config'>('tools');
+export const activeTab = writable<'tools' | 'logs' | 'config' | 'auth'>('tools');
+export const oauthStatuses = writable<Map<string, OAuthStatus>>(new Map());
 export const activeTopLevelTab = writable<'servers' | 'unified-catalog' | 'relay-logs' | 'settings'>('servers');
 
 export interface RelayLogLine {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -38,5 +38,18 @@ export interface EndpointLogs {
   lines: string[];
 }
 
+export type OAuthStatusValue = 'authenticated' | 'needs_login' | 'refreshing' | 'auth_required' | 'disconnected' | 'connection_failed';
+
+export interface OAuthStatus {
+  status: OAuthStatusValue;
+  has_access_token: boolean;
+  has_refresh_token: boolean;
+  expires_at: string | null;
+  expires_in_seconds: number | null;
+  last_refreshed_at: string | null;
+  next_refresh_at: string | null;
+  state: string | null;
+}
+
 export type Theme = 'light' | 'dark' | 'system';
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,8 +7,8 @@
   import RelayLogs from '$lib/components/RelayLogs.svelte';
   import UnifiedCatalog from '$lib/components/UnifiedCatalog.svelte';
   import Onboarding from '$lib/components/Onboarding.svelte';
-  import { endpoints, activeTopLevelTab, miniPlayerMode, relayConnected, showOnboarding, relayPort, relaySidecarStatus, relaySidecarError, initialLoadComplete } from '$lib/stores';
-  import { getEndpoints } from '$lib/api';
+  import { endpoints, activeTopLevelTab, miniPlayerMode, relayConnected, showOnboarding, relayPort, relaySidecarStatus, relaySidecarError, initialLoadComplete, oauthStatuses } from '$lib/stores';
+  import { getEndpoints, getOAuthStatus } from '$lib/api';
   import { initRelayLogListener } from '$lib/logListener';
   import { getActiveTopLevelTab, getVisibleTopLevelTabs, shouldShowRelayStartupFailure, shouldSkipEndpointPolling } from '$lib/relaySidecarUi';
   import { invoke } from '@tauri-apps/api/core';
@@ -65,6 +65,20 @@
       const data = await getEndpoints();
       endpoints.set(data);
       relayConnected.set(true);
+      // Poll OAuth statuses for OAuth endpoints
+      const oauthEndpoints = data.filter(ep => ep.transport === 'oauth');
+      if (oauthEndpoints.length > 0) {
+        const statusMap = new Map(get(oauthStatuses));
+        await Promise.allSettled(
+          oauthEndpoints.map(async (ep) => {
+            try {
+              const s = await getOAuthStatus(ep.name);
+              statusMap.set(ep.name, s);
+            } catch { /* ignore */ }
+          })
+        );
+        oauthStatuses.set(statusMap);
+      }
       // If sidecar status is still starting/unknown but API responds, infer running
       const inferredStatus = get(relaySidecarStatus);
       if (inferredStatus === 'starting' || inferredStatus === 'unknown') {


### PR DESCRIPTION
## Summary

Adds OAuth authentication status UI and management controls to the Endara desktop app. This provides users with visibility into OAuth token state and the ability to revoke/refresh tokens directly from the UI.

**Depends on:** endara-ai/endara-relay PR for the management API routes (revoke/refresh/status endpoints).

## Changes

### New Component: AuthTab (`src/lib/components/AuthTab.svelte`)
- OAuth token management panel with revoke and refresh actions
- Displays token status, expiry information, and auth state

### Auth Status Indicators (`src/lib/components/EndpointRow.svelte`)
- Sidebar badges showing authenticated/expiring/expired state per endpoint
- Visual indicators for OAuth authentication lifecycle

### OAuth API Functions (`src/lib/api.ts`)
- `revokeOAuthToken()` — Call relay management API to revoke tokens
- `refreshOAuthToken()` — Call relay management API to force refresh
- `getOAuthStatus()` — Fetch enhanced OAuth status from relay

### Type Definitions (`src/lib/types.ts`)
- `OAuthStatus` type for frontend OAuth state management

### Integration
- `DetailPanel.svelte` — New AuthTab in endpoint detail view
- `stores.ts` — OAuth status tracking in Svelte stores
- `+page.svelte` — OAuth status integration in main page
- `AddEndpointModal.svelte` — Minor updates for OAuth endpoints

## Files Changed (8)
- `src/lib/api.ts`, `src/lib/components/AuthTab.svelte` (new)
- `src/lib/components/AddEndpointModal.svelte`, `src/lib/components/DetailPanel.svelte`
- `src/lib/components/EndpointRow.svelte`, `src/lib/stores.ts`
- `src/lib/types.ts`, `src/routes/+page.svelte`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author