### PR TITLE
feat: OAuth connect slice 3 — catalog, discovery UI, DCR integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -625,9 +625,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -642,9 +639,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -659,9 +653,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -676,9 +667,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -693,9 +681,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -710,9 +695,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -727,9 +709,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -744,9 +723,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -761,9 +737,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -778,9 +751,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -795,9 +765,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -812,9 +779,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -829,9 +793,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1163,9 +1124,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1183,9 +1141,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1203,9 +1158,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1223,9 +1175,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1413,9 +1362,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1433,9 +1379,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1453,9 +1396,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1473,9 +1413,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1493,9 +1430,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -2255,9 +2189,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2279,9 +2210,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2303,9 +2231,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2327,9 +2252,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "echo 'No linter configured yet'",
     "test": "vitest run",
+    "test:catalog": "RUN_LIVE_TESTS=1 vitest run src/lib/catalog.test.ts",
     "test:watch": "vitest",
     "tauri": "tauri"
   },

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -436,6 +436,7 @@ struct AddEndpointArgs {
     client_id: Option<String>,
     client_secret: Option<String>,
     scopes: Option<String>,
+    token_endpoint: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -449,6 +450,11 @@ struct EndpointConfig {
     description: Option<String>,
     env: Option<HashMap<String, String>>,
     headers: Option<HashMap<String, String>>,
+    oauth_server_url: Option<String>,
+    client_id: Option<String>,
+    client_secret: Option<String>,
+    scopes: Option<String>,
+    token_endpoint: Option<String>,
 }
 
 #[tauri::command]
@@ -472,6 +478,13 @@ async fn get_endpoint_config(name: String) -> Result<EndpointConfig, String> {
                 let headers = ep.get("headers").and_then(|v| v.as_table()).map(|t| {
                     t.iter().map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string())).collect()
                 });
+                let oauth_server_url = ep.get("oauth_server_url").and_then(|v| v.as_str()).map(|s| s.to_string());
+                let client_id = ep.get("client_id").and_then(|v| v.as_str()).map(|s| s.to_string());
+                let client_secret = ep.get("client_secret").and_then(|v| v.as_str()).map(|s| s.to_string());
+                let scopes = ep.get("scopes").and_then(|v| v.as_array()).map(|arr| {
+                    arr.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>().join(" ")
+                });
+                let token_endpoint = ep.get("token_endpoint").and_then(|v| v.as_str()).map(|s| s.to_string());
 
                 return Ok(EndpointConfig {
                     name: name.clone(),
@@ -483,6 +496,11 @@ async fn get_endpoint_config(name: String) -> Result<EndpointConfig, String> {
                     description,
                     env,
                     headers,
+                    oauth_server_url,
+                    client_id,
+                    client_secret,
+                    scopes,
+                    token_endpoint,
                 });
             }
         }
@@ -503,6 +521,11 @@ struct UpdateEndpointArgs {
     description: Option<String>,
     env: Option<HashMap<String, String>>,
     headers: Option<HashMap<String, String>>,
+    oauth_server_url: Option<String>,
+    client_id: Option<String>,
+    client_secret: Option<String>,
+    scopes: Option<String>,
+    token_endpoint: Option<String>,
 }
 
 #[tauri::command]
@@ -565,6 +588,26 @@ async fn update_endpoint(args: UpdateEndpointArgs) -> Result<(), String> {
                         }
                         table.insert("headers".to_string(), toml::Value::Table(headers_table));
                     }
+                }
+                if let Some(oauth_server_url) = &args.oauth_server_url {
+                    table.insert("oauth_server_url".to_string(), toml::Value::String(oauth_server_url.clone()));
+                }
+                if let Some(client_id) = &args.client_id {
+                    table.insert("client_id".to_string(), toml::Value::String(client_id.clone()));
+                }
+                if let Some(client_secret) = &args.client_secret {
+                    table.insert("client_secret".to_string(), toml::Value::String(client_secret.clone()));
+                }
+                if let Some(scopes) = &args.scopes {
+                    let arr: Vec<toml::Value> = scopes.split_whitespace()
+                        .map(|s| toml::Value::String(s.to_string()))
+                        .collect();
+                    if !arr.is_empty() {
+                        table.insert("scopes".to_string(), toml::Value::Array(arr));
+                    }
+                }
+                if let Some(token_endpoint) = &args.token_endpoint {
+                    table.insert("token_endpoint".to_string(), toml::Value::String(token_endpoint.clone()));
                 }
                 break;
             }
@@ -669,6 +712,9 @@ async fn add_endpoint(args: AddEndpointArgs) -> Result<(), String> {
         if !arr.is_empty() {
             endpoint.insert("scopes".to_string(), toml::Value::Array(arr));
         }
+    }
+    if let Some(token_endpoint) = args.token_endpoint {
+        endpoint.insert("token_endpoint".to_string(), toml::Value::String(token_endpoint));
     }
 
     let endpoints = parsed

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import { get } from 'svelte/store';
-import type { RelayStatus, Endpoint, Tool, EndpointLogs, CatalogEntry, OAuthStatus } from './types';
+import type { RelayStatus, Endpoint, Tool, EndpointLogs, CatalogEntry, OAuthStatus, OAuthStartResult, OAuthSetupResponse, OAuthSetupStatusResponse } from './types';
 import { relayPort } from './stores';
 
 function getBaseUrl() {
@@ -117,6 +117,7 @@ export interface AddEndpointParams {
   client_id?: string;
   client_secret?: string;
   scopes?: string;
+  token_endpoint?: string;
 }
 
 export async function addEndpoint(params: AddEndpointParams): Promise<void> {
@@ -167,6 +168,11 @@ export interface EndpointConfig {
   description?: string;
   env?: Record<string, string>;
   headers?: Record<string, string>;
+  oauth_server_url?: string;
+  client_id?: string;
+  client_secret?: string;
+  scopes?: string;
+  token_endpoint?: string;
 }
 
 export async function getEndpointConfig(name: string): Promise<EndpointConfig> {
@@ -184,10 +190,48 @@ export interface UpdateEndpointParams {
   description?: string;
   env?: Record<string, string>;
   headers?: Record<string, string>;
+  oauth_server_url?: string;
+  client_id?: string;
+  client_secret?: string;
+  scopes?: string;
+  token_endpoint?: string;
 }
 
-export async function startOAuth(name: string): Promise<{ authorize_url: string }> {
-  return fetchJson<{ authorize_url: string }>(`/endpoints/${encodeURIComponent(name)}/oauth/start`, { method: 'POST' });
+export async function startOAuth(name: string): Promise<OAuthStartResult> {
+  const res = await fetch(`${getBaseUrl()}/endpoints/${encodeURIComponent(name)}/oauth/start`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+  });
+  const data = await res.json();
+  // If the server returns dcr_unsupported, return it as a typed result instead of throwing
+  if (!res.ok && data?.error === 'dcr_unsupported') {
+    return data as OAuthStartResult;
+  }
+  if (!res.ok && data?.error === 'discovery_failed') {
+    return data as OAuthStartResult;
+  }
+  if (!res.ok) {
+    throw new Error(data?.detail || data?.error || `HTTP ${res.status}: ${res.statusText}`);
+  }
+  return data as OAuthStartResult;
+}
+
+export async function setOAuthCredentials(
+  name: string,
+  clientId: string,
+  clientSecret?: string,
+): Promise<void> {
+  const body: Record<string, string> = { client_id: clientId };
+  if (clientSecret) body.client_secret = clientSecret;
+  const res = await fetch(`${getBaseUrl()}/endpoints/${encodeURIComponent(name)}/oauth/credentials`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => null);
+    throw new Error(data?.message || data?.error || `HTTP ${res.status}: ${res.statusText}`);
+  }
 }
 
 export async function getOAuthStatus(name: string): Promise<OAuthStatus> {
@@ -210,6 +254,78 @@ export async function updateEndpoint(params: UpdateEndpointParams): Promise<void
     await reloadConfig();
   } catch {
     // Relay not reachable; it will pick up config changes on next start
+  }
+}
+
+// ---------------------------------------------------------------------------
+// OAuth Setup (preflight) API
+// ---------------------------------------------------------------------------
+
+export interface OAuthSetupParams {
+  name: string;
+  url: string;
+  scopes?: string[];
+  tool_prefix?: string;
+}
+
+export async function oauthSetup(params: OAuthSetupParams): Promise<OAuthSetupResponse> {
+  const res = await fetch(`${getBaseUrl()}/oauth/setup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(params),
+  });
+  const data = await res.json();
+  // 422 with dcr_error is an expected flow — return typed response
+  if (!res.ok && res.status === 422 && data?.dcr_error) {
+    return data as OAuthSetupResponse;
+  }
+  if (!res.ok) {
+    throw new Error(data?.detail || data?.error || `HTTP ${res.status}: ${res.statusText}`);
+  }
+  return data as OAuthSetupResponse;
+}
+
+export async function oauthSetupCredentials(
+  sessionId: string,
+  clientId: string,
+  clientSecret?: string,
+): Promise<{ status: string; authorize_url: string }> {
+  const body: Record<string, string> = { client_id: clientId };
+  if (clientSecret) body.client_secret = clientSecret;
+  const res = await fetch(`${getBaseUrl()}/oauth/setup/${encodeURIComponent(sessionId)}/credentials`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data?.detail || data?.error || `HTTP ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function oauthSetupStatus(sessionId: string): Promise<OAuthSetupStatusResponse> {
+  return fetchJson<OAuthSetupStatusResponse>(`/oauth/setup/${encodeURIComponent(sessionId)}/status`);
+}
+
+export async function oauthSetupCommit(sessionId: string): Promise<{ status: string; name: string }> {
+  const res = await fetch(`${getBaseUrl()}/oauth/setup/${encodeURIComponent(sessionId)}/commit`, {
+    method: 'POST',
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data?.detail || data?.error || `HTTP ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function oauthSetupCancel(sessionId: string): Promise<void> {
+  const res = await fetch(`${getBaseUrl()}/oauth/setup/${encodeURIComponent(sessionId)}`, {
+    method: 'DELETE',
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data?.detail || data?.error || `HTTP ${res.status}`);
   }
 }
 

--- a/src/lib/catalog.test.ts
+++ b/src/lib/catalog.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { CATALOG_SERVERS } from './catalog';
+
+// Use import.meta.env or a try/catch to avoid direct `process` reference
+// which fails svelte-check (no @types/node in this project)
+let RUN_LIVE_TESTS = false;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  RUN_LIVE_TESTS = !!(globalThis as any).process?.env?.RUN_LIVE_TESTS;
+} catch {
+  // not in Node
+}
+
+// --- Fast tests (no network, always run) ---
+
+describe('CATALOG_SERVERS validation', () => {
+  it('all entries have required fields', () => {
+    for (const entry of CATALOG_SERVERS) {
+      expect(entry.id, `entry missing id`).toBeTruthy();
+      expect(entry.name, `${entry.id}: missing name`).toBeTruthy();
+      expect(entry.description, `${entry.id}: missing description`).toBeTruthy();
+      expect(entry.command, `${entry.id}: missing command`).toBeTruthy();
+      expect(entry.icon, `${entry.id}: missing icon`).toBeTruthy();
+    }
+  });
+
+  it('no duplicate IDs', () => {
+    const ids = CATALOG_SERVERS.map((e) => e.id);
+    const unique = new Set(ids);
+    expect(ids.length).toBe(unique.size);
+    // Show which IDs are duplicated if the test fails
+    if (ids.length !== unique.size) {
+      const seen = new Set<string>();
+      for (const id of ids) {
+        if (seen.has(id)) {
+          throw new Error(`Duplicate catalog ID: ${id}`);
+        }
+        seen.add(id);
+      }
+    }
+  });
+
+  it('all entries have valid transport', () => {
+    const validTransports = ['stdio', 'sse', 'http'];
+    for (const entry of CATALOG_SERVERS) {
+      expect(
+        validTransports,
+        `${entry.id}: invalid transport '${entry.transport}'`
+      ).toContain(entry.transport);
+    }
+  });
+
+  it('all entries have a non-empty args array', () => {
+    for (const entry of CATALOG_SERVERS) {
+      expect(entry.args, `${entry.id}: args should be an array`).toBeInstanceOf(Array);
+      expect(entry.args.length, `${entry.id}: args should not be empty`).toBeGreaterThan(0);
+    }
+  });
+});
+
+// --- Slow tests (network, run on demand with RUN_LIVE_TESTS=1) ---
+
+const RUN_LIVE = RUN_LIVE_TESTS;
+
+const npxEntries = CATALOG_SERVERS.filter((e) => e.command === 'npx');
+const uvxEntries = CATALOG_SERVERS.filter((e) => e.command === 'uvx');
+
+// Extract npm package name from args (the argument after '-y')
+function extractNpmPackage(args: string[]): string | null {
+  const yIdx = args.indexOf('-y');
+  if (yIdx >= 0 && yIdx + 1 < args.length) {
+    return args[yIdx + 1];
+  }
+  return null;
+}
+
+// Extract PyPI package name from args (first arg for uvx)
+function extractPypiPackage(args: string[]): string | null {
+  return args.length > 0 ? args[0] : null;
+}
+
+// Collect all helpUrls from envVars
+function collectHelpUrls(): { id: string; url: string }[] {
+  const urls: { id: string; url: string }[] = [];
+  for (const entry of CATALOG_SERVERS) {
+    for (const envVar of entry.envVars) {
+      if (envVar.helpUrl) {
+        urls.push({ id: entry.id, url: envVar.helpUrl });
+      }
+    }
+  }
+  return urls;
+}
+
+describe.skipIf(!RUN_LIVE)('live package validation', () => {
+  it.each(npxEntries.map((e) => [e.id, extractNpmPackage(e.args)]))(
+    'npm package for %s (%s) exists',
+    async (_id, pkg) => {
+      expect(pkg).toBeTruthy();
+      const resp = await fetch(`https://registry.npmjs.org/${pkg}`);
+      expect(resp.status, `npm package ${pkg} not found`).toBe(200);
+    },
+    15_000
+  );
+
+  it.each(uvxEntries.map((e) => [e.id, extractPypiPackage(e.args)]))(
+    'pypi package for %s (%s) exists',
+    async (_id, pkg) => {
+      expect(pkg).toBeTruthy();
+      const resp = await fetch(`https://pypi.org/pypi/${pkg}/json`);
+      expect(resp.status, `PyPI package ${pkg} not found`).toBe(200);
+    },
+    15_000
+  );
+
+  const helpUrls = collectHelpUrls();
+  if (helpUrls.length > 0) {
+    it.each(helpUrls.map((h) => [h.id, h.url]))(
+      'help URL for %s (%s) is reachable',
+      async (_id, url) => {
+        const resp = await fetch(url, { redirect: 'manual' });
+        const status = resp.status;
+        expect(
+          status < 400 || status === 403,
+          `Help URL ${url} returned ${status}`
+        ).toBe(true);
+      },
+      15_000
+    );
+  }
+});
+

--- a/src/lib/components/AddEndpointModal.svelte
+++ b/src/lib/components/AddEndpointModal.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { addEndpoint, getEndpoints, testConnection, startOAuth, getOAuthStatus, type AddEndpointParams, type TestConnectionParams } from '$lib/api';
+  import { addEndpoint, getEndpoints, testConnection, oauthSetup, oauthSetupStatus, oauthSetupCredentials, oauthSetupCommit, oauthSetupCancel, reloadConfig, type AddEndpointParams, type TestConnectionParams, type OAuthSetupParams } from '$lib/api';
   import { endpoints, selectedEndpoint } from '$lib/stores';
   import { toast } from 'svelte-sonner';
   import { CATALOG_SERVERS, type CatalogServer } from '$lib/catalog';
+  import { oauthCatalog, type OAuthCatalogEntry } from '$lib/data/oauth-catalog';
   import { sanitizeName } from '$lib/utils';
   import { openUrl } from '@tauri-apps/plugin-opener';
   import { open as dialogOpen } from '@tauri-apps/plugin-dialog';
@@ -37,6 +38,12 @@
   let clientId = $state('');
   let clientSecret = $state('');
   let scopes = $state('');
+  let selectedOAuthEntry: OAuthCatalogEntry | null = $state(null);
+  let showingDcrFallback = $state(false);
+  let dcrFallbackData: { authorization_endpoint?: string } = $state({});
+  let dcrClientId = $state('');
+  let dcrClientSecret = $state('');
+  let pendingSetupSessionId: string | null = $state(null);
 
   let prefixPreview = $derived(prefix ? `${prefix}__tool` : 'prefix__tool');
 
@@ -62,8 +69,61 @@
       : CATALOG_SERVERS,
   );
 
+  let filteredOAuthServers = $derived(
+    search.trim()
+      ? oauthCatalog.filter((s) => {
+          const q = search.toLowerCase();
+          return s.name.toLowerCase().includes(q) || s.description.toLowerCase().includes(q);
+        })
+      : oauthCatalog,
+  );
+
+  // Filter toggles for unified browse list
+  let showOAuth = $state(true);
+  let showLocal = $state(true);
+
+  type UnifiedEntry =
+    | { type: 'oauth'; entry: OAuthCatalogEntry }
+    | { type: 'local'; entry: CatalogServer };
+
+  let unifiedServers: UnifiedEntry[] = $derived.by(() => {
+    let items: UnifiedEntry[] = [];
+    if (showOAuth) {
+      items.push(...filteredOAuthServers.map((e) => ({ type: 'oauth' as const, entry: e })));
+    }
+    if (showLocal) {
+      items.push(...filteredServers.map((e) => ({ type: 'local' as const, entry: e })));
+    }
+    return items.sort((a, b) => a.entry.name.localeCompare(b.entry.name));
+  });
+
+  function selectOAuthService(service: OAuthCatalogEntry) {
+    selectedCatalog = null;
+    selectedOAuthEntry = service;
+    name = service.name;
+    prefixCustom = false;
+    prefix = sanitizeName(service.name);
+    description = service.description;
+    transport = 'oauth';
+    url = service.url;
+    oauthServerUrl = service.oauthServerUrl || '';
+    clientId = '';
+    clientSecret = '';
+    scopes = service.defaultScopes.join(' ');
+    envVars = [];
+    headerVars = [];
+    catalogEnvValues = {};
+    userArgValues = [];
+    showingDcrFallback = false;
+    dcrClientId = '';
+    dcrClientSecret = '';
+    error = '';
+    step = 'configure';
+  }
+
   function selectCatalog(server: CatalogServer) {
     selectedCatalog = server;
+    selectedOAuthEntry = null;
     name = server.name;
     prefixCustom = false;
     prefix = sanitizeName(server.name);
@@ -79,12 +139,14 @@
     clientId = '';
     clientSecret = '';
     scopes = '';
+    showingDcrFallback = false;
     error = '';
     step = 'configure';
   }
 
   function selectCustom() {
     selectedCatalog = null;
+    selectedOAuthEntry = null;
     name = '';
     prefixCustom = false;
     prefix = '';
@@ -101,6 +163,7 @@
     clientId = '';
     clientSecret = '';
     scopes = '';
+    showingDcrFallback = false;
     error = '';
     step = 'configure';
   }
@@ -109,6 +172,7 @@
     step = 'browse';
     error = '';
     testResult = null;
+    showingDcrFallback = false;
   }
 
   function handlePrefixInput(value: string) {
@@ -229,11 +293,9 @@
       }
     } else if (transport === 'oauth') {
       if (!url.trim()) { error = 'Server URL is required'; return; }
-      if (!oauthServerUrl.trim()) { error = 'OAuth Server URL is required'; return; }
-      if (!clientId.trim()) { error = 'Client ID is required'; return; }
       params.url = url.trim();
-      params.oauth_server_url = oauthServerUrl.trim();
-      params.client_id = clientId.trim();
+      if (oauthServerUrl.trim()) params.oauth_server_url = oauthServerUrl.trim();
+      if (clientId.trim()) params.client_id = clientId.trim();
       if (clientSecret.trim()) params.client_secret = clientSecret.trim();
       if (scopes.trim()) params.scopes = scopes.trim();
     } else {
@@ -289,96 +351,155 @@
   }
 
   async function handleOAuthSubmit() {
-    // First save the endpoint via normal handleSubmit logic but don't close
     error = '';
     if (!name.trim()) { error = 'Name is required'; return; }
     if (!url.trim()) { error = 'Server URL is required'; return; }
-    if (!oauthServerUrl.trim()) { error = 'OAuth Server URL is required'; return; }
-    if (!clientId.trim()) { error = 'Client ID is required'; return; }
 
     const trimmedName = name.trim();
     const defaultPrefix = sanitizeName(trimmedName);
 
-    const params: AddEndpointParams = {
+    const setupParams: OAuthSetupParams = {
       name: trimmedName,
-      transport,
+      url: url.trim(),
     };
-
     if (prefixCustom && prefix !== defaultPrefix) {
-      params.tool_prefix = prefix;
+      setupParams.tool_prefix = prefix;
     }
-    if (description.trim()) {
-      params.description = description.trim();
-    }
-
-    params.url = url.trim();
-    params.oauth_server_url = oauthServerUrl.trim();
-    params.client_id = clientId.trim();
-    if (clientSecret.trim()) params.client_secret = clientSecret.trim();
-    if (scopes.trim()) params.scopes = scopes.trim();
-
-    // Build env
-    const env: Record<string, string> = {};
-    const filteredEnv = envVars.filter((e) => e.key.trim());
-    for (const e of filteredEnv) {
-      env[e.key.trim()] = e.value;
-    }
-    if (Object.keys(env).length > 0) {
-      params.env = env;
+    if (scopes.trim()) {
+      setupParams.scopes = scopes.trim().split(/\s+/);
     }
 
     submitting = true;
     try {
-      await addEndpoint(params);
+      const result = await oauthSetup(setupParams);
+      pendingSetupSessionId = result.session_id;
 
-      // Start OAuth flow
-      const { authorize_url } = await startOAuth(trimmedName);
-
-      // Open browser for authorization
-      await openUrl(authorize_url);
-
-      // Poll for OAuth completion (every 1s, up to 2 minutes)
-      const maxAttempts = 120;
-      for (let i = 0; i < maxAttempts; i++) {
-        await new Promise((r) => setTimeout(r, 1000));
-        try {
-          const oauthResult = await getOAuthStatus(trimmedName);
-          if ((oauthResult.status as string) === 'authorized' || (oauthResult.status as string) === 'complete' || oauthResult.status === 'authenticated') {
-            // Success — refresh and close
-            try {
-              const data = await getEndpoints();
-              endpoints.set(data);
-            } catch {
-              // Will be picked up by the next poll cycle
-            }
-            selectedEndpoint.set(trimmedName);
-            onclose();
-            return;
-          }
-          if ((oauthResult.status as string) === 'error' || oauthResult.status === 'connection_failed') {
-            error = 'OAuth authorization failed';
-            return;
-          }
-        } catch {
-          // Polling error, continue
-        }
+      if (result.status === 'awaiting_credentials' && result.dcr_error) {
+        // DCR failed — show manual credentials form
+        showingDcrFallback = true;
+        dcrFallbackData = {
+          authorization_endpoint: result.discovery?.auth_server,
+        };
+        dcrClientId = '';
+        dcrClientSecret = '';
+        submitting = false;
+        return;
       }
-      error = 'OAuth authorization timed out. Please try again.';
+
+      if (result.authorize_url) {
+        // Open browser for authorization
+        await openUrl(result.authorize_url);
+
+        // Poll for setup session completion (every 1s, up to 2 minutes)
+        await pollForSetupAuth(result.session_id, trimmedName);
+      }
     } catch (e) {
       error = e instanceof Error ? e.message : String(e);
+      // Clean up the setup session on failure
+      if (pendingSetupSessionId) {
+        try { await oauthSetupCancel(pendingSetupSessionId); } catch { /* best effort */ }
+        pendingSetupSessionId = null;
+      }
     } finally {
       submitting = false;
     }
   }
 
+  async function pollForSetupAuth(sessionId: string, endpointName: string) {
+    const maxAttempts = 120;
+    for (let i = 0; i < maxAttempts; i++) {
+      await new Promise((r) => setTimeout(r, 1000));
+      try {
+        const statusResult = await oauthSetupStatus(sessionId);
+        if (statusResult.status === 'authorized') {
+          // Authorization complete — commit the endpoint to config.toml
+          try {
+            await oauthSetupCommit(sessionId);
+          } catch (e) {
+            error = `Failed to save endpoint: ${e instanceof Error ? e.message : String(e)}`;
+            pendingSetupSessionId = null;
+            return;
+          }
+          pendingSetupSessionId = null;
+
+          // Wait for config watcher to pick up the new endpoint
+          await new Promise((r) => setTimeout(r, 500));
+          try {
+            const data = await getEndpoints();
+            endpoints.set(data);
+          } catch {
+            // Will be picked up by the next poll cycle
+          }
+          selectedEndpoint.set(endpointName);
+          toast.success(`Connected to "${endpointName}"`);
+          onclose();
+          return;
+        }
+      } catch {
+        // Polling error, continue
+      }
+    }
+    error = 'OAuth authorization timed out. Please try again.';
+    // Clean up on timeout — no config was ever written
+    if (pendingSetupSessionId) {
+      try { await oauthSetupCancel(pendingSetupSessionId); } catch { /* best effort */ }
+      pendingSetupSessionId = null;
+    }
+  }
+
+  async function handleDcrFallbackSubmit() {
+    error = '';
+    if (!dcrClientId.trim()) { error = 'Client ID is required'; return; }
+    if (!pendingSetupSessionId) { error = 'No active setup session'; return; }
+
+    const trimmedName = name.trim();
+    submitting = true;
+    try {
+      const result = await oauthSetupCredentials(
+        pendingSetupSessionId,
+        dcrClientId.trim(),
+        dcrClientSecret.trim() || undefined,
+      );
+
+      if (result.authorize_url) {
+        showingDcrFallback = false;
+        await openUrl(result.authorize_url);
+        await pollForSetupAuth(pendingSetupSessionId, trimmedName);
+      } else {
+        error = 'OAuth flow failed after credential submission. Please try again.';
+        if (pendingSetupSessionId) {
+          try { await oauthSetupCancel(pendingSetupSessionId); } catch { /* best effort */ }
+          pendingSetupSessionId = null;
+        }
+      }
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e);
+      if (pendingSetupSessionId) {
+        try { await oauthSetupCancel(pendingSetupSessionId); } catch { /* best effort */ }
+        pendingSetupSessionId = null;
+      }
+    } finally {
+      submitting = false;
+    }
+  }
+
+  async function handleCancel() {
+    // Cancel pending setup session if user cancels — no config cleanup needed
+    if (pendingSetupSessionId) {
+      try { await oauthSetupCancel(pendingSetupSessionId); } catch { /* best effort */ }
+      pendingSetupSessionId = null;
+    }
+    onclose();
+  }
+
   function handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'Escape') onclose();
+    if (e.key === 'Escape') handleCancel();
   }
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
 
-<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="presentation" onclick={onclose} onkeydown={handleKeydown}>
+<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="presentation" onclick={handleCancel} onkeydown={handleKeydown}>
   <div
     class="bg-(--color-surface) rounded-xl shadow-xl border border-(--color-border) p-6 w-[36rem] max-w-[90vw] max-h-[90vh] overflow-y-auto"
     role="dialog"
@@ -399,28 +520,68 @@
         class="w-full text-sm px-3 py-2 rounded-lg border border-(--color-border) bg-(--color-surface) text-(--color-text) placeholder:text-(--color-text-secondary)/50 focus:outline-none focus:border-(--color-accent) mb-4"
       />
 
-      <div class="grid grid-cols-2 gap-2 mb-3">
-        {#each filteredServers as server (server.id)}
-          <button
-            class="text-left p-3 rounded-lg border border-(--color-border) hover:border-(--color-accent) hover:bg-(--color-surface-hover) transition-colors"
-            onclick={() => selectCatalog(server)}
-          >
-            <div class="flex items-center gap-2 mb-1">
-              <span class="w-5 h-5 flex-shrink-0 text-(--color-text-secondary)">{@html server.icon}</span>
-              <span class="text-sm font-medium text-(--color-text)">{server.name}</span>
-            </div>
-            <p class="text-xs text-(--color-text-secondary) line-clamp-2 mb-1.5">{server.description}</p>
-            <div class="flex items-center gap-1.5">
-              <span class="inline-block text-[10px] px-1.5 py-0.5 rounded-full bg-(--color-accent)/10 text-(--color-accent) font-medium">
-                {CATEGORY_LABELS[server.category] ?? server.category}
-              </span>
-              {#if server.envVars.some(e => e.required)}
-                <span class="inline-block text-[10px] px-1.5 py-0.5 rounded-full bg-amber-500/10 text-amber-600 dark:text-amber-400 font-medium">
-                  API Key Required
+      <!-- Filter toggles -->
+      <div class="flex gap-2 mb-4">
+        <button
+          class="px-3 py-1 text-xs rounded-full border transition-colors {showOAuth
+            ? 'border-(--color-accent) bg-(--color-accent)/10 text-(--color-accent)'
+            : 'border-(--color-border) text-(--color-text-secondary) hover:bg-(--color-surface-hover)'}"
+          onclick={() => showOAuth = !showOAuth}
+        >
+          OAuth
+        </button>
+        <button
+          class="px-3 py-1 text-xs rounded-full border transition-colors {showLocal
+            ? 'border-(--color-accent) bg-(--color-accent)/10 text-(--color-accent)'
+            : 'border-(--color-border) text-(--color-text-secondary) hover:bg-(--color-surface-hover)'}"
+          onclick={() => showLocal = !showLocal}
+        >
+          Local
+        </button>
+      </div>
+
+      <!-- Unified server list -->
+      <div class="flex flex-col gap-2 mb-3">
+        {#each unifiedServers as item (item.type + '-' + item.entry.id)}
+          {#if item.type === 'oauth'}
+            {@const service = item.entry as OAuthCatalogEntry}
+            <button
+              class="w-full text-left p-3 rounded-lg border border-(--color-border) hover:border-(--color-accent) hover:bg-(--color-surface-hover) transition-colors flex items-center gap-3"
+              onclick={() => selectOAuthService(service)}
+            >
+              <span class="w-5 h-5 flex-shrink-0 text-(--color-text-secondary)">{@html service.icon}</span>
+              <span class="text-sm font-medium text-(--color-text) flex-shrink-0">{service.name}</span>
+              <p class="text-xs text-(--color-text-secondary) line-clamp-1 flex-1 min-w-0">{service.description}</p>
+              <div class="flex items-center gap-1.5 flex-shrink-0">
+                <span class="inline-block text-[10px] px-1.5 py-0.5 rounded-full bg-(--color-accent)/10 text-(--color-accent) font-medium">
+                  {CATEGORY_LABELS[service.category] ?? service.category}
                 </span>
-              {/if}
-            </div>
-          </button>
+                <span class="inline-block text-[10px] px-1.5 py-0.5 rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 font-medium">
+                  OAuth
+                </span>
+              </div>
+            </button>
+          {:else}
+            {@const server = item.entry as CatalogServer}
+            <button
+              class="w-full text-left p-3 rounded-lg border border-(--color-border) hover:border-(--color-accent) hover:bg-(--color-surface-hover) transition-colors flex items-center gap-3"
+              onclick={() => selectCatalog(server)}
+            >
+              <span class="w-5 h-5 flex-shrink-0 text-(--color-text-secondary)">{@html server.icon}</span>
+              <span class="text-sm font-medium text-(--color-text) flex-shrink-0">{server.name}</span>
+              <p class="text-xs text-(--color-text-secondary) line-clamp-1 flex-1 min-w-0">{server.description}</p>
+              <div class="flex items-center gap-1.5 flex-shrink-0">
+                <span class="inline-block text-[10px] px-1.5 py-0.5 rounded-full bg-(--color-accent)/10 text-(--color-accent) font-medium">
+                  {CATEGORY_LABELS[server.category] ?? server.category}
+                </span>
+                {#if server.envVars.some(e => e.required)}
+                  <span class="inline-block text-[10px] px-1.5 py-0.5 rounded-full bg-amber-500/10 text-amber-600 dark:text-amber-400 font-medium">
+                    API Key
+                  </span>
+                {/if}
+              </div>
+            </button>
+          {/if}
         {/each}
       </div>
 
@@ -435,7 +596,7 @@
       <div class="flex justify-end pt-4">
         <button
           class="px-3 py-1.5 text-sm rounded-lg border border-(--color-border) hover:bg-(--color-surface-hover) transition-colors"
-          onclick={onclose}
+          onclick={handleCancel}
         >
           Cancel
         </button>
@@ -453,12 +614,12 @@
           </svg>
         </button>
         <h3 class="text-base font-semibold text-(--color-text)">
-          {selectedCatalog ? `Configure ${selectedCatalog.name}` : 'Custom Server'}
+          {selectedCatalog ? `Configure ${selectedCatalog.name}` : selectedOAuthEntry ? `Connect ${selectedOAuthEntry.name}` : 'Custom Server'}
         </h3>
       </div>
 
       <div class="space-y-3">
-        {#if !selectedCatalog}
+        {#if !selectedCatalog && !selectedOAuthEntry}
           <!-- Custom: transport selector -->
           <fieldset class="border-none p-0 m-0 mb-1">
             <legend class="block text-xs font-medium mb-1 text-(--color-text-secondary)">Transport</legend>
@@ -530,29 +691,41 @@
         {:else if transport === 'oauth'}
           <div>
             <label for="modal-ep-url" class="block text-xs font-medium mb-1 text-(--color-text-secondary)">Server URL</label>
-            <input id="modal-ep-url" type="text" bind:value={url} placeholder="http://localhost:3000/mcp"
-              class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--color-border) bg-(--color-surface) text-(--color-text) placeholder:text-(--color-text-secondary)/50 focus:outline-none focus:border-(--color-accent)" />
-          </div>
-          <div>
-            <label for="modal-ep-oauth-url" class="block text-xs font-medium mb-1 text-(--color-text-secondary)">OAuth Server URL</label>
-            <input id="modal-ep-oauth-url" type="text" bind:value={oauthServerUrl} placeholder="https://auth.example.com"
-              class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--color-border) bg-(--color-surface) text-(--color-text) placeholder:text-(--color-text-secondary)/50 focus:outline-none focus:border-(--color-accent)" />
-          </div>
-          <div>
-            <label for="modal-ep-client-id" class="block text-xs font-medium mb-1 text-(--color-text-secondary)">Client ID</label>
-            <input id="modal-ep-client-id" type="text" bind:value={clientId} placeholder="your-client-id"
-              class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--color-border) bg-(--color-surface) text-(--color-text) placeholder:text-(--color-text-secondary)/50 focus:outline-none focus:border-(--color-accent)" />
-          </div>
-          <div>
-            <label for="modal-ep-client-secret" class="block text-xs font-medium mb-1 text-(--color-text-secondary)">Client Secret <span class="text-(--color-text-secondary)/50">(optional)</span></label>
-            <input id="modal-ep-client-secret" type="password" bind:value={clientSecret} placeholder="••••••••"
+            <input id="modal-ep-url" type="text" bind:value={url} placeholder="https://mcp.linear.app/sse"
               class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--color-border) bg-(--color-surface) text-(--color-text) placeholder:text-(--color-text-secondary)/50 focus:outline-none focus:border-(--color-accent)" />
           </div>
           <div>
             <label for="modal-ep-scopes" class="block text-xs font-medium mb-1 text-(--color-text-secondary)">Scopes <span class="text-(--color-text-secondary)/50">(optional, space-separated)</span></label>
             <input id="modal-ep-scopes" type="text" bind:value={scopes} placeholder="read write"
               class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--color-border) bg-(--color-surface) text-(--color-text) placeholder:text-(--color-text-secondary)/50 focus:outline-none focus:border-(--color-accent)" />
+            <p class="text-[11px] text-(--color-text-secondary) mt-0.5">Space-separated. Leave blank for server defaults.</p>
           </div>
+
+          <!-- Collapsible Advanced section — collapsed by default when from catalog -->
+          <details class="border border-(--color-border) rounded-lg" open={!selectedOAuthEntry}>
+            <summary class="px-3 py-2 text-xs font-medium text-(--color-text-secondary) cursor-pointer hover:bg-(--color-surface-hover) rounded-lg select-none">
+              Advanced
+            </summary>
+            <div class="px-3 pb-3 space-y-3">
+              <div>
+                <label for="modal-ep-oauth-url" class="block text-xs font-medium mb-1 text-(--color-text-secondary)">OAuth Server URL</label>
+                <input id="modal-ep-oauth-url" type="text" bind:value={oauthServerUrl} placeholder="Auto-discovered"
+                  class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--color-border) bg-(--color-surface) text-(--color-text) placeholder:text-(--color-text-secondary)/50 focus:outline-none focus:border-(--color-accent)" />
+                <p class="text-[11px] text-(--color-text-secondary) mt-0.5">Leave blank to auto-discover via RFC 9728</p>
+              </div>
+              <div>
+                <label for="modal-ep-client-id" class="block text-xs font-medium mb-1 text-(--color-text-secondary)">Client ID</label>
+                <input id="modal-ep-client-id" type="text" bind:value={clientId} placeholder="Auto-registered"
+                  class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--color-border) bg-(--color-surface) text-(--color-text) placeholder:text-(--color-text-secondary)/50 focus:outline-none focus:border-(--color-accent)" />
+                <p class="text-[11px] text-(--color-text-secondary) mt-0.5">Leave blank to use Dynamic Client Registration</p>
+              </div>
+              <div>
+                <label for="modal-ep-client-secret" class="block text-xs font-medium mb-1 text-(--color-text-secondary)">Client Secret <span class="text-(--color-text-secondary)/50">(optional)</span></label>
+                <input id="modal-ep-client-secret" type="password" bind:value={clientSecret} placeholder="Optional"
+                  class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--color-border) bg-(--color-surface) text-(--color-text) placeholder:text-(--color-text-secondary)/50 focus:outline-none focus:border-(--color-accent)" />
+              </div>
+            </div>
+          </details>
         {:else}
           <div>
             <label for="modal-ep-url" class="block text-xs font-medium mb-1 text-(--color-text-secondary)">URL</label>
@@ -715,29 +888,80 @@
           </div>
         {/if}
 
+        <!-- DCR Fallback Form -->
+        {#if showingDcrFallback}
+          <div class="border border-amber-500/30 rounded-lg p-4 bg-amber-500/5 space-y-3">
+            <div>
+              <p class="text-sm text-(--color-text)">
+                <strong>{name}</strong> requires manual client registration.
+                Register an OAuth app with the service, then enter your credentials below.
+              </p>
+              {#if dcrFallbackData.authorization_endpoint}
+                <p class="text-[11px] text-(--color-text-secondary) mt-1">
+                  Auth server: <code class="bg-(--color-surface-hover) px-1 py-0.5 rounded text-[11px]">{dcrFallbackData.authorization_endpoint}</code>
+                </p>
+              {/if}
+            </div>
+
+            <div>
+              <label for="modal-dcr-client-id" class="block text-xs font-medium mb-1 text-(--color-text-secondary)">
+                Client ID <span class="text-(--color-offline)">*</span>
+              </label>
+              <input id="modal-dcr-client-id" type="text" bind:value={dcrClientId} placeholder="Your registered client ID"
+                class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--color-border) bg-(--color-surface) text-(--color-text) placeholder:text-(--color-text-secondary)/50 focus:outline-none focus:border-(--color-accent)" />
+            </div>
+
+            <div>
+              <label for="modal-dcr-client-secret" class="block text-xs font-medium mb-1 text-(--color-text-secondary)">
+                Client Secret <span class="text-(--color-text-secondary)/50">(optional for public clients)</span>
+              </label>
+              <input id="modal-dcr-client-secret" type="password" bind:value={dcrClientSecret} placeholder="Optional"
+                class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--color-border) bg-(--color-surface) text-(--color-text) placeholder:text-(--color-text-secondary)/50 focus:outline-none focus:border-(--color-accent)" />
+            </div>
+
+            <button
+              class="w-full px-3 py-1.5 text-sm rounded-lg bg-(--color-accent) text-white hover:bg-(--color-accent-hover) transition-colors disabled:opacity-50"
+              onclick={handleDcrFallbackSubmit}
+              disabled={submitting}
+            >
+              {#if submitting}
+                Connecting…
+              {:else}
+                Save Credentials & Connect
+              {/if}
+            </button>
+          </div>
+        {/if}
+
         {#if error}
           <p class="text-xs text-(--color-offline)">{error}</p>
         {/if}
 
-        <div class="flex justify-end gap-2 pt-2">
-          <button
-            class="px-3 py-1.5 text-sm rounded-lg border border-(--color-border) hover:bg-(--color-surface-hover) transition-colors"
-            onclick={onclose}
-          >
-            Cancel
-          </button>
-          <button
-            class="px-3 py-1.5 text-sm rounded-lg bg-(--color-accent) text-white hover:bg-(--color-accent-hover) transition-colors disabled:opacity-50"
-            onclick={transport === 'oauth' ? handleOAuthSubmit : handleSubmit}
-            disabled={submitting}
-          >
-            {#if submitting}
-              {transport === 'oauth' ? 'Connecting…' : 'Adding…'}
-            {:else}
-              {transport === 'oauth' ? 'Save & Connect' : 'Add Server'}
-            {/if}
-          </button>
-        </div>
+        {#if !showingDcrFallback}
+          <div class="flex justify-end gap-2 pt-2">
+            <button
+              class="px-3 py-1.5 text-sm rounded-lg border border-(--color-border) hover:bg-(--color-surface-hover) transition-colors"
+              onclick={handleCancel}
+            >
+              Cancel
+            </button>
+            <button
+              class="px-3 py-1.5 text-sm rounded-lg bg-(--color-accent) text-white hover:bg-(--color-accent-hover) transition-colors disabled:opacity-50"
+              onclick={transport === 'oauth' ? handleOAuthSubmit : handleSubmit}
+              disabled={submitting}
+            >
+              {#if submitting}
+                {transport === 'oauth' ? 'Connecting…' : 'Adding…'}
+              {:else if selectedOAuthEntry}
+                Connect with {selectedOAuthEntry.name}
+              {:else if transport === 'oauth'}
+                Save & Connect
+              {:else}
+                Add Server
+              {/if}
+            </button>
+          </div>
+        {/if}
       </div>
     {/if}
   </div>

--- a/src/lib/components/AddEndpointModal.test.ts
+++ b/src/lib/components/AddEndpointModal.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { sanitizeName } from '$lib/utils';
+import { CATALOG_SERVERS, type CatalogServer } from '$lib/catalog';
+import { oauthCatalog, type OAuthCatalogEntry } from '$lib/data/oauth-catalog';
 
 describe('sanitizeName', () => {
   it('handles basic lowercase name', () => {
@@ -41,6 +43,157 @@ describe('sanitizeName', () => {
 
   it('preserves digits', () => {
     expect(sanitizeName('server123')).toBe('server123');
+  });
+});
+
+// ── Helpers that mirror the component's inline logic ──
+
+type UnifiedEntry =
+  | { type: 'oauth'; entry: OAuthCatalogEntry }
+  | { type: 'local'; entry: CatalogServer };
+
+function filterBySearch<T extends { name: string; description: string }>(
+  items: T[],
+  search: string,
+): T[] {
+  if (!search.trim()) return items;
+  const q = search.toLowerCase();
+  return items.filter(
+    (s) => s.name.toLowerCase().includes(q) || s.description.toLowerCase().includes(q),
+  );
+}
+
+function buildUnifiedList(opts: {
+  showOAuth: boolean;
+  showLocal: boolean;
+  search: string;
+}): UnifiedEntry[] {
+  const filteredLocal = filterBySearch(CATALOG_SERVERS, opts.search);
+  const filteredOAuth = filterBySearch(oauthCatalog, opts.search);
+  const items: UnifiedEntry[] = [];
+  if (opts.showOAuth) {
+    items.push(...filteredOAuth.map((e) => ({ type: 'oauth' as const, entry: e })));
+  }
+  if (opts.showLocal) {
+    items.push(...filteredLocal.map((e) => ({ type: 'local' as const, entry: e })));
+  }
+  return items.sort((a, b) => a.entry.name.localeCompare(b.entry.name));
+}
+
+// ── Filter toggle tests ──
+
+describe('AddEndpointModal unified browse list', () => {
+  describe('filter toggles', () => {
+    it('shows both OAuth and Local entries by default', () => {
+      const list = buildUnifiedList({ showOAuth: true, showLocal: true, search: '' });
+      const oauthCount = list.filter((e) => e.type === 'oauth').length;
+      const localCount = list.filter((e) => e.type === 'local').length;
+      expect(oauthCount).toBe(oauthCatalog.length);
+      expect(localCount).toBe(CATALOG_SERVERS.length);
+      expect(list.length).toBe(oauthCatalog.length + CATALOG_SERVERS.length);
+    });
+
+    it('toggling OAuth off hides OAuth entries, shows only Local', () => {
+      const list = buildUnifiedList({ showOAuth: false, showLocal: true, search: '' });
+      expect(list.every((e) => e.type === 'local')).toBe(true);
+      expect(list.length).toBe(CATALOG_SERVERS.length);
+    });
+
+    it('toggling Local off hides Local entries, shows only OAuth', () => {
+      const list = buildUnifiedList({ showOAuth: true, showLocal: false, search: '' });
+      expect(list.every((e) => e.type === 'oauth')).toBe(true);
+      expect(list.length).toBe(oauthCatalog.length);
+    });
+
+    it('both off shows empty list', () => {
+      const list = buildUnifiedList({ showOAuth: false, showLocal: false, search: '' });
+      expect(list).toHaveLength(0);
+    });
+
+    it('toggling back on restores entries', () => {
+      const listOff = buildUnifiedList({ showOAuth: false, showLocal: false, search: '' });
+      expect(listOff).toHaveLength(0);
+      const listOn = buildUnifiedList({ showOAuth: true, showLocal: true, search: '' });
+      expect(listOn.length).toBe(oauthCatalog.length + CATALOG_SERVERS.length);
+    });
+  });
+
+  describe('unified list sorting', () => {
+    it('entries are sorted alphabetically by name', () => {
+      const list = buildUnifiedList({ showOAuth: true, showLocal: true, search: '' });
+      const names = list.map((e) => e.entry.name);
+      const sorted = [...names].sort((a, b) => a.localeCompare(b));
+      expect(names).toEqual(sorted);
+    });
+
+    it('OAuth and Local entries are interleaved correctly', () => {
+      const list = buildUnifiedList({ showOAuth: true, showLocal: true, search: '' });
+      const types = list.map((e) => e.type);
+      let hasInterleaving = false;
+      for (let i = 1; i < types.length; i++) {
+        if (types[i] !== types[i - 1]) {
+          hasInterleaving = true;
+          break;
+        }
+      }
+      expect(hasInterleaving).toBe(true);
+    });
+  });
+
+  describe('search + filter interaction', () => {
+    it('search narrows results across both types', () => {
+      const list = buildUnifiedList({ showOAuth: true, showLocal: true, search: 'slack' });
+      expect(list.length).toBeGreaterThanOrEqual(2);
+      expect(list.some((e) => e.type === 'oauth')).toBe(true);
+      expect(list.some((e) => e.type === 'local')).toBe(true);
+      expect(list.every((e) => e.entry.name.toLowerCase().includes('slack'))).toBe(true);
+    });
+
+    it('search + filter toggle work together', () => {
+      const list = buildUnifiedList({ showOAuth: true, showLocal: false, search: 'git' });
+      expect(list.every((e) => e.type === 'oauth')).toBe(true);
+      const github = list.find((e) => e.entry.name === 'GitHub');
+      expect(github).toBeDefined();
+      expect(list.some((e) => e.type === 'local')).toBe(false);
+    });
+
+    it('search with no matches returns empty list', () => {
+      const list = buildUnifiedList({
+        showOAuth: true,
+        showLocal: true,
+        search: 'zzz_nonexistent_zzz',
+      });
+      expect(list).toHaveLength(0);
+    });
+
+    it('search matches on description too', () => {
+      const list = buildUnifiedList({ showOAuth: true, showLocal: true, search: 'issue tracking' });
+      expect(list.length).toBeGreaterThanOrEqual(1);
+      expect(list.some((e) => e.entry.id === 'linear')).toBe(true);
+    });
+  });
+
+  describe('OAuth service selection', () => {
+    it('selectOAuthService populates correct fields from catalog entry', () => {
+      const service = oauthCatalog.find((e) => e.id === 'github')!;
+      expect(service).toBeDefined();
+
+      const name = service.name;
+      const prefix = sanitizeName(service.name);
+      const description = service.description;
+      const transport = 'oauth';
+      const url = service.url;
+      const oauthServerUrl = service.oauthServerUrl || '';
+      const scopeStr = service.defaultScopes.join(' ');
+
+      expect(name).toBe('GitHub');
+      expect(prefix).toBe('github');
+      expect(description).toBe('Code hosting and collaboration');
+      expect(transport).toBe('oauth');
+      expect(url).toBe('https://api.githubcopilot.com/mcp/');
+      expect(oauthServerUrl).toBe('https://github.com/login/oauth');
+      expect(scopeStr).toBe('repo read:user');
+    });
   });
 });
 

--- a/src/lib/components/AuthTab.svelte
+++ b/src/lib/components/AuthTab.svelte
@@ -30,9 +30,9 @@
     connection_failed: 'Connection Failed',
   };
 
-  function formatTime(iso: string | null): string {
-    if (!iso) return '—';
-    const d = new Date(iso);
+  function formatTime(unixSeconds: number | null): string {
+    if (unixSeconds === null || unixSeconds === undefined) return '—';
+    const d = new Date(unixSeconds * 1000);
     return d.toLocaleString();
   }
 
@@ -93,9 +93,17 @@
     if (!name || actionInProgress) return;
     actionInProgress = true;
     try {
-      const { authorize_url } = await startOAuth(name);
-      await openUrl(authorize_url);
-      toast.success('Browser opened for authorization');
+      const result = await startOAuth(name);
+      if ('authorize_url' in result) {
+        await openUrl(result.authorize_url);
+        toast.success('Browser opened for authorization');
+      } else if ('error' in result && result.error === 'discovery_failed') {
+        toast.error('OAuth discovery failed. Go to Settings to configure OAuth server URL manually.');
+      } else if ('error' in result && result.error === 'dcr_unsupported') {
+        toast.error('This server requires manual OAuth app registration. Go to Settings to enter your Client ID.');
+      } else {
+        toast.error('Failed to start OAuth flow');
+      }
     } catch {
       toast.error('Failed to start OAuth flow');
     }
@@ -117,7 +125,7 @@
     showDisconnectConfirm = false;
   }
 
-  let canRefresh = $derived(status !== null && ['authenticated', 'auth_required'].includes(status.status));
+  let canRefresh = $derived(status !== null && status.has_refresh_token && ['authenticated', 'auth_required'].includes(status.status));
   let canReconnect = $derived(status !== null && ['disconnected', 'auth_required', 'needs_login'].includes(status.status));
   let canDisconnect = $derived(status !== null && ['authenticated', 'refreshing', 'auth_required'].includes(status.status));
 </script>
@@ -174,7 +182,7 @@
         </div>
         <div>
           <div class="text-xs text-(--color-text-secondary)">Next Refresh</div>
-          <div class="font-medium">{formatTime(status.next_refresh_at)}</div>
+          <div class="font-medium">{status.has_refresh_token ? formatTime(status.next_refresh_at) : '—'}</div>
         </div>
       </div>
     </div>

--- a/src/lib/components/AuthTab.test.ts
+++ b/src/lib/components/AuthTab.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+
+// Re-implement the pure logic from AuthTab.svelte so we can unit-test it.
+// These must stay in sync with the component implementation.
+
+function formatTime(unixSeconds: number | null): string {
+  if (unixSeconds === null || unixSeconds === undefined) return '—';
+  const d = new Date(unixSeconds * 1000);
+  return d.toLocaleString();
+}
+
+function formatCountdown(seconds: number | null): string {
+  if (seconds === null || seconds === undefined) return '—';
+  if (seconds <= 0) return 'Expired';
+  const m = Math.floor(seconds / 60);
+  const s = Math.round(seconds % 60);
+  if (m > 60) {
+    const h = Math.floor(m / 60);
+    return `${h}h ${m % 60}m`;
+  }
+  return m > 0 ? `${m}m ${s}s` : `${s}s`;
+}
+
+describe('formatTime', () => {
+  it('returns "—" for null', () => {
+    expect(formatTime(null)).toBe('—');
+  });
+
+  it('returns a reasonable 2024 date for unix timestamp 1712188800', () => {
+    const result = formatTime(1712188800);
+    // 1712188800 = April 4, 2024 00:00:00 UTC
+    expect(result).toContain('2024');
+    // Should NOT contain "1970"
+    expect(result).not.toContain('1970');
+  });
+
+  it('returns "—" for undefined (cast as null)', () => {
+    expect(formatTime(undefined as unknown as null)).toBe('—');
+  });
+
+  it('handles zero (epoch) correctly', () => {
+    const result = formatTime(0);
+    // 0 seconds = Jan 1, 1970 — but this is the correct epoch, not a bug
+    expect(result).toContain('1970');
+  });
+});
+
+describe('formatCountdown', () => {
+  it('returns "—" for null', () => {
+    expect(formatCountdown(null)).toBe('—');
+  });
+
+  it('returns "—" for undefined (cast as null)', () => {
+    expect(formatCountdown(undefined as unknown as null)).toBe('—');
+  });
+
+  it('returns "Expired" for 0', () => {
+    expect(formatCountdown(0)).toBe('Expired');
+  });
+
+  it('returns "Expired" for negative values', () => {
+    expect(formatCountdown(-10)).toBe('Expired');
+  });
+
+  it('formats 3600 seconds as "60m 0s"', () => {
+    expect(formatCountdown(3600)).toBe('60m 0s');
+  });
+
+  it('formats 90 seconds as "1m 30s"', () => {
+    expect(formatCountdown(90)).toBe('1m 30s');
+  });
+
+  it('formats 30 seconds as "30s"', () => {
+    expect(formatCountdown(30)).toBe('30s');
+  });
+
+  it('formats large values with hours', () => {
+    // 7200 seconds = 120 minutes = 2h 0m
+    expect(formatCountdown(7200)).toBe('2h 0m');
+  });
+
+  it('formats 3661 seconds as "1h 1m"', () => {
+    // 3661 seconds = 61 minutes 1 second → 1h 1m
+    expect(formatCountdown(3661)).toBe('1h 1m');
+  });
+});
+

--- a/src/lib/components/ConfigTab.svelte
+++ b/src/lib/components/ConfigTab.svelte
@@ -3,7 +3,7 @@
   import { selectedEndpoint, endpoints } from '$lib/stores';
   import { sanitizeName } from '$lib/utils';
 
-  type TransportType = 'stdio' | 'sse' | 'http';
+  type TransportType = 'stdio' | 'sse' | 'http' | 'oauth';
 
   let loading = $state(true);
   let saving = $state(false);
@@ -22,6 +22,10 @@
   let url = $state('');
   let envVars: { key: string; value: string }[] = $state([]);
   let headerVars: { key: string; value: string }[] = $state([]);
+  let oauthServerUrl = $state('');
+  let clientId = $state('');
+  let clientSecret = $state('');
+  let scopes = $state('');
 
   let prefixPreview = $derived(prefix ? `${prefix}__tool` : 'prefix__tool');
 
@@ -59,6 +63,10 @@
         headerVars = config.headers
           ? Object.entries(config.headers).map(([key, value]) => ({ key, value }))
           : [];
+        oauthServerUrl = config.oauth_server_url ?? '';
+        clientId = config.client_id ?? '';
+        clientSecret = config.client_secret ?? '';
+        scopes = config.scopes ?? '';
       })
       .catch(() => {
         error = 'Unable to load endpoint configuration';
@@ -103,6 +111,13 @@
       if (args.trim()) {
         params.args = args.trim().split(/\s+/);
       }
+    } else if (transport === 'oauth') {
+      if (!url.trim()) { error = 'Server URL is required'; return; }
+      params.url = url.trim();
+      if (oauthServerUrl.trim()) params.oauth_server_url = oauthServerUrl.trim();
+      if (clientId.trim()) params.client_id = clientId.trim();
+      if (clientSecret.trim()) params.client_secret = clientSecret.trim();
+      if (scopes.trim()) params.scopes = scopes.trim();
     } else {
       if (!url.trim()) { error = 'URL is required'; return; }
       params.url = url.trim();
@@ -175,7 +190,7 @@
         <fieldset class="border-none p-0 m-0">
           <legend class="block text-xs font-medium mb-1 text-(--color-text-secondary)">Transport</legend>
           <div class="flex gap-2">
-            {#each ['stdio', 'sse', 'http'] as t}
+            {#each ['stdio', 'sse', 'http', 'oauth'] as t}
               <button
                 class="px-3 py-1.5 text-xs rounded-lg border transition-colors
                   {transport === t
@@ -238,6 +253,38 @@
             <input id="config-ep-args" type="text" bind:value={args} placeholder="-y @modelcontextprotocol/server-filesystem /tmp"
               class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--color-border) bg-(--color-surface) text-(--color-text) placeholder:text-(--color-text-secondary)/50 focus:outline-none focus:border-(--color-accent)" />
           </div>
+        {:else if transport === 'oauth'}
+          <div>
+            <label for="config-ep-url" class="block text-xs font-medium mb-1 text-(--color-text-secondary)">Server URL</label>
+            <input id="config-ep-url" type="text" bind:value={url} placeholder="https://api.githubcopilot.com/mcp/"
+              class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--color-border) bg-(--color-surface) text-(--color-text) placeholder:text-(--color-text-secondary)/50 focus:outline-none focus:border-(--color-accent)" />
+          </div>
+          <details class="border border-(--color-border) rounded-lg">
+            <summary class="px-3 py-2 text-xs font-medium text-(--color-text-secondary) cursor-pointer hover:bg-(--color-surface-hover) rounded-lg select-none">Advanced</summary>
+            <div class="px-3 pb-3 space-y-3">
+              <div>
+                <label for="config-ep-oauth-server" class="block text-xs font-medium mb-1 text-(--color-text-secondary)">OAuth Server URL</label>
+                <input id="config-ep-oauth-server" type="text" bind:value={oauthServerUrl} placeholder="Auto-discovered"
+                  class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--color-border) bg-(--color-surface) text-(--color-text) placeholder:text-(--color-text-secondary)/50 focus:outline-none focus:border-(--color-accent)" />
+                <p class="text-[11px] text-(--color-text-secondary) mt-0.5">Leave blank to auto-discover via RFC 9728</p>
+              </div>
+              <div>
+                <label for="config-ep-client-id" class="block text-xs font-medium mb-1 text-(--color-text-secondary)">Client ID</label>
+                <input id="config-ep-client-id" type="text" bind:value={clientId} placeholder="Auto via Dynamic Client Registration"
+                  class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--color-border) bg-(--color-surface) text-(--color-text) placeholder:text-(--color-text-secondary)/50 focus:outline-none focus:border-(--color-accent)" />
+              </div>
+              <div>
+                <label for="config-ep-client-secret" class="block text-xs font-medium mb-1 text-(--color-text-secondary)">Client Secret <span class="text-(--color-text-secondary)/50">(optional)</span></label>
+                <input id="config-ep-client-secret" type="text" bind:value={clientSecret} placeholder=""
+                  class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--color-border) bg-(--color-surface) text-(--color-text) placeholder:text-(--color-text-secondary)/50 focus:outline-none focus:border-(--color-accent)" />
+              </div>
+              <div>
+                <label for="config-ep-scopes" class="block text-xs font-medium mb-1 text-(--color-text-secondary)">Scopes <span class="text-(--color-text-secondary)/50">(space-separated)</span></label>
+                <input id="config-ep-scopes" type="text" bind:value={scopes} placeholder="repo read:user"
+                  class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--color-border) bg-(--color-surface) text-(--color-text) placeholder:text-(--color-text-secondary)/50 focus:outline-none focus:border-(--color-accent)" />
+              </div>
+            </div>
+          </details>
         {:else}
           <div>
             <label for="config-ep-url" class="block text-xs font-medium mb-1 text-(--color-text-secondary)">URL</label>

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -237,7 +237,7 @@
         <div class="text-xs text-(--color-text-secondary)/70 mt-1">When disabled, all tools from all endpoints are listed individually in the MCP catalog.</div>
       </div>
       <button
-        class="relative w-10 h-5 rounded-full transition-colors {$jsExecutionMode ? 'bg-(--color-accent)' : 'bg-(--color-border)'}"
+        class="shrink-0 relative w-10 h-5 rounded-full transition-colors {$jsExecutionMode ? 'bg-green-500' : 'bg-gray-300 dark:bg-gray-600'}"
         onclick={() => toggleJsExecutionMode()}
         role="switch"
         aria-checked={$jsExecutionMode}

--- a/src/lib/data/oauth-catalog.test.ts
+++ b/src/lib/data/oauth-catalog.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { oauthCatalog } from './oauth-catalog';
+
+describe('oauthCatalog', () => {
+  it('should have exactly 5 entries', () => {
+    expect(oauthCatalog).toHaveLength(5);
+  });
+
+  it('should not include Google Drive', () => {
+    const googleDrive = oauthCatalog.find((entry) => entry.id === 'google-drive');
+    expect(googleDrive).toBeUndefined();
+  });
+
+  it('should have the correct GitHub URL', () => {
+    const github = oauthCatalog.find((entry) => entry.id === 'github');
+    expect(github).toBeDefined();
+    expect(github!.url).toBe('https://api.githubcopilot.com/mcp/');
+  });
+
+  it('should have the correct Notion URL', () => {
+    const notion = oauthCatalog.find((entry) => entry.id === 'notion');
+    expect(notion).toBeDefined();
+    expect(notion!.url).toBe('https://mcp.notion.com/mcp');
+    expect(notion!.supportsDiscovery).toBe(true);
+    expect(notion!.supportsDcr).toBe(true);
+  });
+
+  it('should have the correct Slack URL', () => {
+    const slack = oauthCatalog.find((entry) => entry.id === 'slack');
+    expect(slack).toBeDefined();
+    expect(slack!.url).toBe('https://mcp.slack.com/mcp');
+    expect(slack!.supportsDiscovery).toBe(true);
+    expect(slack!.supportsDcr).toBe(false);
+  });
+
+  it('should have the correct Linear URL', () => {
+    const linear = oauthCatalog.find((entry) => entry.id === 'linear');
+    expect(linear).toBeDefined();
+    expect(linear!.url).toBe('https://mcp.linear.app/sse');
+    expect(linear!.supportsDiscovery).toBe(true);
+    expect(linear!.supportsDcr).toBe(true);
+  });
+
+  it('should have the correct Todoist entry', () => {
+    const todoist = oauthCatalog.find((entry) => entry.id === 'todoist');
+    expect(todoist).toBeDefined();
+    expect(todoist!.url).toBe('https://ai.todoist.net/mcp');
+    expect(todoist!.supportsDcr).toBe(true);
+  });
+});
+

--- a/src/lib/data/oauth-catalog.ts
+++ b/src/lib/data/oauth-catalog.ts
@@ -1,0 +1,80 @@
+export interface OAuthCatalogEntry {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  category: 'developer' | 'productivity' | 'search' | 'data';
+  url: string;
+  oauthServerUrl?: string;
+  defaultScopes: string[];
+  supportsDiscovery: boolean;
+  supportsDcr: boolean;
+  tokenEndpoint?: string;
+  notes?: string;
+}
+
+export const oauthCatalog: OAuthCatalogEntry[] = [
+  {
+    id: 'linear',
+    name: 'Linear',
+    description: 'Issue tracking and project management',
+    icon: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3.5 16.5l2.8-2.8a7 7 0 0 1-.8-3.2A7 7 0 0 1 12.5 3.5l.5.5a7 7 0 0 1-7 7 7 7 0 0 1-3.2-.8L3.5 16.5z" fill="currentColor" stroke="none"/></svg>',
+    category: 'developer',
+    url: 'https://mcp.linear.app/sse',
+    defaultScopes: ['read', 'write'],
+    supportsDiscovery: true,
+    supportsDcr: true,
+    notes: 'Full issue, project, and team access',
+  },
+  {
+    id: 'notion',
+    name: 'Notion',
+    description: 'Docs, wikis, and databases',
+    icon: '<svg viewBox="0 0 20 20" fill="currentColor"><path d="M4.5 2.5h9l2 2v13h-11V2.5zm2 4h7M6.5 9.5h7M6.5 12.5h5" fill="none" stroke="currentColor" stroke-width="1.2"/></svg>',
+    category: 'productivity',
+    url: 'https://mcp.notion.com/mcp',
+    defaultScopes: ['read', 'write'],
+    supportsDiscovery: true,
+    supportsDcr: true,
+    notes: 'Requires Notion integration setup — you\'ll be prompted for client credentials',
+  },
+  {
+    id: 'slack',
+    name: 'Slack',
+    description: 'Team messaging and channels',
+    icon: '<svg viewBox="0 0 20 20" fill="currentColor"><path d="M7.5 2a1.5 1.5 0 1 0 0 3H9V3.5A1.5 1.5 0 0 0 7.5 2ZM4 7.5A1.5 1.5 0 0 0 2 7.5 1.5 1.5 0 0 0 3.5 9H5V7.5ZM12.5 5a1.5 1.5 0 1 0 0-3A1.5 1.5 0 0 0 11 3.5V5h1.5ZM16 7.5A1.5 1.5 0 0 1 18 7.5 1.5 1.5 0 0 1 16.5 9H15V7.5ZM12.5 18a1.5 1.5 0 1 0 0-3H11v1.5a1.5 1.5 0 0 0 1.5 1.5ZM16 12.5a1.5 1.5 0 0 1 0 3h-1.5V14h1.5ZM7.5 15a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 1.5-1.5V15H7.5ZM4 12.5a1.5 1.5 0 0 0-2 0A1.5 1.5 0 0 0 3.5 14H5v-1.5Z"/></svg>',
+    category: 'productivity',
+    url: 'https://mcp.slack.com/mcp',
+    defaultScopes: ['channels:read', 'chat:write', 'users:read'],
+    supportsDiscovery: true,
+    supportsDcr: false,
+    notes: 'Requires Slack app registration — you\'ll be prompted for client credentials',
+  },
+  {
+    id: 'github',
+    name: 'GitHub',
+    description: 'Code hosting and collaboration',
+    icon: '<svg viewBox="0 0 20 20" fill="currentColor"><path d="M10 1.5a8.5 8.5 0 0 0-2.69 16.56c.43.08.58-.18.58-.4v-1.54c-2.37.52-2.87-1.01-2.87-1.01-.39-.99-.95-1.25-.95-1.25-.78-.53.06-.52.06-.52.86.06 1.31.88 1.31.88.76 1.3 2 .93 2.49.71.08-.55.3-.93.54-1.14-1.89-.21-3.88-.94-3.88-4.2 0-.93.33-1.69.88-2.28-.09-.22-.38-1.08.08-2.25 0 0 .72-.23 2.35.87a8.18 8.18 0 0 1 4.28 0c1.63-1.1 2.35-.87 2.35-.87.46 1.17.17 2.03.08 2.25.55.59.88 1.35.88 2.28 0 3.27-1.99 3.99-3.89 4.2.31.26.58.78.58 1.58v2.34c0 .22.15.49.58.4A8.5 8.5 0 0 0 10 1.5Z"/></svg>',
+    category: 'developer',
+    url: 'https://api.githubcopilot.com/mcp/',
+    oauthServerUrl: 'https://github.com/login/oauth',
+    defaultScopes: ['repo', 'read:user'],
+    supportsDiscovery: false,
+    supportsDcr: false,
+    tokenEndpoint: 'https://github.com/login/oauth/access_token',
+    notes: 'Repository, issue, and PR access — requires GitHub OAuth app registration',
+  },
+  {
+    id: 'todoist',
+    name: 'Todoist',
+    description: 'Task management and to-do lists',
+    icon: '<svg viewBox="0 0 20 20" fill="currentColor"><path d="M3 5.5l1.2-.7L10 8.5l5.8-3.7L17 5.5l-7 4.5-7-4.5zm0 4l1.2-.7L10 12.5l5.8-3.7L17 9.5l-7 4.5-7-4.5zm0 4l1.2-.7L10 16.5l5.8-3.7L17 13.5l-7 4.5-7-4.5z"/></svg>',
+    category: 'productivity',
+    url: 'https://ai.todoist.net/mcp',
+    defaultScopes: ['data:read_write'],
+    supportsDiscovery: true,
+    supportsDcr: true,
+    notes: 'Task and project management',
+  },
+];
+

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -44,11 +44,49 @@ export interface OAuthStatus {
   status: OAuthStatusValue;
   has_access_token: boolean;
   has_refresh_token: boolean;
-  expires_at: string | null;
+  expires_at: number | null;
   expires_in_seconds: number | null;
-  last_refreshed_at: string | null;
-  next_refresh_at: string | null;
+  last_refreshed_at: number | null;
+  next_refresh_at: number | null;
   state: string | null;
+}
+
+export interface OAuthStartSuccess {
+  authorize_url: string;
+}
+
+export interface OAuthStartDcrUnsupported {
+  error: 'dcr_unsupported';
+  authorization_endpoint?: string;
+  message?: string;
+}
+
+export interface OAuthStartDiscoveryFailed {
+  error: 'discovery_failed';
+  detail?: string;
+}
+
+export type OAuthStartResult = OAuthStartSuccess | OAuthStartDcrUnsupported | OAuthStartDiscoveryFailed;
+
+export type OAuthSetupStatus = 'awaiting_credentials' | 'awaiting_auth' | 'authorized';
+
+export interface OAuthSetupResponse {
+  session_id: string;
+  status: OAuthSetupStatus;
+  authorize_url?: string;
+  discovery?: {
+    auth_server: string;
+    dcr_used: boolean;
+    scopes_available?: string[];
+  };
+  dcr_error?: string;
+}
+
+export interface OAuthSetupStatusResponse {
+  session_id: string;
+  status: OAuthSetupStatus;
+  name: string;
+  url: string;
 }
 
 export type Theme = 'light' | 'dark' | 'system';


### PR DESCRIPTION
## Summary

OAuth Connect Slice 3 — curated catalog, discovery UI, and DCR integration.

### Curated OAuth MCP Server Catalog
- Add `oauth-catalog.ts` with GitHub, Linear, Notion, Slack entries
- Each entry includes discovery URL, OAuth scopes, and display metadata
- Catalog validation tests

### OAuth Discovery & DCR UI
- OAuth setup flow in AuthTab and AddEndpointModal
- Catalog-based endpoint selection in Settings
- API layer updates for OAuth discovery and DCR endpoints
- Component tests for AuthTab

### Dependencies & Tauri Bridge
- Update package.json dependencies
- Add OAuth discovery/DCR commands to Tauri bridge

Companion PR: endara-ai/endara-relay#11

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author