### PR TITLE
chore: rename tab labels

### DIFF
--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -187,7 +187,7 @@
         <p class="text-xs text-(--color-text-secondary) mt-1">
           {$relaySidecarStatus === 'stopped'
             ? 'Relay is stopped. Click Retry to start it again.'
-            : `Relay failed to start on port ${$relayPort}. Check Relay Logs for details.`}
+            : `Relay failed to start on port ${$relayPort}. Check Logs for details.`}
         </p>
         {#if $relaySidecarError}
           <div class="mt-2 p-2 rounded bg-red-500/10 border border-red-500/20">

--- a/src/lib/relaySidecarUi.ts
+++ b/src/lib/relaySidecarUi.ts
@@ -3,9 +3,9 @@ import type { RelaySidecarStatusType } from './stores';
 export type TopLevelTabId = 'servers' | 'unified-catalog' | 'relay-logs' | 'settings';
 
 export const allTopLevelTabs = [
-  { id: 'servers' as const, label: 'MCP Servers' },
-  { id: 'unified-catalog' as const, label: 'Unified Catalog' },
-  { id: 'relay-logs' as const, label: 'Relay Logs' },
+  { id: 'servers' as const, label: 'Servers' },
+  { id: 'unified-catalog' as const, label: 'Catalog' },
+  { id: 'relay-logs' as const, label: 'Logs' },
   { id: 'settings' as const, label: 'Settings' },
 ];
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -31,7 +31,7 @@
     : ($relaySidecarStatus === 'stopped') ? 'Relay stopped'
     : 'Relay status unknown'
   );
-  const relayFailureMessage = $derived($relaySidecarError ?? 'Relay failed to start. Check Relay Logs for more details.');
+  const relayFailureMessage = $derived($relaySidecarError ?? 'Relay failed to start. Check Logs for more details.');
 
   let pollInterval: ReturnType<typeof setInterval> | undefined;
   let sidebar: Sidebar | undefined = $state();
@@ -158,7 +158,7 @@
       <div class="space-y-3">
         <h1 class="text-2xl font-semibold text-(--color-text)">Endara Desktop couldn&apos;t start the relay</h1>
         <p class="text-sm text-(--color-text-secondary)">
-          The app can&apos;t connect to the relay on port {$relayPort}. Review the startup error below, check the relay logs, or update your settings and try again.
+          The app can&apos;t connect to the relay on port {$relayPort}. Review the startup error below, check the logs, or update your settings and try again.
         </p>
       </div>
 
@@ -179,7 +179,7 @@
           class="rounded-lg border border-(--color-border) px-4 py-2 text-sm font-medium text-(--color-text) transition-colors hover:bg-(--color-surface-hover)"
           onclick={openRelayLogs}
         >
-          View Relay Logs
+          View Logs
         </button>
         <button
           class="rounded-lg border border-(--color-border) px-4 py-2 text-sm font-medium text-(--color-text) transition-colors hover:bg-(--color-surface-hover)"


### PR DESCRIPTION
Renames desktop app tab labels for brevity:

- "MCP Servers" → "Servers"
- "Unified Catalog" → "Catalog"
- "Relay Logs" → "Logs"
- "Settings" stays as-is

Also updates error/info messages that referenced "Relay Logs" to say "Logs".

Tab IDs are unchanged — only display labels are affected.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author