### PR TITLE
ci: cache apt packages for system dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,10 @@ jobs:
           targets: ${{ matrix.target }}
       - name: Install system dependencies
         if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          version: 1.0
       - name: Create dummy sidecar for check (Unix)
         if: runner.os != 'Windows'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,9 +54,10 @@ jobs:
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          version: 1.0
 
       - name: Download relay binary
         shell: bash


### PR DESCRIPTION
Replace the manual `apt-get install` step with `awalsh128/cache-apt-pkgs-action` to cache system dependencies across CI runs.

This avoids re-downloading and installing the same packages on every Linux CI run.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author