### PR TITLE
feat: replace colorful emojis with monochrome SVG icons

### DIFF
--- a/src/lib/components/DetailPanel.svelte
+++ b/src/lib/components/DetailPanel.svelte
@@ -194,7 +194,7 @@
   {:else}
     <div class="flex-1 flex items-center justify-center text-(--color-text-secondary)">
       <div class="text-center">
-        <div class="text-4xl mb-3">⚡</div>
+        <div class="text-4xl mb-3 text-(--color-text-secondary)"><svg class="inline-block w-10 h-10" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M11.5 2L5 11h5l-1.5 7L15 9h-5l1.5-7z"/></svg></div>
         <div class="text-sm">Select an endpoint to view details</div>
       </div>
     </div>

--- a/src/lib/components/EndpointRow.svelte
+++ b/src/lib/components/EndpointRow.svelte
@@ -7,13 +7,22 @@
 
   let { endpoint }: { endpoint: Endpoint } = $props();
 
+  const authLabels: Record<OAuthStatusValue, string> = {
+    authenticated: 'Authenticated',
+    refreshing: 'Refreshing token…',
+    auth_required: 'Authentication required',
+    needs_login: 'Login required',
+    disconnected: 'Disconnected',
+    connection_failed: 'Connection failed',
+  };
+
   const authIcons: Record<OAuthStatusValue, string> = {
-    authenticated: '🔑',
-    refreshing: '🔄',
-    auth_required: '🔒',
-    needs_login: '🔒',
-    disconnected: '⚠️',
-    connection_failed: '⚠️',
+    authenticated: '<svg class="inline-block w-3 h-3" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10.5 7V4.5a2.5 2.5 0 0 0-5 0V7"/><rect x="4" y="7" width="8" height="6.5" rx="1.5"/><circle cx="8" cy="10.5" r="1" fill="currentColor" stroke="none"/></svg>',
+    refreshing: '<svg class="inline-block w-3 h-3" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 8A5 5 0 1 1 8 3"/><path d="M13 3v5h-5"/></svg>',
+    auth_required: '<svg class="inline-block w-3 h-3" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3.5" y="7" width="9" height="6.5" rx="1.5"/><path d="M5.5 7V5a2.5 2.5 0 0 1 5 0v2"/><circle cx="8" cy="10.5" r="1" fill="currentColor" stroke="none"/></svg>',
+    needs_login: '<svg class="inline-block w-3 h-3" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3.5" y="7" width="9" height="6.5" rx="1.5"/><path d="M5.5 7V5a2.5 2.5 0 0 1 5 0v2"/><circle cx="8" cy="10.5" r="1" fill="currentColor" stroke="none"/></svg>',
+    disconnected: '<svg class="inline-block w-3 h-3" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 5.5v3.5"/><circle cx="8" cy="11.5" r="0.75" fill="currentColor" stroke="none"/><path d="M3 13.5L8 3l5 10.5H3z"/></svg>',
+    connection_failed: '<svg class="inline-block w-3 h-3" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 5.5v3.5"/><circle cx="8" cy="11.5" r="0.75" fill="currentColor" stroke="none"/><path d="M3 13.5L8 3l5 10.5H3z"/></svg>',
   };
 
   let oauthStatus = $derived(
@@ -50,7 +59,7 @@
         <span class="text-xs text-(--color-text-secondary)">{endpoint.tool_count} tools</span>
       {/if}
       {#if oauthStatus}
-        <span class="text-xs" title={oauthStatus.status}>{authIcons[oauthStatus.status]}</span>
+        <span class="text-xs" title={authLabels[oauthStatus.status]}>{@html authIcons[oauthStatus.status]}</span>
       {/if}
     </div>
   </div>

--- a/src/lib/components/UnifiedCatalog.svelte
+++ b/src/lib/components/UnifiedCatalog.svelte
@@ -81,7 +81,7 @@
           <div class="flex items-center gap-2 shrink-0">
             <span class="px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-(--color-surface-alt) text-(--color-text-secondary)">{entry.endpoint}</span>
             {#if !entry.available}
-              <span class="px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400">⚠️ Unavailable</span>
+              <span class="inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400"><svg class="w-2.5 h-2.5" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 5.5v3.5"/><circle cx="8" cy="11.5" r="0.75" fill="currentColor" stroke="none"/><path d="M3 13.5L8 3l5 10.5H3z"/></svg> Unavailable</span>
             {/if}
             {#if entry.annotations?.readOnlyHint === true}
               <span class="px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400">Read-only</span>


### PR DESCRIPTION
Replace colorful Unicode emojis (🔑🔄🔒⚠️⚡) with monochrome inline SVGs using `currentColor` across three components:

- **EndpointRow.svelte** — Auth status icons (key, refresh, lock, warning) + user-friendly tooltips
- **DetailPanel.svelte** — Empty state icon
- **UnifiedCatalog.svelte** — Unavailable badge

All SVGs use `stroke="currentColor"` with stroke-based style matching existing icons.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author