### PR TITLE
feat: OAuth Slice 4 — desktop status derivation, polling, and UI polish

### DIFF
--- a/src/lib/components/AddEndpointModal.svelte
+++ b/src/lib/components/AddEndpointModal.svelte
@@ -663,7 +663,7 @@
             type="text"
             value={prefix}
             oninput={(event) => handlePrefixInput((event.currentTarget as HTMLInputElement).value)}
-            placeholder="my_server"
+            placeholder={sanitizeName(name) || 'tool_prefix'}
             class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--color-border) bg-(--color-surface) text-(--color-text) placeholder:text-(--color-text-secondary)/50 focus:outline-none focus:border-(--color-accent)"
           />
           <p class="text-[11px] text-(--color-text-secondary) mt-0.5">

--- a/src/lib/components/ConfigTab.svelte
+++ b/src/lib/components/ConfigTab.svelte
@@ -27,11 +27,66 @@
   let clientSecret = $state('');
   let scopes = $state('');
 
+  // Original value snapshots for dirty-state tracking
+  let originalTransport: TransportType = $state('stdio');
+  let originalPrefix = $state('');
+  let originalPrefixCustom = $state(false);
+  let originalDescription = $state('');
+  let originalCommand = $state('');
+  let originalArgs = $state('');
+  let originalUrl = $state('');
+  let originalEnvVars = $state('[]');
+  let originalHeaderVars = $state('[]');
+  let originalOauthServerUrl = $state('');
+  let originalClientId = $state('');
+  let originalClientSecret = $state('');
+  let originalScopes = $state('');
+
+  function snapshotOriginals() {
+    originalTransport = transport;
+    originalPrefix = prefix;
+    originalPrefixCustom = prefixCustom;
+    originalDescription = description;
+    originalCommand = command;
+    originalArgs = args;
+    originalUrl = url;
+    originalEnvVars = JSON.stringify(envVars);
+    originalHeaderVars = JSON.stringify(headerVars);
+    originalOauthServerUrl = oauthServerUrl;
+    originalClientId = clientId;
+    originalClientSecret = clientSecret;
+    originalScopes = scopes;
+  }
+
   let prefixPreview = $derived(prefix ? `${prefix}__tool` : 'prefix__tool');
+
+  let isDirty = $derived(
+    name !== originalName ||
+    transport !== originalTransport ||
+    prefix !== originalPrefix ||
+    prefixCustom !== originalPrefixCustom ||
+    description !== originalDescription ||
+    command !== originalCommand ||
+    args !== originalArgs ||
+    url !== originalUrl ||
+    JSON.stringify(envVars) !== originalEnvVars ||
+    JSON.stringify(headerVars) !== originalHeaderVars ||
+    oauthServerUrl !== originalOauthServerUrl ||
+    clientId !== originalClientId ||
+    clientSecret !== originalClientSecret ||
+    scopes !== originalScopes
+  );
 
   $effect(() => {
     if (!prefixCustom) {
       prefix = sanitizeName(name);
+    }
+  });
+
+  // Clear stale success message when user makes a new change
+  $effect(() => {
+    if (isDirty && success) {
+      success = '';
     }
   });
 
@@ -67,6 +122,7 @@
         clientId = config.client_id ?? '';
         clientSecret = config.client_secret ?? '';
         scopes = config.scopes ?? '';
+        snapshotOriginals();
       })
       .catch(() => {
         error = 'Unable to load endpoint configuration';
@@ -160,6 +216,7 @@
       if (params.name !== $selectedEndpoint) {
         selectedEndpoint.set(params.name);
       }
+      snapshotOriginals();
       success = 'Configuration saved';
       setTimeout(() => { success = ''; }, 3000);
     } catch (e) {
@@ -228,7 +285,7 @@
             type="text"
             value={prefix}
             oninput={(event) => handlePrefixInput((event.currentTarget as HTMLInputElement).value)}
-            placeholder="my_server"
+            placeholder={sanitizeName(name) || 'tool_prefix'}
             class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--color-border) bg-(--color-surface) text-(--color-text) placeholder:text-(--color-text-secondary)/50 focus:outline-none focus:border-(--color-accent)"
           />
           <p class="text-[11px] text-(--color-text-secondary) mt-0.5">
@@ -367,7 +424,7 @@
           <button
             class="px-3 py-1.5 text-sm rounded-lg bg-(--color-accent) text-white hover:bg-(--color-accent-hover) transition-colors disabled:opacity-50"
             onclick={handleSave}
-            disabled={saving}
+            disabled={!isDirty || saving}
           >
             {saving ? 'Saving…' : 'Save Changes'}
           </button>

--- a/src/lib/oauth/derive-status.test.ts
+++ b/src/lib/oauth/derive-status.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { deriveOAuthDisplayStatus } from './derive-status';
+import type { OAuthStatus, OAuthStatusValue, OAuthDisplayStatus } from '$lib/types';
+
+function makeStatus(status: OAuthStatusValue): OAuthStatus {
+  return {
+    status,
+    has_access_token: status === 'authenticated',
+    has_refresh_token: false,
+    expires_at: null,
+    expires_in_seconds: null,
+    last_refreshed_at: null,
+    next_refresh_at: null,
+    state: null,
+  };
+}
+
+const expectedMappings: Array<{
+  input: OAuthStatusValue;
+  color: OAuthDisplayStatus['color'];
+  label: string;
+  healthDotVariant: OAuthDisplayStatus['healthDotVariant'];
+  canConnect: boolean;
+  canDisconnect: boolean;
+  canRefresh: boolean;
+}> = [
+  { input: 'authenticated', color: 'green', label: 'Authenticated', healthDotVariant: 'healthy', canConnect: false, canDisconnect: true, canRefresh: true },
+  { input: 'needs_login', color: 'yellow', label: 'Needs Login', healthDotVariant: 'degraded', canConnect: true, canDisconnect: false, canRefresh: false },
+  { input: 'refreshing', color: 'blue', label: 'Refreshing', healthDotVariant: 'healthy', canConnect: false, canDisconnect: false, canRefresh: false },
+  { input: 'auth_required', color: 'orange', label: 'Auth Required', healthDotVariant: 'error', canConnect: true, canDisconnect: false, canRefresh: false },
+  { input: 'disconnected', color: 'gray', label: 'Disconnected', healthDotVariant: 'offline', canConnect: true, canDisconnect: false, canRefresh: false },
+  { input: 'connection_failed', color: 'red', label: 'Connection Failed', healthDotVariant: 'error', canConnect: false, canDisconnect: true, canRefresh: true },
+];
+
+describe('deriveOAuthDisplayStatus', () => {
+  describe.each(expectedMappings)(
+    '$input → $color / $label',
+    ({ input, color, label, healthDotVariant, canConnect, canDisconnect, canRefresh }) => {
+      const result = deriveOAuthDisplayStatus(makeStatus(input));
+
+      it(`maps to color "${color}"`, () => {
+        expect(result.color).toBe(color);
+      });
+
+      it(`maps to label "${label}"`, () => {
+        expect(result.label).toBe(label);
+      });
+
+      it(`maps to healthDotVariant "${healthDotVariant}"`, () => {
+        expect(result.healthDotVariant).toBe(healthDotVariant);
+      });
+
+      it(`canConnect = ${canConnect}`, () => {
+        expect(result.canConnect).toBe(canConnect);
+      });
+
+      it(`canDisconnect = ${canDisconnect}`, () => {
+        expect(result.canDisconnect).toBe(canDisconnect);
+      });
+
+      it(`canRefresh = ${canRefresh}`, () => {
+        expect(result.canRefresh).toBe(canRefresh);
+      });
+    },
+  );
+
+  it('returns a new object each call (no shared reference)', () => {
+    const a = deriveOAuthDisplayStatus(makeStatus('authenticated'));
+    const b = deriveOAuthDisplayStatus(makeStatus('authenticated'));
+    expect(a).toEqual(b);
+    expect(a).not.toBe(b);
+  });
+});
+

--- a/src/lib/oauth/derive-status.ts
+++ b/src/lib/oauth/derive-status.ts
@@ -1,0 +1,57 @@
+import type { OAuthStatus, OAuthStatusValue, OAuthDisplayStatus, HealthStatus } from '$lib/types';
+
+const statusMap: Record<OAuthStatusValue, OAuthDisplayStatus> = {
+  authenticated: {
+    color: 'green',
+    label: 'Authenticated',
+    healthDotVariant: 'healthy',
+    canConnect: false,
+    canDisconnect: true,
+    canRefresh: true,
+  },
+  needs_login: {
+    color: 'yellow',
+    label: 'Needs Login',
+    healthDotVariant: 'degraded',
+    canConnect: true,
+    canDisconnect: false,
+    canRefresh: false,
+  },
+  refreshing: {
+    color: 'blue',
+    label: 'Refreshing',
+    healthDotVariant: 'healthy',
+    canConnect: false,
+    canDisconnect: false,
+    canRefresh: false,
+  },
+  auth_required: {
+    color: 'orange',
+    label: 'Auth Required',
+    healthDotVariant: 'error',
+    canConnect: true,
+    canDisconnect: false,
+    canRefresh: false,
+  },
+  disconnected: {
+    color: 'gray',
+    label: 'Disconnected',
+    healthDotVariant: 'offline',
+    canConnect: true,
+    canDisconnect: false,
+    canRefresh: false,
+  },
+  connection_failed: {
+    color: 'red',
+    label: 'Connection Failed',
+    healthDotVariant: 'error',
+    canConnect: false,
+    canDisconnect: true,
+    canRefresh: true,
+  },
+};
+
+export function deriveOAuthDisplayStatus(status: OAuthStatus): OAuthDisplayStatus {
+  return { ...statusMap[status.status] };
+}
+

--- a/src/lib/oauth/oauth-status-poller.test.ts
+++ b/src/lib/oauth/oauth-status-poller.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { get } from 'svelte/store';
+import type { OAuthStatus } from '$lib/types';
+
+// Mock the api module before importing the poller
+vi.mock('$lib/api', () => ({
+  getOAuthStatus: vi.fn(),
+}));
+
+import { getOAuthStatus } from '$lib/api';
+import { oauthStatuses } from '$lib/stores';
+import { createOAuthStatusPoller } from './oauth-status-poller';
+
+const mockGetOAuthStatus = vi.mocked(getOAuthStatus);
+
+function makeOAuthStatus(status: OAuthStatus['status'] = 'authenticated'): OAuthStatus {
+  return {
+    status,
+    has_access_token: true,
+    has_refresh_token: true,
+    expires_at: null,
+    expires_in_seconds: null,
+    last_refreshed_at: null,
+    next_refresh_at: null,
+    state: null,
+  };
+}
+
+describe('createOAuthStatusPoller', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockGetOAuthStatus.mockReset();
+    oauthStatuses.set(new Map());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('calls getOAuthStatus immediately on start', async () => {
+    mockGetOAuthStatus.mockResolvedValue(makeOAuthStatus());
+    const poller = createOAuthStatusPoller('linear', 5000);
+
+    poller.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(mockGetOAuthStatus).toHaveBeenCalledWith('linear');
+    expect(mockGetOAuthStatus).toHaveBeenCalledTimes(1);
+    poller.stop();
+  });
+
+  it('polls at the specified interval', async () => {
+    mockGetOAuthStatus.mockResolvedValue(makeOAuthStatus());
+    const poller = createOAuthStatusPoller('linear', 5000);
+
+    poller.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockGetOAuthStatus).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(mockGetOAuthStatus).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(mockGetOAuthStatus).toHaveBeenCalledTimes(3);
+
+    poller.stop();
+  });
+
+  it('updates the status readable store on successful poll', async () => {
+    const expected = makeOAuthStatus('needs_login');
+    mockGetOAuthStatus.mockResolvedValue(expected);
+
+    const poller = createOAuthStatusPoller('test-ep', 1000);
+    poller.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(get(poller.status)).toEqual(expected);
+    poller.stop();
+  });
+
+  it('updates the oauthStatuses store on successful poll', async () => {
+    const expected = makeOAuthStatus('authenticated');
+    mockGetOAuthStatus.mockResolvedValue(expected);
+
+    const poller = createOAuthStatusPoller('my-endpoint', 1000);
+    poller.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const map = get(oauthStatuses);
+    expect(map.get('my-endpoint')).toEqual(expected);
+    poller.stop();
+  });
+
+  it('sets status to null on error', async () => {
+    mockGetOAuthStatus.mockRejectedValue(new Error('network error'));
+
+    const poller = createOAuthStatusPoller('broken', 1000);
+    poller.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(get(poller.status)).toBeNull();
+    poller.stop();
+  });
+
+  it('stops polling after stop() is called', async () => {
+    mockGetOAuthStatus.mockResolvedValue(makeOAuthStatus());
+    const poller = createOAuthStatusPoller('linear', 1000);
+
+    poller.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockGetOAuthStatus).toHaveBeenCalledTimes(1);
+
+    poller.stop();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(mockGetOAuthStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not start twice if start() called multiple times', async () => {
+    mockGetOAuthStatus.mockResolvedValue(makeOAuthStatus());
+    const poller = createOAuthStatusPoller('linear', 1000);
+
+    poller.start();
+    poller.start(); // second call should be no-op
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(mockGetOAuthStatus).toHaveBeenCalledTimes(1);
+    poller.stop();
+  });
+});
+

--- a/src/lib/oauth/oauth-status-poller.ts
+++ b/src/lib/oauth/oauth-status-poller.ts
@@ -1,0 +1,58 @@
+import { writable, type Readable } from 'svelte/store';
+import type { OAuthStatus } from '$lib/types';
+import { getOAuthStatus } from '$lib/api';
+import { oauthStatuses } from '$lib/stores';
+
+const DEFAULT_INTERVAL_MS = 30_000;
+
+export interface OAuthStatusPoller {
+  start: () => void;
+  stop: () => void;
+  status: Readable<OAuthStatus | null>;
+}
+
+export function createOAuthStatusPoller(
+  endpointName: string,
+  intervalMs: number = DEFAULT_INTERVAL_MS,
+): OAuthStatusPoller {
+  const status = writable<OAuthStatus | null>(null);
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let running = false;
+
+  async function poll(): Promise<void> {
+    try {
+      const result = await getOAuthStatus(endpointName);
+      status.set(result);
+      oauthStatuses.update((map) => {
+        const next = new Map(map);
+        next.set(endpointName, result);
+        return next;
+      });
+    } catch {
+      status.set(null);
+    }
+  }
+
+  function start(): void {
+    if (running) return;
+    running = true;
+    // Fire immediately, then at interval
+    poll();
+    timer = setInterval(poll, intervalMs);
+  }
+
+  function stop(): void {
+    running = false;
+    if (timer !== null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  return {
+    start,
+    stop,
+    status: { subscribe: status.subscribe },
+  };
+}
+

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -49,6 +49,16 @@ export interface OAuthStatus {
   last_refreshed_at: number | null;
   next_refresh_at: number | null;
   state: string | null;
+  transition_history?: Array<{ from: string; to: string; reason: string; ago_ms: number }>;
+}
+
+export interface OAuthDisplayStatus {
+  color: 'green' | 'yellow' | 'blue' | 'orange' | 'gray' | 'red';
+  label: string;
+  healthDotVariant: HealthStatus;
+  canConnect: boolean;
+  canDisconnect: boolean;
+  canRefresh: boolean;
 }
 
 export interface OAuthStartSuccess {


### PR DESCRIPTION
## Summary

OAuth Slice 4 desktop changes:

### New files
- `src/lib/oauth/derive-status.ts` — Maps 6 `OAuthStatusValue` variants to display properties (color, label, capabilities)
- `src/lib/oauth/oauth-status-poller.ts` — Interval-based poller for OAuth status updates
- `src/lib/oauth/derive-status.test.ts` — 37 Vitest tests for status derivation
- `src/lib/oauth/oauth-status-poller.test.ts` — 7 Vitest tests for poller behavior

### UI polish
- Tool prefix placeholder now dynamically shows `sanitizeName(name)` instead of hardcoded `my_server`
- ConfigTab Save Changes button disabled until form is dirty
- Success message clears when new edits are made
- `transition_history` field added to `OAuthStatus` type

### Tests
- 66 tests pass (22 existing + 44 new)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author