### PR TITLE
ci: fix release workflow to use tag name and add macOS signing secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,11 +83,18 @@ jobs:
           # Store the private key as a GitHub secret named TAURI_SIGNING_PRIVATE_KEY
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # macOS code signing
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
-          tagName: v__VERSION__
-          releaseName: 'Endara Desktop v__VERSION__'
+          tagName: ${{ github.ref_name }}
+          releaseName: 'Endara Desktop ${{ github.ref_name }}'
           releaseBody: 'See the assets to download and install.'
           releaseDraft: false
-          prerelease: false
+          prerelease: ${{ contains(github.ref_name, 'rc') }}
           args: --target ${{ matrix.target }}
           tauriScript: npx tauri


### PR DESCRIPTION
## Changes

- Fix release workflow to use `github.ref_name` for tag/release naming instead of `v__VERSION__`
- Add macOS code signing environment variables (Apple certificate, signing identity, notarization credentials)
- Mark releases as prerelease when tag contains `rc`

This enables proper tag-based releases and macOS code signing for the desktop app.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author