### PR TITLE
chore: update relay version default to v0.1.0-rc3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,13 @@ on:
       relay_version:
         description: 'Relay version to bundle (e.g. v0.1.0, or "latest")'
         required: false
-        default: 'latest'
+        default: 'v0.1.0-rc3'
 
 permissions:
   contents: write
 
 env:
-  RELAY_VERSION: ${{ inputs.relay_version || 'latest' }}
+  RELAY_VERSION: ${{ inputs.relay_version || 'v0.1.0-rc3' }}
 
 jobs:
   publish:


### PR DESCRIPTION
Updates the release workflow to download relay binaries from the v0.1.0-rc3 relay release (which is marked as a prerelease and won't be picked up by 'latest').

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author