### PR TITLE
ci: add Rust and npm caching to CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'npm'
       - name: Install dependencies
         run: npm ci
       - name: Svelte check
@@ -35,6 +36,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: './src-tauri -> target'
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install system dependencies
         if: runner.os == 'Linux'
         uses: awalsh128/cache-apt-pkgs-action@latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

Improve CI and release build times by adding Rust compilation caching and npm dependency caching.

### Changes

- **ci.yml**: Add `swatinem/rust-cache@v2` with `workspaces: './src-tauri -> target'`
- **ci.yml**: Add `cache: 'npm'` to `actions/setup-node@v4`
- **release.yml**: Add `cache: 'npm'` to `actions/setup-node@v4` (already had Rust caching)
- CI cache steps use `save-if` to only persist on `main` branch pushes

### Expected Impact

- CI `cargo check` on Windows: ~3.5 min → significantly faster on cache hits
- `npm ci` across all platforms: faster with cached node_modules

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author