### PR TITLE
feat: auto-match relay version from tag + enable auto-generated release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,17 +3,14 @@ on:
   push:
     tags: ['v*']
   workflow_dispatch:
-    inputs:
-      relay_version:
-        description: 'Relay version to bundle (e.g. v0.1.0, or "latest")'
-        required: false
-        default: 'v0.1.0-rc3'
 
 permissions:
   contents: write
 
 env:
-  RELAY_VERSION: ${{ inputs.relay_version || 'v0.1.0-rc3' }}
+  # For tag pushes, use the tag name (relay releases with matching version).
+  # For manual workflow_dispatch runs, fall back to 'latest'.
+  RELAY_VERSION: ${{ github.ref_name && startsWith(github.ref_name, 'v') && github.ref_name || 'latest' }}
 
 jobs:
   publish:
@@ -93,7 +90,7 @@ jobs:
         with:
           tagName: ${{ github.ref_name }}
           releaseName: 'Endara Desktop ${{ github.ref_name }}'
-          releaseBody: 'See the assets to download and install.'
+          generateReleaseNotes: true
           releaseDraft: false
           prerelease: ${{ contains(github.ref_name, 'rc') }}
           args: --target ${{ matrix.target }}


### PR DESCRIPTION
## Changes

### 1. Auto-match relay version from desktop tag
- Removed the hardcoded `relay_version` workflow_dispatch input
- `RELAY_VERSION` is now derived from `github.ref_name` for tag pushes (since relay and desktop release with matching version tags)
- Falls back to `latest` for manual `workflow_dispatch` runs where there is no tag

### 2. Enable auto-generated release notes
- Replaced the static `releaseBody` with `generateReleaseNotes: true` in the tauri-action step
- GitHub will now auto-generate release notes from merged PRs

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author