### PR TITLE
feat: dev mode port isolation with log buffering and dynamic config path

### DIFF
--- a/scripts/kill-relay.sh
+++ b/scripts/kill-relay.sh
@@ -1,14 +1,19 @@
 #!/usr/bin/env bash
 # Kill any running relay process before dev restart
 
-CONFIG="$HOME/.endara/config.toml"
-PORT=9400
+# If ENDARA_DEV_PORT is set, use it directly (dev mode port isolation)
+if [ -n "$ENDARA_DEV_PORT" ]; then
+  PORT=$ENDARA_DEV_PORT
+else
+  CONFIG="$HOME/.endara/config.toml"
+  PORT=9400
 
-# Try to read port from config
-if [ -f "$CONFIG" ]; then
-  PARSED_PORT=$(grep -A5 '\[relay\]' "$CONFIG" | grep '^port' | head -1 | sed 's/.*= *//' | tr -d ' ')
-  if [ -n "$PARSED_PORT" ] && [ "$PARSED_PORT" -gt 0 ] 2>/dev/null; then
-    PORT=$PARSED_PORT
+  # Try to read port from config
+  if [ -f "$CONFIG" ]; then
+    PARSED_PORT=$(grep -A5 '\[relay\]' "$CONFIG" | grep '^port' | head -1 | sed 's/.*= *//' | tr -d ' ')
+    if [ -n "$PARSED_PORT" ] && [ "$PARSED_PORT" -gt 0 ] 2>/dev/null; then
+      PORT=$PARSED_PORT
+    fi
   fi
 fi
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,16 +29,45 @@ fn set_macos_activation_policy(regular: bool) {
     app.setActivationPolicy(policy);
 }
 
+/// Dev-mode data directory name (relative to home).
+const DEV_DATA_DIR_NAME: &str = ".endara-dev";
+
+/// Default relay port for dev mode.
+const DEV_RELAY_PORT: u16 = 9500;
+
+/// Default relay port for production.
+const DEFAULT_RELAY_PORT: u16 = 9400;
+
+/// Returns `true` when running in dev mode.
+///
+/// Dev mode is detected via `cfg!(debug_assertions)` (true during `cargo tauri dev`,
+/// false in release builds) **or** when the `ENDARA_DATA_DIR` env var is set.
+fn is_dev_mode() -> bool {
+    cfg!(debug_assertions) || std::env::var("ENDARA_DATA_DIR").is_ok()
+}
+
+/// Returns the base data directory: `~/.endara-dev` in dev mode, `~/.endara` in production.
+fn data_dir() -> Result<std::path::PathBuf, String> {
+    let home = dirs::home_dir().ok_or_else(|| "Could not determine home directory".to_string())?;
+    if is_dev_mode() {
+        Ok(home.join(DEV_DATA_DIR_NAME))
+    } else {
+        Ok(home.join(".endara"))
+    }
+}
+
 /// Check if a port is already in use by attempting a TCP connection.
 fn is_port_in_use(port: u16) -> bool {
     let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
     std::net::TcpStream::connect_timeout(&addr, std::time::Duration::from_millis(500)).is_ok()
 }
 
-/// Read the relay port from ~/.endara/config.toml [relay] section.
+/// Read the relay port from config.toml [relay] section.
+/// Uses the dev or production data directory based on `is_dev_mode()`.
 /// Returns None if the file doesn't exist, can't be parsed, or has no port setting.
 fn read_port_from_config() -> Option<u16> {
-    let config_path = dirs::home_dir()?.join(".endara").join("config.toml");
+    let dir = data_dir().ok()?;
+    let config_path = dir.join("config.toml");
     let contents = std::fs::read_to_string(&config_path).ok()?;
     let parsed: toml::Table = contents.parse().ok()?;
     parsed
@@ -72,11 +101,9 @@ fn strip_ansi(s: &str) -> String {
     result
 }
 
-/// Return the path to `~/.endara/config.toml`.
+/// Return the path to config.toml in the appropriate data directory.
 fn config_path() -> Result<std::path::PathBuf, String> {
-    dirs::home_dir()
-        .map(|h| h.join(".endara").join("config.toml"))
-        .ok_or_else(|| "Could not determine home directory".to_string())
+    data_dir().map(|d| d.join("config.toml"))
 }
 
 /// Read and parse `~/.endara/config.toml`, returning `Err` if the file is missing or invalid.
@@ -85,8 +112,8 @@ fn read_config() -> Result<toml::Table, String> {
     if !path.exists() {
         return Err("Config file not found".to_string());
     }
-    let contents = std::fs::read_to_string(&path)
-        .map_err(|e| format!("Failed to read config: {e}"))?;
+    let contents =
+        std::fs::read_to_string(&path).map_err(|e| format!("Failed to read config: {e}"))?;
     contents
         .parse()
         .map_err(|e| format!("Failed to parse config: {e}"))
@@ -95,10 +122,9 @@ fn read_config() -> Result<toml::Table, String> {
 /// Serialize and write a `toml::Table` back to `~/.endara/config.toml`.
 fn write_config(table: &toml::Table) -> Result<(), String> {
     let path = config_path()?;
-    let new_contents = toml::to_string_pretty(table)
-        .map_err(|e| format!("Failed to serialize config: {e}"))?;
-    std::fs::write(&path, &new_contents)
-        .map_err(|e| format!("Failed to write config: {e}"))
+    let new_contents =
+        toml::to_string_pretty(table).map_err(|e| format!("Failed to serialize config: {e}"))?;
+    std::fs::write(&path, &new_contents).map_err(|e| format!("Failed to write config: {e}"))
 }
 
 /// Holds the relay sidecar child process handle.
@@ -111,6 +137,7 @@ pub struct RelayState {
     port: Arc<Mutex<u16>>,
     last_sidecar_status: Arc<Mutex<String>>,
     last_sidecar_error: Arc<Mutex<Option<String>>>,
+    log_buffer: Arc<Mutex<Vec<RelayLogPayload>>>,
 }
 
 #[derive(Serialize, Clone)]
@@ -178,14 +205,17 @@ async fn spawn_relay(
     port: u16,
 ) -> Result<tauri_plugin_shell::process::CommandChild, String> {
     let config_file = config_path()?;
+    let base_dir = data_dir()?;
 
     // Ensure log directory exists for relay file logging
-    if let Some(home) = dirs::home_dir() {
-        let log_dir = home.join(".endara").join("logs");
-        let _ = std::fs::create_dir_all(&log_dir);
-    }
+    let log_dir = base_dir.join("logs");
+    let _ = std::fs::create_dir_all(&log_dir);
 
-    eprintln!("[relay] attempting to spawn sidecar with config: {:?}, port: {}", config_file, port);
+    let dev = is_dev_mode();
+    eprintln!(
+        "[relay] attempting to spawn sidecar (dev={}) with config: {:?}, port: {}",
+        dev, config_file, port
+    );
 
     // Pre-flight port conflict check
     if is_port_in_use(port) {
@@ -199,6 +229,19 @@ async fn spawn_relay(
     emit_sidecar_status(app, "starting", None).await;
 
     let port_str = port.to_string();
+    let config_lossy = config_file.to_string_lossy().to_string();
+    let data_dir_lossy = base_dir.to_string_lossy().to_string();
+
+    // Build sidecar args — in dev mode use --data-dir (without --config) so
+    // the relay derives its config path from data-dir and performs the
+    // first-run config copy from production.  In production mode pass
+    // --config explicitly.
+    let sidecar_args: Vec<&str> = if dev {
+        vec!["start", "--data-dir", &data_dir_lossy, "--port", &port_str]
+    } else {
+        vec!["start", "--config", &config_lossy, "--port", &port_str]
+    };
+
     let (mut rx, child) = app
         .shell()
         .sidecar("endara-relay")
@@ -206,7 +249,7 @@ async fn spawn_relay(
             eprintln!("[relay] FAILED to create sidecar command: {e}");
             format!("Failed to create sidecar command: {e}")
         })?
-        .args(["start", "--config", &config_file.to_string_lossy(), "--port", &port_str])
+        .args(&sidecar_args)
         .spawn()
         .map_err(|e| {
             eprintln!("[relay] FAILED to spawn relay sidecar: {e}");
@@ -226,10 +269,24 @@ async fn spawn_relay(
                     if text.contains("MCP server running") {
                         emit_sidecar_status(&app_handle, "running", None).await;
                     }
-                    let _ = app_handle.emit("relay-log", RelayLogPayload {
-                        level: "info".to_string(),
-                        message: text,
-                    });
+                    if let Some(state) = app_handle.try_state::<RelayState>() {
+                        let mut buf = state.log_buffer.lock().await;
+                        buf.push(RelayLogPayload {
+                            level: "info".to_string(),
+                            message: text.clone(),
+                        });
+                        let len = buf.len();
+                        if len > 5000 {
+                            buf.drain(..len - 5000);
+                        }
+                    }
+                    let _ = app_handle.emit(
+                        "relay-log",
+                        RelayLogPayload {
+                            level: "info".to_string(),
+                            message: text,
+                        },
+                    );
                 }
                 CommandEvent::Stderr(line) => {
                     let text = strip_ansi(&String::from_utf8_lossy(&line));
@@ -244,18 +301,37 @@ async fn spawn_relay(
                     if text.contains("MCP server running") {
                         emit_sidecar_status(&app_handle, "running", None).await;
                     }
-                    let _ = app_handle.emit("relay-log", RelayLogPayload {
-                        level: level.to_string(),
-                        message: text.clone(),
-                    });
+                    if let Some(state) = app_handle.try_state::<RelayState>() {
+                        let mut buf = state.log_buffer.lock().await;
+                        buf.push(RelayLogPayload {
+                            level: level.to_string(),
+                            message: text.clone(),
+                        });
+                        let len = buf.len();
+                        if len > 5000 {
+                            buf.drain(..len - 5000);
+                        }
+                    }
+                    let _ = app_handle.emit(
+                        "relay-log",
+                        RelayLogPayload {
+                            level: level.to_string(),
+                            message: text.clone(),
+                        },
+                    );
                     // Emit relay-health event for ERROR lines
                     if level == "error" {
-                        let _ = app_handle.emit("relay-health", RelayHealthPayload {
-                            status: "error".to_string(),
-                            message: Some(text.clone()),
-                        });
+                        let _ = app_handle.emit(
+                            "relay-health",
+                            RelayHealthPayload {
+                                status: "error".to_string(),
+                                message: Some(text.clone()),
+                            },
+                        );
                         // Emit sidecar failed status for critical errors
-                        if text.contains("Failed to start HTTP server") || text.contains("Address already in use") {
+                        if text.contains("Failed to start HTTP server")
+                            || text.contains("Address already in use")
+                        {
                             emit_sidecar_status(&app_handle, "failed", Some(text.clone())).await;
                         }
                     }
@@ -273,10 +349,16 @@ async fn spawn_relay(
                         *state.child.lock().await = None;
                     }
                     // Emit relay-health event for termination
-                    let _ = app_handle.emit("relay-health", RelayHealthPayload {
-                        status: "disconnected".to_string(),
-                        message: Some(format!("Process terminated (code: {:?}, signal: {:?})", code, signal)),
-                    });
+                    let _ = app_handle.emit(
+                        "relay-health",
+                        RelayHealthPayload {
+                            status: "disconnected".to_string(),
+                            message: Some(format!(
+                                "Process terminated (code: {:?}, signal: {:?})",
+                                code, signal
+                            )),
+                        },
+                    );
 
                     // Emit sidecar lifecycle status based on exit code
                     let exited_cleanly = code == Some(0) || (code.is_none() && signal.is_some());
@@ -286,8 +368,12 @@ async fn spawn_relay(
                         emit_sidecar_status(
                             &app_handle,
                             "failed",
-                            Some(format!("Process exited with code: {:?}, signal: {:?}", code, signal)),
-                        ).await;
+                            Some(format!(
+                                "Process exited with code: {:?}, signal: {:?}",
+                                code, signal
+                            )),
+                        )
+                        .await;
                     }
                     break;
                 }
@@ -328,7 +414,9 @@ async fn stop_relay(state: State<'_, RelayState>) -> Result<RelayStatusInfo, Str
     }
     let mut child_guard = state.child.lock().await;
     if let Some(child) = child_guard.take() {
-        child.kill().map_err(|e| format!("Failed to kill relay: {e}"))?;
+        child
+            .kill()
+            .map_err(|e| format!("Failed to kill relay: {e}"))?;
     }
     *state.running.lock().await = false;
     Ok(RelayStatusInfo { running: false })
@@ -380,6 +468,28 @@ async fn get_sidecar_status(
 }
 
 #[tauri::command]
+async fn get_config_path_display() -> Result<String, String> {
+    let path = config_path()?;
+    if let Some(home) = dirs::home_dir() {
+        let path_str = path.to_string_lossy();
+        let home_str = home.to_string_lossy();
+        if path_str.starts_with(home_str.as_ref()) {
+            return Ok(format!("~{}", &path_str[home_str.len()..]));
+        }
+    }
+    Ok(path.to_string_lossy().to_string())
+}
+
+#[tauri::command]
+async fn get_buffered_relay_logs(
+    state: State<'_, RelayState>,
+) -> Result<Vec<RelayLogPayload>, String> {
+    let mut buf = state.log_buffer.lock().await;
+    let logs = buf.drain(..).collect();
+    Ok(logs)
+}
+
+#[tauri::command]
 async fn get_relay_port(state: State<'_, RelayState>) -> Result<u16, String> {
     Ok(*state.port.lock().await)
 }
@@ -393,10 +503,7 @@ async fn set_relay_port(port: u16, state: State<'_, RelayState>) -> Result<(), S
 
     // Set port in the [relay] section
     if let Some(relay) = table.get_mut("relay").and_then(|v| v.as_table_mut()) {
-        relay.insert(
-            "port".to_string(),
-            toml::Value::Integer(port as i64),
-        );
+        relay.insert("port".to_string(), toml::Value::Integer(port as i64));
     } else {
         return Err("Missing [relay] section in config".to_string());
     }
@@ -464,27 +571,64 @@ async fn get_endpoint_config(name: String) -> Result<EndpointConfig, String> {
     if let Some(toml::Value::Array(endpoints)) = parsed.get("endpoints") {
         for ep in endpoints {
             if ep.get("name").and_then(|v| v.as_str()) == Some(&name) {
-                let transport = ep.get("transport").and_then(|v| v.as_str()).unwrap_or("stdio").to_string();
-                let command = ep.get("command").and_then(|v| v.as_str()).map(|s| s.to_string());
+                let transport = ep
+                    .get("transport")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("stdio")
+                    .to_string();
+                let command = ep
+                    .get("command")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
                 let args = ep.get("args").and_then(|v| v.as_array()).map(|arr| {
-                    arr.iter().filter_map(|v| v.as_str().map(|s| s.to_string())).collect()
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                        .collect()
                 });
-                let url = ep.get("url").and_then(|v| v.as_str()).map(|s| s.to_string());
-                let tool_prefix = ep.get("tool_prefix").and_then(|v| v.as_str()).map(|s| s.to_string());
-                let description = ep.get("description").and_then(|v| v.as_str()).map(|s| s.to_string());
+                let url = ep
+                    .get("url")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                let tool_prefix = ep
+                    .get("tool_prefix")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                let description = ep
+                    .get("description")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
                 let env = ep.get("env").and_then(|v| v.as_table()).map(|t| {
-                    t.iter().map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string())).collect()
+                    t.iter()
+                        .map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string()))
+                        .collect()
                 });
                 let headers = ep.get("headers").and_then(|v| v.as_table()).map(|t| {
-                    t.iter().map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string())).collect()
+                    t.iter()
+                        .map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string()))
+                        .collect()
                 });
-                let oauth_server_url = ep.get("oauth_server_url").and_then(|v| v.as_str()).map(|s| s.to_string());
-                let client_id = ep.get("client_id").and_then(|v| v.as_str()).map(|s| s.to_string());
-                let client_secret = ep.get("client_secret").and_then(|v| v.as_str()).map(|s| s.to_string());
+                let oauth_server_url = ep
+                    .get("oauth_server_url")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                let client_id = ep
+                    .get("client_id")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                let client_secret = ep
+                    .get("client_secret")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
                 let scopes = ep.get("scopes").and_then(|v| v.as_array()).map(|arr| {
-                    arr.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>().join(" ")
+                    arr.iter()
+                        .filter_map(|v| v.as_str())
+                        .collect::<Vec<_>>()
+                        .join(" ")
                 });
-                let token_endpoint = ep.get("token_endpoint").and_then(|v| v.as_str()).map(|s| s.to_string());
+                let token_endpoint = ep
+                    .get("token_endpoint")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
 
                 return Ok(EndpointConfig {
                     name: name.clone(),
@@ -553,23 +697,35 @@ async fn update_endpoint(args: UpdateEndpointArgs) -> Result<(), String> {
                 // Clear old fields and set new ones
                 table.clear();
                 table.insert("name".to_string(), toml::Value::String(args.name.clone()));
-                table.insert("transport".to_string(), toml::Value::String(args.transport.clone()));
+                table.insert(
+                    "transport".to_string(),
+                    toml::Value::String(args.transport.clone()),
+                );
                 if let Some(tool_prefix) = &args.tool_prefix {
-                    table.insert("tool_prefix".to_string(), toml::Value::String(tool_prefix.clone()));
+                    table.insert(
+                        "tool_prefix".to_string(),
+                        toml::Value::String(tool_prefix.clone()),
+                    );
                 }
 
                 if let Some(cmd) = &args.command {
                     table.insert("command".to_string(), toml::Value::String(cmd.clone()));
                 }
                 if let Some(cmd_args) = &args.args {
-                    let arr: Vec<toml::Value> = cmd_args.iter().map(|a| toml::Value::String(a.clone())).collect();
+                    let arr: Vec<toml::Value> = cmd_args
+                        .iter()
+                        .map(|a| toml::Value::String(a.clone()))
+                        .collect();
                     table.insert("args".to_string(), toml::Value::Array(arr));
                 }
                 if let Some(url) = &args.url {
                     table.insert("url".to_string(), toml::Value::String(url.clone()));
                 }
                 if let Some(description) = &args.description {
-                    table.insert("description".to_string(), toml::Value::String(description.clone()));
+                    table.insert(
+                        "description".to_string(),
+                        toml::Value::String(description.clone()),
+                    );
                 }
                 if let Some(env) = &args.env {
                     if !env.is_empty() {
@@ -590,16 +746,26 @@ async fn update_endpoint(args: UpdateEndpointArgs) -> Result<(), String> {
                     }
                 }
                 if let Some(oauth_server_url) = &args.oauth_server_url {
-                    table.insert("oauth_server_url".to_string(), toml::Value::String(oauth_server_url.clone()));
+                    table.insert(
+                        "oauth_server_url".to_string(),
+                        toml::Value::String(oauth_server_url.clone()),
+                    );
                 }
                 if let Some(client_id) = &args.client_id {
-                    table.insert("client_id".to_string(), toml::Value::String(client_id.clone()));
+                    table.insert(
+                        "client_id".to_string(),
+                        toml::Value::String(client_id.clone()),
+                    );
                 }
                 if let Some(client_secret) = &args.client_secret {
-                    table.insert("client_secret".to_string(), toml::Value::String(client_secret.clone()));
+                    table.insert(
+                        "client_secret".to_string(),
+                        toml::Value::String(client_secret.clone()),
+                    );
                 }
                 if let Some(scopes) = &args.scopes {
-                    let arr: Vec<toml::Value> = scopes.split_whitespace()
+                    let arr: Vec<toml::Value> = scopes
+                        .split_whitespace()
                         .map(|s| toml::Value::String(s.to_string()))
                         .collect();
                     if !arr.is_empty() {
@@ -607,7 +773,10 @@ async fn update_endpoint(args: UpdateEndpointArgs) -> Result<(), String> {
                     }
                 }
                 if let Some(token_endpoint) = &args.token_endpoint {
-                    table.insert("token_endpoint".to_string(), toml::Value::String(token_endpoint.clone()));
+                    table.insert(
+                        "token_endpoint".to_string(),
+                        toml::Value::String(token_endpoint.clone()),
+                    );
                 }
                 break;
             }
@@ -627,8 +796,7 @@ async fn add_endpoint(args: AddEndpointArgs) -> Result<(), String> {
 
     // Read existing config or create default
     let contents = if path.exists() {
-        std::fs::read_to_string(&path)
-            .map_err(|e| format!("Failed to read config: {e}"))?
+        std::fs::read_to_string(&path).map_err(|e| format!("Failed to read config: {e}"))?
     } else {
         // Create parent directory if needed
         if let Some(parent) = path.parent() {
@@ -697,16 +865,23 @@ async fn add_endpoint(args: AddEndpointArgs) -> Result<(), String> {
         }
     }
     if let Some(oauth_server_url) = args.oauth_server_url {
-        endpoint.insert("oauth_server_url".to_string(), toml::Value::String(oauth_server_url));
+        endpoint.insert(
+            "oauth_server_url".to_string(),
+            toml::Value::String(oauth_server_url),
+        );
     }
     if let Some(client_id) = args.client_id {
         endpoint.insert("client_id".to_string(), toml::Value::String(client_id));
     }
     if let Some(client_secret) = args.client_secret {
-        endpoint.insert("client_secret".to_string(), toml::Value::String(client_secret));
+        endpoint.insert(
+            "client_secret".to_string(),
+            toml::Value::String(client_secret),
+        );
     }
     if let Some(scopes) = args.scopes {
-        let arr: Vec<toml::Value> = scopes.split_whitespace()
+        let arr: Vec<toml::Value> = scopes
+            .split_whitespace()
             .map(|s| toml::Value::String(s.to_string()))
             .collect();
         if !arr.is_empty() {
@@ -714,7 +889,10 @@ async fn add_endpoint(args: AddEndpointArgs) -> Result<(), String> {
         }
     }
     if let Some(token_endpoint) = args.token_endpoint {
-        endpoint.insert("token_endpoint".to_string(), toml::Value::String(token_endpoint));
+        endpoint.insert(
+            "token_endpoint".to_string(),
+            toml::Value::String(token_endpoint),
+        );
     }
 
     let endpoints = parsed
@@ -755,18 +933,27 @@ pub fn run() {
         child: Arc::new(Mutex::new(None)),
         pid: Arc::new(std::sync::Mutex::new(None)),
         running: Arc::new(Mutex::new(false)),
-        port: Arc::new(Mutex::new(read_port_from_config().unwrap_or(9400))),
+        port: Arc::new(Mutex::new(read_port_from_config().unwrap_or(
+            if is_dev_mode() {
+                DEV_RELAY_PORT
+            } else {
+                DEFAULT_RELAY_PORT
+            },
+        ))),
         last_sidecar_status: Arc::new(Mutex::new("unknown".to_string())),
         last_sidecar_error: Arc::new(Mutex::new(None)),
+        log_buffer: Arc::new(Mutex::new(Vec::new())),
     };
 
     let child_handle = relay_state.child.clone();
     let pid_handle = relay_state.pid.clone();
 
     tauri::Builder::default()
-        .plugin(tauri_plugin_log::Builder::new()
-            .level(log::LevelFilter::Info)
-            .build())
+        .plugin(
+            tauri_plugin_log::Builder::new()
+                .level(log::LevelFilter::Info)
+                .build(),
+        )
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
@@ -787,16 +974,20 @@ pub fn run() {
             get_relay_port,
             set_relay_port,
             set_js_execution_mode,
+            get_config_path_display,
+            get_buffered_relay_logs,
         ])
         .setup(|app| {
             // Build tray menu
             let status_item =
                 MenuItem::with_id(app, "status", "Endara — Running", false, None::<&str>)?;
             let open_item = MenuItem::with_id(app, "open", "Open Endara", true, None::<&str>)?;
-            let update_item = MenuItem::with_id(app, "check_update", "Check for Updates", true, None::<&str>)?;
+            let update_item =
+                MenuItem::with_id(app, "check_update", "Check for Updates", true, None::<&str>)?;
             let quit_item = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
 
-            let menu = Menu::with_items(app, &[&status_item, &open_item, &update_item, &quit_item])?;
+            let menu =
+                Menu::with_items(app, &[&status_item, &open_item, &update_item, &quit_item])?;
 
             let _tray = TrayIconBuilder::new()
                 .icon(app.default_window_icon().unwrap().clone())
@@ -831,7 +1022,9 @@ pub fn run() {
                                 if let Some(pid) = pid_guard.take() {
                                     eprintln!("[relay] killing sidecar pid {} on tray quit", pid);
                                     #[cfg(unix)]
-                                    unsafe { libc::kill(pid as i32, libc::SIGTERM); }
+                                    unsafe {
+                                        libc::kill(pid as i32, libc::SIGTERM);
+                                    }
                                 }
                             }
                             // Also kill via child handle as fallback
@@ -854,8 +1047,10 @@ pub fn run() {
             tauri::async_runtime::spawn(async move {
                 let port = if let Some(state) = app_handle.try_state::<RelayState>() {
                     *state.port.lock().await
+                } else if is_dev_mode() {
+                    DEV_RELAY_PORT
                 } else {
-                    9400
+                    DEFAULT_RELAY_PORT
                 };
                 match spawn_relay(&app_handle, port).await {
                     Ok(child) => {
@@ -900,7 +1095,9 @@ pub fn run() {
                         if let Some(pid) = guard.take() {
                             eprintln!("[relay] killing sidecar pid {} on app exit", pid);
                             #[cfg(unix)]
-                            unsafe { libc::kill(pid as i32, libc::SIGTERM); }
+                            unsafe {
+                                libc::kill(pid as i32, libc::SIGTERM);
+                            }
                         }
                     }
                     // Also try the async child.kill() as fallback, in a separate thread
@@ -915,7 +1112,8 @@ pub fn run() {
                                 }
                             });
                         }
-                    }).join();
+                    })
+                    .join();
                 }
                 _ => {}
             }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "identifier": "ai.endara.desktop",
   "build": {
-    "beforeDevCommand": "bash scripts/kill-relay.sh; npm run dev",
+    "beforeDevCommand": "ENDARA_DEV_PORT=9500 bash scripts/kill-relay.sh; npm run dev",
     "devUrl": "http://localhost:1420",
     "beforeBuildCommand": "npm run build",
     "frontendDist": "../build"

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -10,6 +10,7 @@
   let portInput: number = $state($relayPort);
   let portSaved = $state(false);
   let portError = $state<string | null>(null);
+  let configFilePath = $state('~/.endara/config.toml');
 
   async function savePort() {
     const port = Math.floor(portInput);
@@ -31,7 +32,7 @@
   const connectionItems = $derived([
     { label: 'MCP Endpoint', value: `http://localhost:${$relayPort}/mcp` },
     { label: 'SSE Endpoint', value: `http://localhost:${$relayPort}/mcp/sse` },
-    { label: 'Config File', value: '~/.endara/config.toml' },
+    { label: 'Config File', value: configFilePath },
   ]);
 
   let copiedIndex: number | null = $state(null);
@@ -106,6 +107,7 @@
     } catch (e) {
       console.error('Failed to get build info:', e);
     }
+    invoke('get_config_path_display').then((p: unknown) => { if (typeof p === 'string') configFilePath = p; }).catch(() => {});
     fetchRelayStatus();
     fetchJsExecutionMode();
     statusPollInterval = setInterval(fetchRelayStatus, 5000);

--- a/src/lib/logListener.ts
+++ b/src/lib/logListener.ts
@@ -54,6 +54,24 @@ export async function initRelayLogListener() {
 
   await Promise.allSettled(listenerRegistrations);
 
+  // Replay any buffered logs that arrived before the listener was ready
+  try {
+    const buffered = await invoke<Array<{ level: string; message: string }>>('get_buffered_relay_logs');
+    if (buffered && buffered.length > 0) {
+      const lines: RelayLogLine[] = buffered.map(entry => ({
+        timestamp: new Date().toLocaleTimeString(),
+        level: (entry.level as RelayLogLine['level']) || 'info',
+        message: entry.message,
+      }));
+      relayLogLines.update(existing => {
+        const merged = [...lines, ...existing];
+        return merged.length > 5000 ? merged.slice(-5000) : merged;
+      });
+    }
+  } catch (e) {
+    console.error('Failed to get buffered relay logs:', e);
+  }
+
   try {
     const { status, error } = await invoke<RelaySidecarStatusSnapshot>('get_sidecar_status');
     applySidecarStatus(status, error);


### PR DESCRIPTION
Isolates dev mode relay from production by using a separate data directory (`~/.endara-dev`) and port (9500).

Changes:
- `is_dev_mode()` detection via `cfg!(debug_assertions)` or `ENDARA_DATA_DIR` env var
- Dev mode uses `~/.endara-dev` data dir and port 9500 (vs `~/.endara` and 9400 in production)
- Sidecar launched with `--data-dir` in dev mode (no `--config`) to enable first-run config copy from production
- `kill-relay.sh` respects `ENDARA_DEV_PORT` env var; `beforeDevCommand` hardcodes it for `cargo tauri dev`
- New `get_config_path_display` command for dynamic config path in Settings UI
- Relay log buffering: early sidecar output is buffered in `RelayState` and replayed when the frontend mounts, fixing missing startup logs

Depends on: endara-ai/endara-relay PR (--data-dir flag)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author