### PR TITLE
feat: add auto-start on login with minimized launch support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",
+        "@tauri-apps/plugin-autostart": "^2.5.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",
         "@tauri-apps/plugin-opener": "^2",
         "@tauri-apps/plugin-process": "^2.3.1",
@@ -1488,6 +1489,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-autostart": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-autostart/-/plugin-autostart-2.5.1.tgz",
+      "integrity": "sha512-zS/xx7yzveCcotkA+8TqkI2lysmG2wvQXv2HGAVExITmnFfHAdj1arGsbbfs3o6EktRHf6l34pJxc3YGG2mg7w==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@tauri-apps/plugin-dialog": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-autostart": "^2.5.1",
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-process": "^2.3.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -251,6 +251,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +855,15 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
@@ -858,6 +878,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -992,7 +1023,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.12+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -1024,6 +1055,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-dialog",
  "tauri-plugin-log",
  "tauri-plugin-opener",
@@ -4443,6 +4475,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6040,6 +6086,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ toml = "0.8"
 hostname = "0.4"
 tauri-plugin-log = "2.8.0"
 tauri-plugin-dialog = "2.6.0"
+tauri-plugin-autostart = "2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.4"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -29,6 +29,7 @@
     "shell:allow-kill",
     "updater:default",
     "process:default",
-    "dialog:default"
+    "dialog:default",
+    "autostart:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -927,6 +927,36 @@ async fn remove_endpoint(name: String) -> Result<(), String> {
     write_config(&parsed)
 }
 
+/// Check if autostart is enabled.
+#[tauri::command]
+fn get_autostart(app: AppHandle) -> Result<bool, String> {
+    use tauri_plugin_autostart::ManagerExt;
+    app.autolaunch()
+        .is_enabled()
+        .map_err(|e| format!("Failed to check autostart: {e}"))
+}
+
+/// Enable or disable autostart.
+#[tauri::command]
+fn set_autostart(app: AppHandle, enabled: bool) -> Result<(), String> {
+    use tauri_plugin_autostart::ManagerExt;
+    let manager = app.autolaunch();
+    if enabled {
+        manager
+            .enable()
+            .map_err(|e| format!("Failed to enable autostart: {e}"))
+    } else {
+        manager
+            .disable()
+            .map_err(|e| format!("Failed to disable autostart: {e}"))
+    }
+}
+
+/// Check if app was started with the autostart flag.
+fn is_autostarted() -> bool {
+    std::env::args().any(|arg| arg == "--autostarted")
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let relay_state = RelayState {
@@ -959,6 +989,12 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_shell::init())
+        .plugin(
+            tauri_plugin_autostart::Builder::new()
+                .macos_launcher(tauri_plugin_autostart::MacosLauncher::LaunchAgent)
+                .args(["--autostarted"])
+                .build(),
+        )
         .manage(relay_state)
         .invoke_handler(tauri::generate_handler![
             start_relay,
@@ -976,6 +1012,8 @@ pub fn run() {
             set_js_execution_mode,
             get_config_path_display,
             get_buffered_relay_logs,
+            get_autostart,
+            set_autostart,
         ])
         .setup(|app| {
             // Build tray menu
@@ -1069,9 +1107,20 @@ pub fn run() {
                 }
             });
 
-            // Ensure app appears in Cmd-Tab on startup
-            #[cfg(target_os = "macos")]
-            set_macos_activation_policy(true);
+            // Handle autostarted launch: hide window and set accessory mode
+            if is_autostarted() {
+                // Hide the window when auto-launched
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.hide();
+                }
+                // Set accessory mode (no Dock icon, no Cmd-Tab)
+                #[cfg(target_os = "macos")]
+                set_macos_activation_policy(false);
+            } else {
+                // Normal launch: ensure app appears in Cmd-Tab on startup
+                #[cfg(target_os = "macos")]
+                set_macos_activation_policy(true);
+            }
 
             Ok(())
         })

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -989,12 +989,13 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_shell::init())
-        .plugin(
-            tauri_plugin_autostart::Builder::new()
-                .macos_launcher(tauri_plugin_autostart::MacosLauncher::LaunchAgent)
-                .args(["--autostarted"])
-                .build(),
-        )
+        .plugin({
+            let builder = tauri_plugin_autostart::Builder::new().args(["--autostarted"]);
+            #[cfg(target_os = "macos")]
+            let builder =
+                builder.macos_launcher(tauri_plugin_autostart::MacosLauncher::LaunchAgent);
+            builder.build()
+        })
         .manage(relay_state)
         .invoke_handler(tauri::generate_handler![
             start_relay,

--- a/src/lib/components/Onboarding.svelte
+++ b/src/lib/components/Onboarding.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { relayPort } from '$lib/stores';
+  import { invoke } from '@tauri-apps/api/core';
+  import { onMount } from 'svelte';
   import AddEndpointModal from './AddEndpointModal.svelte';
 
   const RELAY_MCP_URL = $derived(`http://localhost:${$relayPort}/mcp`);
@@ -12,6 +14,28 @@
     navigator.clipboard.writeText(text);
     copied = true;
     setTimeout(() => copied = false, 2000);
+  }
+
+  let autostart = $state(false);
+
+  onMount(async () => {
+    try {
+      autostart = await invoke<boolean>('get_autostart');
+    } catch (e) {
+      console.error('Failed to get autostart state:', e);
+    }
+  });
+
+  async function toggleAutostart() {
+    const newValue = !autostart;
+    autostart = newValue;
+    try {
+      await invoke('set_autostart', { enabled: newValue });
+    } catch (e) {
+      // Revert on failure
+      autostart = !newValue;
+      console.error('Failed to set autostart:', e);
+    }
   }
 </script>
 
@@ -50,6 +74,25 @@
     >
       Add Your First Server
     </button>
+
+    <!-- Autostart toggle -->
+    <div class="rounded-lg border border-(--color-border) bg-(--color-surface-alt) p-4">
+      <div class="flex items-start justify-between gap-4">
+        <div>
+          <div class="text-sm font-medium text-(--color-text)">Start on Login</div>
+          <div class="text-xs text-(--color-text-secondary) mt-0.5">Automatically start Endara Desktop when you log in to your computer.</div>
+        </div>
+        <button
+          class="shrink-0 relative w-10 h-5 rounded-full transition-colors {autostart ? 'bg-green-500' : 'bg-gray-300 dark:bg-gray-600'}"
+          onclick={() => toggleAutostart()}
+          role="switch"
+          aria-checked={autostart}
+          aria-label="Toggle start on login"
+        >
+          <span class="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform {autostart ? 'translate-x-5' : ''}"></span>
+        </button>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -11,6 +11,7 @@
   let portSaved = $state(false);
   let portError = $state<string | null>(null);
   let configFilePath = $state('~/.endara/config.toml');
+  let autoStartEnabled = $state(false);
 
   async function savePort() {
     const port = Math.floor(portInput);
@@ -89,6 +90,26 @@
     }
   }
 
+  async function toggleAutoStart() {
+    const newValue = !autoStartEnabled;
+    autoStartEnabled = newValue;
+    try {
+      await invoke('set_autostart', { enabled: newValue });
+    } catch (e) {
+      // Revert on failure
+      autoStartEnabled = !newValue;
+      console.error('Failed to set autostart:', e);
+    }
+  }
+
+  async function fetchAutoStart() {
+    try {
+      autoStartEnabled = await invoke<boolean>('get_autostart');
+    } catch (e) {
+      console.error('Failed to get autostart:', e);
+    }
+  }
+
   async function fetchJsExecutionMode() {
     try {
       const config = await getConfig();
@@ -110,6 +131,7 @@
     invoke('get_config_path_display').then((p: unknown) => { if (typeof p === 'string') configFilePath = p; }).catch(() => {});
     fetchRelayStatus();
     fetchJsExecutionMode();
+    fetchAutoStart();
     statusPollInterval = setInterval(fetchRelayStatus, 5000);
   });
 
@@ -246,6 +268,22 @@
         aria-label="Toggle JS execution mode"
       >
         <span class="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform {$jsExecutionMode ? 'translate-x-5' : ''}"></span>
+      </button>
+    </div>
+
+    <div class="flex items-start justify-between gap-4">
+      <div>
+        <div class="text-sm font-medium">Start on Login</div>
+        <div class="text-xs text-(--color-text-secondary) mt-0.5">Automatically start Endara Desktop when you log in to your computer.</div>
+      </div>
+      <button
+        class="shrink-0 relative w-10 h-5 rounded-full transition-colors {autoStartEnabled ? 'bg-green-500' : 'bg-gray-300 dark:bg-gray-600'}"
+        onclick={() => toggleAutoStart()}
+        role="switch"
+        aria-checked={autoStartEnabled}
+        aria-label="Toggle start on login"
+      >
+        <span class="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform {autoStartEnabled ? 'translate-x-5' : ''}"></span>
       </button>
     </div>
 


### PR DESCRIPTION
## Summary
Add a "Start on Login" toggle to both the Settings page and Onboarding screen. When enabled, the app registers to auto-launch when the user logs in.

### Changes
- **Backend**: Added `tauri-plugin-autostart` with `get_autostart`/`set_autostart` Tauri commands
- **Minimized launch**: When auto-launched (via `--autostarted` CLI flag), the app starts hidden in the tray instead of showing the window
- **Settings UI**: "Start on Login" toggle between JS Execution Mode and Connection Info sections
- **Onboarding UI**: Same toggle below "Add Your First Server" to nudge new users

### Platform support
Uses Tauri's official `tauri-plugin-autostart` which handles:
- **macOS**: LaunchAgent
- **Windows**: Registry entry
- **Linux**: .desktop file in ~/.config/autostart/

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author