### PR TITLE
fix: add createUpdaterArtifacts to enable updater manifest generation

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -34,6 +34,7 @@
   },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": ["nsis", "msi", "dmg", "deb", "appimage"],
     "externalBin": [
       "binaries/endara-relay"


### PR DESCRIPTION
## Summary

Adds `createUpdaterArtifacts: true` to the bundle section in `tauri.conf.json`.

This setting enables Tauri to generate the updater artifacts (like `latest.json`) during the build process, which are required for the auto-update functionality to work.

## Changes

- Added `"createUpdaterArtifacts": true` to the `bundle` section in `src-tauri/tauri.conf.json`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author