### PR TITLE
feat: dual-track auto-update channels (stable/beta)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,3 +96,30 @@ jobs:
           prerelease: ${{ contains(github.ref_name, 'rc') }}
           args: --target ${{ matrix.target }}
           tauriScript: npx tauri
+
+  # Publish latest.json to gh-pages for the auto-updater
+  # This provides a stable URL: https://endara-ai.github.io/endara-desktop/latest.json
+  publish-update-manifest:
+    runs-on: ubuntu-latest
+    needs: [publish]
+    steps:
+      - uses: actions/checkout@v4
+
+      # Wait briefly for GitHub to finalize release assets
+      - name: Wait for release assets to finalize
+        run: sleep 30
+
+      - name: Download latest.json from release
+        run: |
+          mkdir -p gh-pages-deploy
+          gh release download "${{ github.ref_name }}" --pattern "latest.json" --dir gh-pages-deploy
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./gh-pages-deploy
+          # Keep existing files on gh-pages (in case we add more assets later)
+          keep_files: true

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,7 +8,13 @@ use tauri::{
     AppHandle, Emitter, Manager, RunEvent, State,
 };
 use tauri_plugin_shell::{process::CommandEvent, ShellExt};
+use tauri_plugin_updater::UpdaterExt;
 use tokio::sync::Mutex;
+
+// Update channel URLs
+const STABLE_UPDATE_URL: &str =
+    "https://github.com/endara-ai/endara-desktop/releases/latest/download/latest.json";
+const BETA_UPDATE_URL: &str = "https://endara-ai.github.io/endara-desktop/latest.json";
 
 /// Workaround: In Tauri v2, `set_activation_policy` is only available on `App`,
 /// not on `AppHandle`, so it cannot be called from event handlers.
@@ -85,8 +91,8 @@ fn read_config() -> Result<toml::Table, String> {
     if !path.exists() {
         return Err("Config file not found".to_string());
     }
-    let contents = std::fs::read_to_string(&path)
-        .map_err(|e| format!("Failed to read config: {e}"))?;
+    let contents =
+        std::fs::read_to_string(&path).map_err(|e| format!("Failed to read config: {e}"))?;
     contents
         .parse()
         .map_err(|e| format!("Failed to parse config: {e}"))
@@ -95,10 +101,24 @@ fn read_config() -> Result<toml::Table, String> {
 /// Serialize and write a `toml::Table` back to `~/.endara/config.toml`.
 fn write_config(table: &toml::Table) -> Result<(), String> {
     let path = config_path()?;
-    let new_contents = toml::to_string_pretty(table)
-        .map_err(|e| format!("Failed to serialize config: {e}"))?;
-    std::fs::write(&path, &new_contents)
-        .map_err(|e| format!("Failed to write config: {e}"))
+    let new_contents =
+        toml::to_string_pretty(table).map_err(|e| format!("Failed to serialize config: {e}"))?;
+    std::fs::write(&path, &new_contents).map_err(|e| format!("Failed to write config: {e}"))
+}
+
+/// Read the update channel from ~/.endara/config.toml [desktop] section.
+/// Returns "stable" if not set or on any error.
+fn read_update_channel() -> String {
+    let Ok(parsed) = read_config() else {
+        return "stable".to_string();
+    };
+    parsed
+        .get("desktop")
+        .and_then(|v| v.as_table())
+        .and_then(|t| t.get("update_channel"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| "stable".to_string())
 }
 
 /// Holds the relay sidecar child process handle.
@@ -135,6 +155,18 @@ pub struct RelaySidecarStatusPayload {
     pub status: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+}
+
+/// Holds a pending update that has been checked but not yet installed.
+pub struct PendingUpdate(std::sync::Mutex<Option<tauri_plugin_updater::Update>>);
+
+/// Metadata about an available update.
+#[derive(Serialize, Clone)]
+pub struct UpdateMetadata {
+    pub version: String,
+    pub current_version: String,
+    pub body: Option<String>,
+    pub date: Option<String>,
 }
 
 async fn emit_sidecar_status(app: &AppHandle, status: &str, error: Option<String>) {
@@ -185,7 +217,10 @@ async fn spawn_relay(
         let _ = std::fs::create_dir_all(&log_dir);
     }
 
-    eprintln!("[relay] attempting to spawn sidecar with config: {:?}, port: {}", config_file, port);
+    eprintln!(
+        "[relay] attempting to spawn sidecar with config: {:?}, port: {}",
+        config_file, port
+    );
 
     // Pre-flight port conflict check
     if is_port_in_use(port) {
@@ -206,7 +241,13 @@ async fn spawn_relay(
             eprintln!("[relay] FAILED to create sidecar command: {e}");
             format!("Failed to create sidecar command: {e}")
         })?
-        .args(["start", "--config", &config_file.to_string_lossy(), "--port", &port_str])
+        .args([
+            "start",
+            "--config",
+            &config_file.to_string_lossy(),
+            "--port",
+            &port_str,
+        ])
         .spawn()
         .map_err(|e| {
             eprintln!("[relay] FAILED to spawn relay sidecar: {e}");
@@ -226,10 +267,13 @@ async fn spawn_relay(
                     if text.contains("MCP server running") {
                         emit_sidecar_status(&app_handle, "running", None).await;
                     }
-                    let _ = app_handle.emit("relay-log", RelayLogPayload {
-                        level: "info".to_string(),
-                        message: text,
-                    });
+                    let _ = app_handle.emit(
+                        "relay-log",
+                        RelayLogPayload {
+                            level: "info".to_string(),
+                            message: text,
+                        },
+                    );
                 }
                 CommandEvent::Stderr(line) => {
                     let text = strip_ansi(&String::from_utf8_lossy(&line));
@@ -244,18 +288,26 @@ async fn spawn_relay(
                     if text.contains("MCP server running") {
                         emit_sidecar_status(&app_handle, "running", None).await;
                     }
-                    let _ = app_handle.emit("relay-log", RelayLogPayload {
-                        level: level.to_string(),
-                        message: text.clone(),
-                    });
+                    let _ = app_handle.emit(
+                        "relay-log",
+                        RelayLogPayload {
+                            level: level.to_string(),
+                            message: text.clone(),
+                        },
+                    );
                     // Emit relay-health event for ERROR lines
                     if level == "error" {
-                        let _ = app_handle.emit("relay-health", RelayHealthPayload {
-                            status: "error".to_string(),
-                            message: Some(text.clone()),
-                        });
+                        let _ = app_handle.emit(
+                            "relay-health",
+                            RelayHealthPayload {
+                                status: "error".to_string(),
+                                message: Some(text.clone()),
+                            },
+                        );
                         // Emit sidecar failed status for critical errors
-                        if text.contains("Failed to start HTTP server") || text.contains("Address already in use") {
+                        if text.contains("Failed to start HTTP server")
+                            || text.contains("Address already in use")
+                        {
                             emit_sidecar_status(&app_handle, "failed", Some(text.clone())).await;
                         }
                     }
@@ -273,10 +325,16 @@ async fn spawn_relay(
                         *state.child.lock().await = None;
                     }
                     // Emit relay-health event for termination
-                    let _ = app_handle.emit("relay-health", RelayHealthPayload {
-                        status: "disconnected".to_string(),
-                        message: Some(format!("Process terminated (code: {:?}, signal: {:?})", code, signal)),
-                    });
+                    let _ = app_handle.emit(
+                        "relay-health",
+                        RelayHealthPayload {
+                            status: "disconnected".to_string(),
+                            message: Some(format!(
+                                "Process terminated (code: {:?}, signal: {:?})",
+                                code, signal
+                            )),
+                        },
+                    );
 
                     // Emit sidecar lifecycle status based on exit code
                     let exited_cleanly = code == Some(0) || (code.is_none() && signal.is_some());
@@ -286,8 +344,12 @@ async fn spawn_relay(
                         emit_sidecar_status(
                             &app_handle,
                             "failed",
-                            Some(format!("Process exited with code: {:?}, signal: {:?}", code, signal)),
-                        ).await;
+                            Some(format!(
+                                "Process exited with code: {:?}, signal: {:?}",
+                                code, signal
+                            )),
+                        )
+                        .await;
                     }
                     break;
                 }
@@ -328,7 +390,9 @@ async fn stop_relay(state: State<'_, RelayState>) -> Result<RelayStatusInfo, Str
     }
     let mut child_guard = state.child.lock().await;
     if let Some(child) = child_guard.take() {
-        child.kill().map_err(|e| format!("Failed to kill relay: {e}"))?;
+        child
+            .kill()
+            .map_err(|e| format!("Failed to kill relay: {e}"))?;
     }
     *state.running.lock().await = false;
     Ok(RelayStatusInfo { running: false })
@@ -393,10 +457,7 @@ async fn set_relay_port(port: u16, state: State<'_, RelayState>) -> Result<(), S
 
     // Set port in the [relay] section
     if let Some(relay) = table.get_mut("relay").and_then(|v| v.as_table_mut()) {
-        relay.insert(
-            "port".to_string(),
-            toml::Value::Integer(port as i64),
-        );
+        relay.insert("port".to_string(), toml::Value::Integer(port as i64));
     } else {
         return Err("Missing [relay] section in config".to_string());
     }
@@ -419,6 +480,95 @@ async fn set_js_execution_mode(enabled: bool) -> Result<(), String> {
     }
 
     write_config(&table)
+}
+
+/// Get the current update channel ("stable" or "beta").
+#[tauri::command]
+async fn get_update_channel() -> Result<String, String> {
+    Ok(read_update_channel())
+}
+
+/// Set the update channel and persist it to config.toml.
+#[tauri::command]
+async fn set_update_channel(channel: String) -> Result<(), String> {
+    let mut table = read_config().unwrap_or_else(|_| toml::Table::new());
+
+    // Ensure [desktop] section exists
+    let desktop = table
+        .entry("desktop")
+        .or_insert_with(|| toml::Value::Table(toml::Table::new()))
+        .as_table_mut()
+        .ok_or("Invalid [desktop] section in config")?;
+
+    desktop.insert("update_channel".to_string(), toml::Value::String(channel));
+
+    write_config(&table)
+}
+
+/// Check for an available update using the channel-specific endpoint.
+/// Stores the update in PendingUpdate state if found.
+#[tauri::command]
+async fn check_for_update(
+    app: AppHandle,
+    pending: State<'_, PendingUpdate>,
+) -> Result<Option<UpdateMetadata>, String> {
+    let channel = read_update_channel();
+    let url = if channel == "beta" {
+        BETA_UPDATE_URL
+    } else {
+        STABLE_UPDATE_URL
+    };
+
+    let update = app
+        .updater_builder()
+        .endpoints(vec![url
+            .parse()
+            .map_err(|e| format!("Invalid URL: {e}"))?])
+        .map_err(|e| format!("Failed to configure updater: {e}"))?
+        .build()
+        .map_err(|e| format!("Failed to build updater: {e}"))?
+        .check()
+        .await
+        .map_err(|e| format!("Failed to check for update: {e}"))?;
+
+    match update {
+        Some(upd) => {
+            let metadata = UpdateMetadata {
+                version: upd.version.clone(),
+                current_version: upd.current_version.clone(),
+                body: upd.body.clone(),
+                date: upd.date.clone(),
+            };
+            // Store the update for later installation
+            if let Ok(mut guard) = pending.0.lock() {
+                *guard = Some(upd);
+            }
+            Ok(Some(metadata))
+        }
+        None => Ok(None),
+    }
+}
+
+/// Download and install the pending update.
+#[tauri::command]
+async fn download_and_install_update(pending: State<'_, PendingUpdate>) -> Result<(), String> {
+    let update = {
+        let mut guard = pending
+            .0
+            .lock()
+            .map_err(|e| format!("Failed to lock pending update: {e}"))?;
+        guard.take()
+    };
+
+    match update {
+        Some(upd) => {
+            upd.download_and_install(|_, _| {}, || {})
+                .await
+                .map_err(|e| format!("Failed to download and install update: {e}"))?;
+            Ok(())
+        }
+        None => Err("No pending update to install".to_string()),
+    }
 }
 
 #[derive(Deserialize)]
@@ -464,27 +614,64 @@ async fn get_endpoint_config(name: String) -> Result<EndpointConfig, String> {
     if let Some(toml::Value::Array(endpoints)) = parsed.get("endpoints") {
         for ep in endpoints {
             if ep.get("name").and_then(|v| v.as_str()) == Some(&name) {
-                let transport = ep.get("transport").and_then(|v| v.as_str()).unwrap_or("stdio").to_string();
-                let command = ep.get("command").and_then(|v| v.as_str()).map(|s| s.to_string());
+                let transport = ep
+                    .get("transport")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("stdio")
+                    .to_string();
+                let command = ep
+                    .get("command")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
                 let args = ep.get("args").and_then(|v| v.as_array()).map(|arr| {
-                    arr.iter().filter_map(|v| v.as_str().map(|s| s.to_string())).collect()
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                        .collect()
                 });
-                let url = ep.get("url").and_then(|v| v.as_str()).map(|s| s.to_string());
-                let tool_prefix = ep.get("tool_prefix").and_then(|v| v.as_str()).map(|s| s.to_string());
-                let description = ep.get("description").and_then(|v| v.as_str()).map(|s| s.to_string());
+                let url = ep
+                    .get("url")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                let tool_prefix = ep
+                    .get("tool_prefix")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                let description = ep
+                    .get("description")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
                 let env = ep.get("env").and_then(|v| v.as_table()).map(|t| {
-                    t.iter().map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string())).collect()
+                    t.iter()
+                        .map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string()))
+                        .collect()
                 });
                 let headers = ep.get("headers").and_then(|v| v.as_table()).map(|t| {
-                    t.iter().map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string())).collect()
+                    t.iter()
+                        .map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string()))
+                        .collect()
                 });
-                let oauth_server_url = ep.get("oauth_server_url").and_then(|v| v.as_str()).map(|s| s.to_string());
-                let client_id = ep.get("client_id").and_then(|v| v.as_str()).map(|s| s.to_string());
-                let client_secret = ep.get("client_secret").and_then(|v| v.as_str()).map(|s| s.to_string());
+                let oauth_server_url = ep
+                    .get("oauth_server_url")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                let client_id = ep
+                    .get("client_id")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                let client_secret = ep
+                    .get("client_secret")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
                 let scopes = ep.get("scopes").and_then(|v| v.as_array()).map(|arr| {
-                    arr.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>().join(" ")
+                    arr.iter()
+                        .filter_map(|v| v.as_str())
+                        .collect::<Vec<_>>()
+                        .join(" ")
                 });
-                let token_endpoint = ep.get("token_endpoint").and_then(|v| v.as_str()).map(|s| s.to_string());
+                let token_endpoint = ep
+                    .get("token_endpoint")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
 
                 return Ok(EndpointConfig {
                     name: name.clone(),
@@ -553,23 +740,35 @@ async fn update_endpoint(args: UpdateEndpointArgs) -> Result<(), String> {
                 // Clear old fields and set new ones
                 table.clear();
                 table.insert("name".to_string(), toml::Value::String(args.name.clone()));
-                table.insert("transport".to_string(), toml::Value::String(args.transport.clone()));
+                table.insert(
+                    "transport".to_string(),
+                    toml::Value::String(args.transport.clone()),
+                );
                 if let Some(tool_prefix) = &args.tool_prefix {
-                    table.insert("tool_prefix".to_string(), toml::Value::String(tool_prefix.clone()));
+                    table.insert(
+                        "tool_prefix".to_string(),
+                        toml::Value::String(tool_prefix.clone()),
+                    );
                 }
 
                 if let Some(cmd) = &args.command {
                     table.insert("command".to_string(), toml::Value::String(cmd.clone()));
                 }
                 if let Some(cmd_args) = &args.args {
-                    let arr: Vec<toml::Value> = cmd_args.iter().map(|a| toml::Value::String(a.clone())).collect();
+                    let arr: Vec<toml::Value> = cmd_args
+                        .iter()
+                        .map(|a| toml::Value::String(a.clone()))
+                        .collect();
                     table.insert("args".to_string(), toml::Value::Array(arr));
                 }
                 if let Some(url) = &args.url {
                     table.insert("url".to_string(), toml::Value::String(url.clone()));
                 }
                 if let Some(description) = &args.description {
-                    table.insert("description".to_string(), toml::Value::String(description.clone()));
+                    table.insert(
+                        "description".to_string(),
+                        toml::Value::String(description.clone()),
+                    );
                 }
                 if let Some(env) = &args.env {
                     if !env.is_empty() {
@@ -590,16 +789,26 @@ async fn update_endpoint(args: UpdateEndpointArgs) -> Result<(), String> {
                     }
                 }
                 if let Some(oauth_server_url) = &args.oauth_server_url {
-                    table.insert("oauth_server_url".to_string(), toml::Value::String(oauth_server_url.clone()));
+                    table.insert(
+                        "oauth_server_url".to_string(),
+                        toml::Value::String(oauth_server_url.clone()),
+                    );
                 }
                 if let Some(client_id) = &args.client_id {
-                    table.insert("client_id".to_string(), toml::Value::String(client_id.clone()));
+                    table.insert(
+                        "client_id".to_string(),
+                        toml::Value::String(client_id.clone()),
+                    );
                 }
                 if let Some(client_secret) = &args.client_secret {
-                    table.insert("client_secret".to_string(), toml::Value::String(client_secret.clone()));
+                    table.insert(
+                        "client_secret".to_string(),
+                        toml::Value::String(client_secret.clone()),
+                    );
                 }
                 if let Some(scopes) = &args.scopes {
-                    let arr: Vec<toml::Value> = scopes.split_whitespace()
+                    let arr: Vec<toml::Value> = scopes
+                        .split_whitespace()
                         .map(|s| toml::Value::String(s.to_string()))
                         .collect();
                     if !arr.is_empty() {
@@ -607,7 +816,10 @@ async fn update_endpoint(args: UpdateEndpointArgs) -> Result<(), String> {
                     }
                 }
                 if let Some(token_endpoint) = &args.token_endpoint {
-                    table.insert("token_endpoint".to_string(), toml::Value::String(token_endpoint.clone()));
+                    table.insert(
+                        "token_endpoint".to_string(),
+                        toml::Value::String(token_endpoint.clone()),
+                    );
                 }
                 break;
             }
@@ -627,8 +839,7 @@ async fn add_endpoint(args: AddEndpointArgs) -> Result<(), String> {
 
     // Read existing config or create default
     let contents = if path.exists() {
-        std::fs::read_to_string(&path)
-            .map_err(|e| format!("Failed to read config: {e}"))?
+        std::fs::read_to_string(&path).map_err(|e| format!("Failed to read config: {e}"))?
     } else {
         // Create parent directory if needed
         if let Some(parent) = path.parent() {
@@ -697,16 +908,23 @@ async fn add_endpoint(args: AddEndpointArgs) -> Result<(), String> {
         }
     }
     if let Some(oauth_server_url) = args.oauth_server_url {
-        endpoint.insert("oauth_server_url".to_string(), toml::Value::String(oauth_server_url));
+        endpoint.insert(
+            "oauth_server_url".to_string(),
+            toml::Value::String(oauth_server_url),
+        );
     }
     if let Some(client_id) = args.client_id {
         endpoint.insert("client_id".to_string(), toml::Value::String(client_id));
     }
     if let Some(client_secret) = args.client_secret {
-        endpoint.insert("client_secret".to_string(), toml::Value::String(client_secret));
+        endpoint.insert(
+            "client_secret".to_string(),
+            toml::Value::String(client_secret),
+        );
     }
     if let Some(scopes) = args.scopes {
-        let arr: Vec<toml::Value> = scopes.split_whitespace()
+        let arr: Vec<toml::Value> = scopes
+            .split_whitespace()
             .map(|s| toml::Value::String(s.to_string()))
             .collect();
         if !arr.is_empty() {
@@ -714,7 +932,10 @@ async fn add_endpoint(args: AddEndpointArgs) -> Result<(), String> {
         }
     }
     if let Some(token_endpoint) = args.token_endpoint {
-        endpoint.insert("token_endpoint".to_string(), toml::Value::String(token_endpoint));
+        endpoint.insert(
+            "token_endpoint".to_string(),
+            toml::Value::String(token_endpoint),
+        );
     }
 
     let endpoints = parsed
@@ -763,16 +984,21 @@ pub fn run() {
     let child_handle = relay_state.child.clone();
     let pid_handle = relay_state.pid.clone();
 
+    let pending_update = PendingUpdate(std::sync::Mutex::new(None));
+
     tauri::Builder::default()
-        .plugin(tauri_plugin_log::Builder::new()
-            .level(log::LevelFilter::Info)
-            .build())
+        .plugin(
+            tauri_plugin_log::Builder::new()
+                .level(log::LevelFilter::Info)
+                .build(),
+        )
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_shell::init())
         .manage(relay_state)
+        .manage(pending_update)
         .invoke_handler(tauri::generate_handler![
             start_relay,
             stop_relay,
@@ -787,16 +1013,22 @@ pub fn run() {
             get_relay_port,
             set_relay_port,
             set_js_execution_mode,
+            get_update_channel,
+            set_update_channel,
+            check_for_update,
+            download_and_install_update,
         ])
         .setup(|app| {
             // Build tray menu
             let status_item =
                 MenuItem::with_id(app, "status", "Endara — Running", false, None::<&str>)?;
             let open_item = MenuItem::with_id(app, "open", "Open Endara", true, None::<&str>)?;
-            let update_item = MenuItem::with_id(app, "check_update", "Check for Updates", true, None::<&str>)?;
+            let update_item =
+                MenuItem::with_id(app, "check_update", "Check for Updates", true, None::<&str>)?;
             let quit_item = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
 
-            let menu = Menu::with_items(app, &[&status_item, &open_item, &update_item, &quit_item])?;
+            let menu =
+                Menu::with_items(app, &[&status_item, &open_item, &update_item, &quit_item])?;
 
             let _tray = TrayIconBuilder::new()
                 .icon(app.default_window_icon().unwrap().clone())
@@ -831,7 +1063,9 @@ pub fn run() {
                                 if let Some(pid) = pid_guard.take() {
                                     eprintln!("[relay] killing sidecar pid {} on tray quit", pid);
                                     #[cfg(unix)]
-                                    unsafe { libc::kill(pid as i32, libc::SIGTERM); }
+                                    unsafe {
+                                        libc::kill(pid as i32, libc::SIGTERM);
+                                    }
                                 }
                             }
                             // Also kill via child handle as fallback
@@ -900,7 +1134,9 @@ pub fn run() {
                         if let Some(pid) = guard.take() {
                             eprintln!("[relay] killing sidecar pid {} on app exit", pid);
                             #[cfg(unix)]
-                            unsafe { libc::kill(pid as i32, libc::SIGTERM); }
+                            unsafe {
+                                libc::kill(pid as i32, libc::SIGTERM);
+                            }
                         }
                     }
                     // Also try the async child.kill() as fallback, in a separate thread
@@ -915,7 +1151,8 @@ pub fn run() {
                                 }
                             });
                         }
-                    }).join();
+                    })
+                    .join();
                 }
                 _ => {}
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -537,7 +537,7 @@ async fn check_for_update(
                 version: upd.version.clone(),
                 current_version: upd.current_version.clone(),
                 body: upd.body.clone(),
-                date: upd.date.clone(),
+                date: upd.date.as_ref().map(|d| d.to_string()),
             };
             // Store the update for later installation
             if let Ok(mut guard) = pending.0.lock() {

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import { theme, jsExecutionMode, relayPort, relayConnected, relaySidecarStatus, relaySidecarError, updateStatus, updateVersion, updateError } from '$lib/stores';
+  import { theme, jsExecutionMode, relayPort, relayConnected, relaySidecarStatus, relaySidecarError, updateStatus, updateVersion, updateError, updateChannel } from '$lib/stores';
   import type { Theme, RelayStatus } from '$lib/types';
   import { invoke } from '@tauri-apps/api/core';
   import { getStatus, getConfig, reloadConfig } from '$lib/api';
   import { canRetryRelay, restartRelay } from '$lib/relaySidecarUi';
-  import { checkForUpdate, downloadAndInstall, restartApp } from '$lib/updater';
+  import { checkForUpdate, downloadAndInstall, restartApp, getUpdateChannel, setUpdateChannel } from '$lib/updater';
   import { onMount, onDestroy } from 'svelte';
 
   let portInput: number = $state($relayPort);
@@ -54,9 +54,39 @@
   let relayStatus: RelayStatus | null = $state(null);
   let statusPollInterval: ReturnType<typeof setInterval> | undefined;
   let retryingRelay = $state(false);
+  let selectedChannel: 'stable' | 'beta' = $state('stable');
+  let channelChanging = $state(false);
 
   function setTheme(t: Theme) {
     theme.set(t);
+  }
+
+  async function fetchUpdateChannel() {
+    try {
+      const channel = await getUpdateChannel();
+      if (channel === 'stable' || channel === 'beta') {
+        selectedChannel = channel;
+        updateChannel.set(channel);
+      }
+    } catch (e) {
+      console.error('Failed to get update channel:', e);
+    }
+  }
+
+  async function handleChannelChange(channel: 'stable' | 'beta') {
+    if (channelChanging || channel === selectedChannel) return;
+    channelChanging = true;
+    try {
+      await setUpdateChannel(channel);
+      selectedChannel = channel;
+      updateChannel.set(channel);
+      // Immediately check for updates on the new channel
+      await checkForUpdate();
+    } catch (e) {
+      console.error('Failed to set update channel:', e);
+    } finally {
+      channelChanging = false;
+    }
   }
 
   async function fetchRelayStatus() {
@@ -108,6 +138,7 @@
     }
     fetchRelayStatus();
     fetchJsExecutionMode();
+    fetchUpdateChannel();
     statusPollInterval = setInterval(fetchRelayStatus, 5000);
   });
 
@@ -325,6 +356,31 @@
           Current version: <span class="font-mono">{buildInfo.version}</span>
         </div>
       {/if}
+
+      <!-- Update Channel Selector -->
+      <fieldset class="border-none p-0 mb-4">
+        <legend class="block text-xs font-medium mb-1.5">Update Channel</legend>
+        <div class="flex gap-2">
+          <button
+            class="flex-1 px-3 py-2 text-xs rounded-lg border transition-colors
+              {selectedChannel === 'stable' ? 'border-(--color-accent) bg-(--color-accent)/10 text-(--color-accent)' : 'border-(--color-border) hover:bg-(--color-surface-hover)'}"
+            onclick={() => handleChannelChange('stable')}
+            disabled={channelChanging}
+          >
+            <div class="font-medium">Stable</div>
+            <div class="text-[0.65rem] mt-0.5 opacity-70">Only receive final releases</div>
+          </button>
+          <button
+            class="flex-1 px-3 py-2 text-xs rounded-lg border transition-colors
+              {selectedChannel === 'beta' ? 'border-(--color-accent) bg-(--color-accent)/10 text-(--color-accent)' : 'border-(--color-border) hover:bg-(--color-surface-hover)'}"
+            onclick={() => handleChannelChange('beta')}
+            disabled={channelChanging}
+          >
+            <div class="font-medium">Beta</div>
+            <div class="text-[0.65rem] mt-0.5 opacity-70">Receive pre-release (RC) builds</div>
+          </button>
+        </div>
+      </fieldset>
 
       {#if $updateStatus === 'idle'}
         <button

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -6,6 +6,7 @@
   import { canRetryRelay, restartRelay } from '$lib/relaySidecarUi';
   import { checkForUpdate, downloadAndInstall, restartApp, getUpdateChannel, setUpdateChannel } from '$lib/updater';
   import { onMount, onDestroy } from 'svelte';
+  import { toast } from 'svelte-sonner';
 
   let portInput: number = $state($relayPort);
   let portSaved = $state(false);
@@ -75,11 +76,16 @@
 
   async function handleChannelChange(channel: 'stable' | 'beta') {
     if (channelChanging || channel === selectedChannel) return;
+    const previousChannel = selectedChannel;
     channelChanging = true;
     try {
       await setUpdateChannel(channel);
       selectedChannel = channel;
       updateChannel.set(channel);
+      // Show info toast when switching from beta to stable
+      if (previousChannel === 'beta' && channel === 'stable') {
+        toast.info("You're now on the stable channel. You'll stay on your current version until a stable release newer than your current version is available.");
+      }
       // Immediately check for updates on the new channel
       await checkForUpdate();
     } catch (e) {

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -124,4 +124,5 @@ export const selectedEndpointData = derived(
 export const updateStatus = writable<string>('idle');
 export const updateVersion = writable<string | null>(null);
 export const updateError = writable<string | null>(null);
+export const updateChannel = writable<'stable' | 'beta'>('stable');
 

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,21 +1,24 @@
-import { check, Update } from '@tauri-apps/plugin-updater';
+import { invoke } from '@tauri-apps/api/core';
 import { relaunch } from '@tauri-apps/plugin-process';
 import { updateStatus, updateVersion, updateError } from './stores';
 
-let updateInstance: Update | null = null;
+interface UpdateMetadata {
+  version: string;
+  current_version: string;
+  body: string | null;
+  date: string | null;
+}
 
 export async function checkForUpdate() {
   updateStatus.set('checking');
   updateError.set(null);
   try {
-    const update = await check();
-    if (update) {
-      updateVersion.set(update.version);
+    const metadata = await invoke<UpdateMetadata | null>('check_for_update');
+    if (metadata) {
+      updateVersion.set(metadata.version);
       updateStatus.set('available');
-      updateInstance = update;
     } else {
       updateStatus.set('up-to-date');
-      // Reset to idle after 10s
       setTimeout(() => updateStatus.set('idle'), 10000);
     }
   } catch (e) {
@@ -25,10 +28,9 @@ export async function checkForUpdate() {
 }
 
 export async function downloadAndInstall() {
-  if (!updateInstance) return;
   updateStatus.set('downloading');
   try {
-    await updateInstance.downloadAndInstall();
+    await invoke('download_and_install_update');
     updateStatus.set('ready');
   } catch (e) {
     updateError.set(e instanceof Error ? e.message : String(e));
@@ -38,5 +40,13 @@ export async function downloadAndInstall() {
 
 export async function restartApp() {
   await relaunch();
+}
+
+export async function getUpdateChannel(): Promise<string> {
+  return invoke<string>('get_update_channel');
+}
+
+export async function setUpdateChannel(channel: 'stable' | 'beta'): Promise<void> {
+  await invoke('set_update_channel', { channel });
 }
 


### PR DESCRIPTION
## Summary

Adds dual-track auto-update channels so users can choose between **Stable** (default) and **Beta** update tracks.

- **Stable** checks `https://github.com/endara-ai/endara-desktop/releases/latest/download/latest.json` — GitHub's `/releases/latest` naturally ignores prereleases
- **Beta** checks `https://endara-ai.github.io/endara-desktop/latest.json` — a fixed URL that always has the latest release manifest including prereleases

## Changes

### 1. Release workflow (`publish-update-manifest` job)
- New job that runs after all platform builds complete
- Downloads `latest.json` from the release and deploys it to GitHub Pages
- Provides a stable URL for the beta update channel

### 2. Rust backend (`lib.rs`)
- `read_update_channel()` — reads `update_channel` from `[desktop]` section of `~/.endara/config.toml` (defaults to "stable")
- `get_update_channel` / `set_update_channel` Tauri commands for frontend access
- `check_for_update` — uses `app.updater_builder().endpoints()` to override the update URL based on the selected channel
- `download_and_install_update` — installs a previously checked update stored in `PendingUpdate` state
- `PendingUpdate` / `UpdateMetadata` structs for managing update lifecycle

### 3. Frontend UI (`Settings.svelte`, `stores.ts`, `updater.ts`)
- Channel selector in Settings with Stable/Beta toggle buttons
- `updateChannel` store in `stores.ts`
- `updater.ts` uses `invoke('check_for_update')` instead of the JS plugin `check()` — all update logic goes through the Rust backend
- Changing channel immediately triggers an update check

## Prerequisites

- Depends on PR #31 (`createUpdaterArtifacts: true` in tauri.conf.json)

## Setup Required

> **Note for repo admin**: GitHub Pages must be enabled on this repository (Settings → Pages → Source: "Deploy from a branch" → Branch: `gh-pages`). The `publish-update-manifest` workflow job will deploy `latest.json` to `https://endara-ai.github.io/endara-desktop/latest.json`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author