### PR TITLE
ci: add preflight check to validate relay release before building

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,40 @@ permissions:
 env:
   # For tag pushes, use the tag name (relay releases with matching version).
   # For manual workflow_dispatch runs, fall back to 'latest'.
+  # The preflight job validates this release exists before platform builds start.
   RELAY_VERSION: ${{ github.ref_name && startsWith(github.ref_name, 'v') && github.ref_name || 'latest' }}
 
 jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      relay_version: ${{ steps.check.outputs.relay_version }}
+    steps:
+      - name: Validate relay release exists
+        id: check
+        shell: bash
+        run: |
+          if [[ "${{ github.ref_name }}" == v* ]]; then
+            RELAY_VERSION="${{ github.ref_name }}"
+          else
+            RELAY_VERSION="latest"
+          fi
+          echo "relay_version=$RELAY_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Checking for relay release: $RELAY_VERSION"
+          if [[ "$RELAY_VERSION" == "latest" ]]; then
+            gh release view --repo endara-ai/endara-relay --json tagName -q .tagName
+          else
+            gh release view "$RELAY_VERSION" --repo endara-ai/endara-relay --json tagName -q .tagName
+          fi
+          if [[ $? -ne 0 ]]; then
+            echo "::error::Relay release '$RELAY_VERSION' not found in endara-ai/endara-relay. Release the relay first!"
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   publish:
+    needs: [preflight]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Adds a fast preflight job that validates the matching endara-relay release exists before spinning up 4 platform build jobs. Fails fast with a clear error message if the relay release is missing.

## Changes
- Add \ job that runs before \ 
- Validates relay release exists using \title:	v0.0.1-rc1
tag:	v0.0.1-rc1
draft:	false
prerelease:	false
immutable:	false
author:	github-actions[bot]
created:	2026-03-28T00:07:07Z
published:	2026-03-28T00:14:57Z
url:	https://github.com/endara-ai/endara-desktop/releases/tag/v0.0.1-rc1
asset:	Endara.Desktop_0.1.0_aarch64.dmg
asset:	Endara.Desktop_0.1.0_amd64.AppImage
asset:	Endara.Desktop_0.1.0_amd64.deb
asset:	Endara.Desktop_0.1.0_x64-setup.exe
asset:	Endara.Desktop_0.1.0_x64.dmg
asset:	Endara.Desktop_0.1.0_x64_en-US.msi
--
## What's Changed
* feat: Tauri desktop app for MCP relay management by @panghy in https://github.com/endara-ai/endara-desktop/pull/1
* ci: add release workflow with relay binary download by @panghy in https://github.com/endara-ai/endara-desktop/pull/2
* docs: add releasing and CI sections to README by @panghy in https://github.com/endara-ai/endara-desktop/pull/3
* fix: add rust target and use npx tauri-cli in release workflow by @panghy in https://github.com/endara-ai/endara-desktop/pull/4

## New Contributors
* @panghy made their first contribution in https://github.com/endara-ai/endara-desktop/pull/1

**Full Changelog**: https://github.com/endara-ai/endara-desktop/commits/v0.0.1-rc1
- Outputs resolved relay version for downstream jobs
- Fails fast with clear error if relay release is missing
- \ job now has \