### PR TITLE
fix: restore autostart feature and add macOS updater target

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -970,6 +970,36 @@ async fn remove_endpoint(name: String) -> Result<(), String> {
     write_config(&parsed)
 }
 
+/// Check if autostart is enabled.
+#[tauri::command]
+fn get_autostart(app: AppHandle) -> Result<bool, String> {
+    use tauri_plugin_autostart::ManagerExt;
+    app.autolaunch()
+        .is_enabled()
+        .map_err(|e| format!("Failed to check autostart: {e}"))
+}
+
+/// Enable or disable autostart.
+#[tauri::command]
+fn set_autostart(app: AppHandle, enabled: bool) -> Result<(), String> {
+    use tauri_plugin_autostart::ManagerExt;
+    let manager = app.autolaunch();
+    if enabled {
+        manager
+            .enable()
+            .map_err(|e| format!("Failed to enable autostart: {e}"))
+    } else {
+        manager
+            .disable()
+            .map_err(|e| format!("Failed to disable autostart: {e}"))
+    }
+}
+
+/// Check if app was started with the autostart flag.
+fn is_autostarted() -> bool {
+    std::env::args().any(|arg| arg == "--autostarted")
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let relay_state = RelayState {
@@ -997,6 +1027,13 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_shell::init())
+        .plugin({
+            let builder = tauri_plugin_autostart::Builder::new().args(["--autostarted"]);
+            #[cfg(target_os = "macos")]
+            let builder =
+                builder.macos_launcher(tauri_plugin_autostart::MacosLauncher::LaunchAgent);
+            builder.build()
+        })
         .manage(relay_state)
         .manage(pending_update)
         .invoke_handler(tauri::generate_handler![
@@ -1017,6 +1054,8 @@ pub fn run() {
             set_update_channel,
             check_for_update,
             download_and_install_update,
+            get_autostart,
+            set_autostart,
         ])
         .setup(|app| {
             // Build tray menu
@@ -1108,9 +1147,20 @@ pub fn run() {
                 }
             });
 
-            // Ensure app appears in Cmd-Tab on startup
-            #[cfg(target_os = "macos")]
-            set_macos_activation_policy(true);
+            // Handle autostarted launch: hide window and set accessory mode
+            if is_autostarted() {
+                // Hide the window when auto-launched
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.hide();
+                }
+                // Set accessory mode (no Dock icon, no Cmd-Tab)
+                #[cfg(target_os = "macos")]
+                set_macos_activation_policy(false);
+            } else {
+                // Normal launch: ensure app appears in Cmd-Tab on startup
+                #[cfg(target_os = "macos")]
+                set_macos_activation_policy(true);
+            }
 
             Ok(())
         })

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,7 +35,7 @@
   "bundle": {
     "active": true,
     "createUpdaterArtifacts": true,
-    "targets": ["nsis", "msi", "dmg", "deb", "appimage"],
+    "targets": ["app", "nsis", "msi", "dmg", "deb", "appimage"],
     "externalBin": [
       "binaries/endara-relay"
     ],

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -11,6 +11,7 @@
   let portInput: number = $state($relayPort);
   let portSaved = $state(false);
   let portError = $state<string | null>(null);
+  let autoStartEnabled = $state(false);
 
   async function savePort() {
     const port = Math.floor(portInput);
@@ -124,6 +125,25 @@
     }
   }
 
+  async function toggleAutoStart() {
+    const newValue = !autoStartEnabled;
+    autoStartEnabled = newValue;
+    try {
+      await invoke('set_autostart', { enabled: newValue });
+    } catch (e) {
+      autoStartEnabled = !newValue;
+      console.error('Failed to set autostart:', e);
+    }
+  }
+
+  async function fetchAutoStart() {
+    try {
+      autoStartEnabled = await invoke<boolean>('get_autostart');
+    } catch (e) {
+      console.error('Failed to get autostart:', e);
+    }
+  }
+
   async function fetchJsExecutionMode() {
     try {
       const config = await getConfig();
@@ -144,6 +164,7 @@
     }
     fetchRelayStatus();
     fetchJsExecutionMode();
+    fetchAutoStart();
     fetchUpdateChannel();
     statusPollInterval = setInterval(fetchRelayStatus, 5000);
   });
@@ -281,6 +302,22 @@
         aria-label="Toggle JS execution mode"
       >
         <span class="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform {$jsExecutionMode ? 'translate-x-5' : ''}"></span>
+      </button>
+    </div>
+
+    <div class="flex items-start justify-between gap-4">
+      <div>
+        <div class="text-sm font-medium">Start on Login</div>
+        <div class="text-xs text-(--color-text-secondary) mt-0.5">Automatically start Endara Desktop when you log in to your computer.</div>
+      </div>
+      <button
+        class="shrink-0 relative w-10 h-5 rounded-full transition-colors {autoStartEnabled ? 'bg-green-500' : 'bg-gray-300 dark:bg-gray-600'}"
+        onclick={() => toggleAutoStart()}
+        role="switch"
+        aria-checked={autoStartEnabled}
+        aria-label="Toggle start on login"
+      >
+        <span class="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform {autoStartEnabled ? 'translate-x-5' : ''}"></span>
       </button>
     </div>
 


### PR DESCRIPTION
## Changes

### Restore autostart (regression from #32)
The dual-track auto-update channels PR (#32) accidentally removed the autostart feature. This restores:
- `get_autostart` / `set_autostart` Tauri commands
- `is_autostarted()` detection + minimized launch behavior (hide window, accessory mode on macOS)
- `tauri_plugin_autostart` plugin registration with `--autostarted` flag and LaunchAgent
- "Start on Login" toggle in Settings UI

### Fix macOS auto-updater
Added `"app"` to the bundle targets in `tauri.conf.json`. This generates `.app.tar.gz` updater artifacts for macOS, which are required for the Tauri updater to work on Mac. Previously only `.dmg` was generated, which doesn't produce updater artifacts — resulting in `latest.json` missing `darwin-aarch64` / `darwin-x86_64` entries.

## Verification
- ✅ `cargo check` — compiles
- ✅ `npm run check` — 0 errors, 0 warnings
- ✅ `npm run build` — succeeds