### PR TITLE
fix: show correct version and commit hashes in About section

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,9 @@ jobs:
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Build info for About section — picked up by build.rs
+          DESKTOP_COMMIT: ${{ github.sha }}
+          BUILD_VERSION: ${{ github.ref_name }}
           # Required for updater — generate with: npx @tauri-apps/cli signer generate
           # Store the private key as a GitHub secret named TAURI_SIGNING_PRIVATE_KEY
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -8,13 +8,34 @@ fn git_hash(dir: &str) -> String {
         .ok()
         .and_then(|o| String::from_utf8(o.stdout).ok())
         .map(|s| s.trim().to_string())
-        .unwrap_or_else(|| "unknown".to_string())
+        .unwrap_or_else(|| "n/a".to_string())
+}
+
+/// Read from environment variable first (CI-provided), fall back to git command.
+/// Treats empty strings as unset (CI may set vars to empty).
+/// Truncates to 8 chars to match git short hash format.
+fn env_or_git(env_key: &str, git_dir: &str) -> String {
+    std::env::var(env_key)
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(|s| s[..s.len().min(8)].to_string())
+        .unwrap_or_else(|| git_hash(git_dir))
 }
 
 fn main() {
-    let monorepo_hash = git_hash("../../..");
-    let relay_hash = git_hash("../../../packages/relay");
-    let desktop_hash = git_hash("../..");
+    // Check env vars first (set by CI), fall back to git commands for local builds
+    let monorepo_hash = env_or_git("MONOREPO_COMMIT", "../../..");
+    let relay_hash = env_or_git("RELAY_COMMIT", "../../../packages/relay");
+    let desktop_hash = env_or_git("DESKTOP_COMMIT", "../..");
+
+    // BUILD_VERSION from CI (e.g., "0.1.0-rc6"), stripped of leading "v" if present
+    let build_version = std::env::var("BUILD_VERSION")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(|v| v.strip_prefix('v').map(|s| s.to_string()).unwrap_or(v));
+    if let Some(version) = build_version {
+        println!("cargo:rustc-env=BUILD_VERSION={}", version);
+    }
 
     // Build date without chrono
     let date_output = Command::new("date")
@@ -29,6 +50,12 @@ fn main() {
     println!("cargo:rustc-env=RELAY_COMMIT={}", relay_hash);
     println!("cargo:rustc-env=DESKTOP_COMMIT={}", desktop_hash);
     println!("cargo:rustc-env=BUILD_DATE={}", date_output);
+
+    // Rerun if env vars change (for CI builds)
+    println!("cargo:rerun-if-env-changed=DESKTOP_COMMIT");
+    println!("cargo:rerun-if-env-changed=MONOREPO_COMMIT");
+    println!("cargo:rerun-if-env-changed=RELAY_COMMIT");
+    println!("cargo:rerun-if-env-changed=BUILD_VERSION");
 
     // Only emit rerun-if-changed for git paths that exist — in a standalone
     // checkout (outside the monorepo) these paths won't be present.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -194,8 +194,12 @@ pub struct BuildInfo {
 
 #[tauri::command]
 async fn get_build_info() -> Result<BuildInfo, String> {
+    // Use BUILD_VERSION from CI if available (includes RC suffix), else fall back to Cargo.toml version
+    let version = option_env!("BUILD_VERSION")
+        .unwrap_or(env!("CARGO_PKG_VERSION"))
+        .to_string();
     Ok(BuildInfo {
-        version: env!("CARGO_PKG_VERSION").to_string(),
+        version,
         monorepo_commit: env!("MONOREPO_COMMIT").to_string(),
         relay_commit: env!("RELAY_COMMIT").to_string(),
         desktop_commit: env!("DESKTOP_COMMIT").to_string(),

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -394,12 +394,6 @@
     <div class="pt-4 mt-4 border-t border-(--color-border)">
       <div class="text-xs font-medium text-(--color-text-secondary) uppercase tracking-wide mb-2">Updates</div>
 
-      {#if buildInfo}
-        <div class="text-xs text-(--color-text-secondary) mb-2">
-          Current version: <span class="font-mono">{buildInfo.version}</span>
-        </div>
-      {/if}
-
       <!-- Update Channel Selector -->
       <fieldset class="border-none p-0 mb-4">
         <legend class="block text-xs font-medium mb-1.5">Update Channel</legend>


### PR DESCRIPTION
## Changes

### Fix empty commit hashes in CI builds
`build.rs` now checks CI env vars (`DESKTOP_COMMIT`, `MONOREPO_COMMIT`, `RELAY_COMMIT`) first, falling back to git commands for local builds. Truncates env values to 8 chars for consistent short hash display.

### Fix version display
- Added `BUILD_VERSION` env var support — CI sets this from the git tag (e.g., `v0.1.0-rc6` → `0.1.0-rc6`), so RC builds show the correct version with suffix
- Falls back to `CARGO_PKG_VERSION` for local builds

### Remove duplicate version line
Removed the "Current version" text from the Updates section — version is already shown in the About section above.

### CI workflow updates
`release.yml` now passes `DESKTOP_COMMIT` and `BUILD_VERSION` to the tauri-action step.

## Verification
- ✅ `cargo check` — compiles
- ✅ `npm run check` — 0 errors, 0 warnings

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author