### PR TITLE
fix: patch tauri.conf.json version from git tag in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,26 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Patch tauri.conf.json version from git tag (e.g., v0.1.0-rc8 → 0.1.0-rc8)
+      # This ensures the built app reports the correct version for the updater
+      - name: Patch tauri.conf.json version (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          BUILD_VER=${GITHUB_REF_NAME#v}
+          jq --arg v "$BUILD_VER" '.version = $v' src-tauri/tauri.conf.json > tmp.json && mv tmp.json src-tauri/tauri.conf.json
+          echo "Patched tauri.conf.json version to: $BUILD_VER"
+
+      - name: Patch tauri.conf.json version (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ver = "$env:GITHUB_REF_NAME" -replace '^v', ''
+          $json = Get-Content src-tauri/tauri.conf.json | ConvertFrom-Json
+          $json.version = $ver
+          $json | ConvertTo-Json -Depth 10 | Set-Content src-tauri/tauri.conf.json
+          Write-Output "Patched tauri.conf.json version to: $ver"
+
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Patches `tauri.conf.json` version field from the git tag before building in CI. This ensures the built app reports the correct version (including RC suffix) so the updater can detect new releases.

## Problem

Currently, all builds report version `0.1.0` from `tauri.conf.json`, which means the updater can't distinguish between RC releases (e.g., v0.1.0-rc6 vs v0.1.0-rc7) since Tauri compares versions to determine if an update is available.

## Solution

Added a step before `tauri-apps/tauri-action` that:
1. Strips the leading `v` from the git tag (e.g., `v0.1.0-rc8` → `0.1.0-rc8`)
2. Patches `tauri.conf.json` version field with the result

Used platform-specific approaches:
- **macOS/Linux**: bash + jq
- **Windows**: PowerShell (since jq may not be available)

## Testing

The change will be verified on the next release build. The `latest.json` manifest should show the full RC version instead of just `0.1.0`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author