### PR TITLE
fix: remove monorepo and relay hashes from About section

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -24,8 +24,6 @@ fn env_or_git(env_key: &str, git_dir: &str) -> String {
 
 fn main() {
     // Check env vars first (set by CI), fall back to git commands for local builds
-    let monorepo_hash = env_or_git("MONOREPO_COMMIT", "../../..");
-    let relay_hash = env_or_git("RELAY_COMMIT", "../../../packages/relay");
     let desktop_hash = env_or_git("DESKTOP_COMMIT", "../..");
 
     // BUILD_VERSION from CI (e.g., "0.1.0-rc6"), stripped of leading "v" if present
@@ -46,23 +44,17 @@ fn main() {
         .map(|s| s.trim().to_string())
         .unwrap_or_else(|| "unknown".to_string());
 
-    println!("cargo:rustc-env=MONOREPO_COMMIT={}", monorepo_hash);
-    println!("cargo:rustc-env=RELAY_COMMIT={}", relay_hash);
     println!("cargo:rustc-env=DESKTOP_COMMIT={}", desktop_hash);
     println!("cargo:rustc-env=BUILD_DATE={}", date_output);
 
     // Rerun if env vars change (for CI builds)
     println!("cargo:rerun-if-env-changed=DESKTOP_COMMIT");
-    println!("cargo:rerun-if-env-changed=MONOREPO_COMMIT");
-    println!("cargo:rerun-if-env-changed=RELAY_COMMIT");
     println!("cargo:rerun-if-env-changed=BUILD_VERSION");
 
     // Only emit rerun-if-changed for git paths that exist — in a standalone
     // checkout (outside the monorepo) these paths won't be present.
-    for path in &["../../../.git/HEAD", "../../.git/HEAD"] {
-        if std::path::Path::new(path).exists() {
-            println!("cargo:rerun-if-changed={}", path);
-        }
+    if std::path::Path::new("../../.git/HEAD").exists() {
+        println!("cargo:rerun-if-changed=../../.git/HEAD");
     }
 
     tauri_build::build()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -186,8 +186,6 @@ async fn emit_sidecar_status(app: &AppHandle, status: &str, error: Option<String
 #[derive(Serialize, Clone)]
 pub struct BuildInfo {
     pub version: String,
-    pub monorepo_commit: String,
-    pub relay_commit: String,
     pub desktop_commit: String,
     pub build_date: String,
 }
@@ -200,8 +198,6 @@ async fn get_build_info() -> Result<BuildInfo, String> {
         .to_string();
     Ok(BuildInfo {
         version,
-        monorepo_commit: env!("MONOREPO_COMMIT").to_string(),
-        relay_commit: env!("RELAY_COMMIT").to_string(),
         desktop_commit: env!("DESKTOP_COMMIT").to_string(),
         build_date: env!("BUILD_DATE").to_string(),
     })

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -46,8 +46,6 @@
 
   interface BuildInfo {
     version: string;
-    monorepo_commit: string;
-    relay_commit: string;
     desktop_commit: string;
     build_date: string;
   }
@@ -382,10 +380,6 @@
           <span>{buildInfo.build_date}</span>
           <span class="text-(--color-text-secondary)">Desktop</span>
           <span class="font-mono text-[0.6875rem]">{buildInfo.desktop_commit}</span>
-          <span class="text-(--color-text-secondary)">Relay</span>
-          <span class="font-mono text-[0.6875rem]">{buildInfo.relay_commit}</span>
-          <span class="text-(--color-text-secondary)">Monorepo</span>
-          <span class="font-mono text-[0.6875rem]">{buildInfo.monorepo_commit}</span>
         </div>
       </div>
     {/if}


### PR DESCRIPTION
## Summary

Removes the Monorepo and Relay commit hash rows from the About section in Settings.

## Motivation

- **Monorepo hash**: Always empty in CI (private repo, GitHub Actions can't resolve it)
- **Relay hash**: Shows "n/a" (desktop repo doesn't have the relay submodule path)

These rows provided no useful information and cluttered the UI.

## Changes

- `Settings.svelte`: Remove Monorepo and Relay rows from About grid, update BuildInfo interface
- `lib.rs`: Remove `monorepo_commit` and `relay_commit` from BuildInfo struct and get_build_info command
- `build.rs`: Remove generation of monorepo and relay commit hashes

## After

The About section now shows only:
- Version
- Build Date
- Desktop (commit hash)

## Testing

- `cargo check` passes ✅
- `npm run check` passes ✅
- `cargo fmt --check` passes ✅

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author