### PR TITLE
fix: improve release versioning, skip MSI for RC, resilient manifest deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,25 +104,43 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Patch tauri.conf.json version from git tag (e.g., v0.1.0-rc8 → 0.1.0-rc8)
-      # This ensures the built app reports the correct version for the updater
+      # Patch tauri.conf.json version from git tag
+      # Convert RC versions: v0.1.0-rc8 → 0.1.8 (use RC number as patch for semver ordering)
+      # Stable versions: v0.1.0 → 0.1.0 (unchanged)
       - name: Patch tauri.conf.json version (Unix)
         if: runner.os != 'Windows'
         shell: bash
         run: |
-          BUILD_VER=${GITHUB_REF_NAME#v}
-          jq --arg v "$BUILD_VER" '.version = $v' src-tauri/tauri.conf.json > tmp.json && mv tmp.json src-tauri/tauri.conf.json
-          echo "Patched tauri.conf.json version to: $BUILD_VER"
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [[ "$TAG_VERSION" =~ ^([0-9]+)\.([0-9]+)\.[0-9]+-rc([0-9]+)$ ]]; then
+            TAG_VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
+          fi
+          jq --arg v "$TAG_VERSION" '.version = $v' src-tauri/tauri.conf.json > tmp.json && mv tmp.json src-tauri/tauri.conf.json
+          echo "Patched tauri.conf.json version to: $TAG_VERSION"
 
       - name: Patch tauri.conf.json version (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $ver = "$env:GITHUB_REF_NAME" -replace '^v', ''
+          $tag = $env:GITHUB_REF_NAME -replace '^v', ''
+          if ($tag -match '^(\d+)\.(\d+)\.\d+-rc(\d+)$') {
+            $tag = "$($Matches[1]).$($Matches[2]).$($Matches[3])"
+          }
           $json = Get-Content src-tauri/tauri.conf.json | ConvertFrom-Json
-          $json.version = $ver
+          $json.version = $tag
           $json | ConvertTo-Json -Depth 10 | Set-Content src-tauri/tauri.conf.json
-          Write-Output "Patched tauri.conf.json version to: $ver"
+          Write-Output "Patched tauri.conf.json version to: $tag"
+
+      # Set build args: skip MSI for RC builds on Windows (only produce NSIS)
+      - name: Set build args
+        id: build-args
+        shell: bash
+        run: |
+          ARGS="--target ${{ matrix.target }}"
+          if [[ "${{ matrix.platform }}" == "windows-latest" ]] && [[ "${{ github.ref_name }}" == *"rc"* ]]; then
+            ARGS="$ARGS --bundles nsis"
+          fi
+          echo "args=$ARGS" >> "$GITHUB_OUTPUT"
 
       - uses: tauri-apps/tauri-action@v0
         env:
@@ -147,7 +165,7 @@ jobs:
           generateReleaseNotes: true
           releaseDraft: false
           prerelease: ${{ contains(github.ref_name, 'rc') }}
-          args: --target ${{ matrix.target }}
+          args: ${{ steps.build-args.outputs.args }}
           tauriScript: npx tauri
 
   # Publish latest.json to gh-pages for the auto-updater
@@ -155,6 +173,7 @@ jobs:
   publish-update-manifest:
     runs-on: ubuntu-latest
     needs: [publish]
+    if: always() && !cancelled()
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,32 +104,25 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Patch tauri.conf.json version from git tag
-      # Convert RC versions: v0.1.0-rc8 → 0.1.8 (use RC number as patch for semver ordering)
-      # Stable versions: v0.1.0 → 0.1.0 (unchanged)
+      # Patch tauri.conf.json version from git tag (e.g., v0.1.0-rc8 → 0.1.0-rc8)
+      # This ensures the built app reports the correct version for the updater
       - name: Patch tauri.conf.json version (Unix)
         if: runner.os != 'Windows'
         shell: bash
         run: |
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
-          if [[ "$TAG_VERSION" =~ ^([0-9]+)\.([0-9]+)\.[0-9]+-rc([0-9]+)$ ]]; then
-            TAG_VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
-          fi
-          jq --arg v "$TAG_VERSION" '.version = $v' src-tauri/tauri.conf.json > tmp.json && mv tmp.json src-tauri/tauri.conf.json
-          echo "Patched tauri.conf.json version to: $TAG_VERSION"
+          BUILD_VER=${GITHUB_REF_NAME#v}
+          jq --arg v "$BUILD_VER" '.version = $v' src-tauri/tauri.conf.json > tmp.json && mv tmp.json src-tauri/tauri.conf.json
+          echo "Patched tauri.conf.json version to: $BUILD_VER"
 
       - name: Patch tauri.conf.json version (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $tag = $env:GITHUB_REF_NAME -replace '^v', ''
-          if ($tag -match '^(\d+)\.(\d+)\.\d+-rc(\d+)$') {
-            $tag = "$($Matches[1]).$($Matches[2]).$($Matches[3])"
-          }
+          $ver = "$env:GITHUB_REF_NAME" -replace '^v', ''
           $json = Get-Content src-tauri/tauri.conf.json | ConvertFrom-Json
-          $json.version = $tag
+          $json.version = $ver
           $json | ConvertTo-Json -Depth 10 | Set-Content src-tauri/tauri.conf.json
-          Write-Output "Patched tauri.conf.json version to: $tag"
+          Write-Output "Patched tauri.conf.json version to: $ver"
 
       # Set build args: skip MSI for RC builds on Windows (only produce NSIS)
       - name: Set build args


### PR DESCRIPTION
## Summary

Fixes two issues in the release CI workflow:

### 1. Skip MSI for RC builds on Windows

Adds `--bundles nsis` for Windows RC builds to skip MSI generation. This simplifies RC releases while keeping full installer support for stable releases.

### 2. Resilient manifest deployment

Adds `if: always() && !cancelled()` to the `publish-update-manifest` job so it runs even if some platform builds fail. This ensures `latest.json` gets deployed if any platform succeeded.

---

Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author