### PR TITLE
feat: auto-download updates and show restart notification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-autostart": "^2.5.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",
+        "@tauri-apps/plugin-notification": "^2.3.3",
         "@tauri-apps/plugin-opener": "^2",
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-shell": "^2.3.5",
@@ -1504,6 +1505,15 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.6.0.tgz",
       "integrity": "sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-notification": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-notification/-/plugin-notification-2.3.3.tgz",
+      "integrity": "sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-autostart": "^2.5.1",
     "@tauri-apps/plugin-dialog": "^2.6.0",
+    "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-shell": "^2.3.5",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1058,6 +1058,7 @@ dependencies = [
  "tauri-plugin-autostart",
  "tauri-plugin-dialog",
  "tauri-plugin-log",
+ "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-shell",
@@ -2297,6 +2298,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+dependencies = [
+ "cc",
+ "objc2",
+ "objc2-foundation",
+ "time",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2448,6 +2461,20 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "notify-rust"
+version = "4.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8146c105ae33d744e2d645f684d063b01176a99daf5986556266777b428816"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
 
 [[package]]
 name = "num-conv"
@@ -3056,7 +3083,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -3218,6 +3245,15 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
@@ -3278,6 +3314,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3298,6 +3344,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3313,6 +3369,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -4551,6 +4616,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-notification"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4734,6 +4818,18 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml 0.37.5",
+ "thiserror 2.0.18",
+ "windows",
+ "windows-version",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,7 @@ hostname = "0.4"
 tauri-plugin-log = "2.8.0"
 tauri-plugin-dialog = "2.6.0"
 tauri-plugin-autostart = "2"
+tauri-plugin-notification = "2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.4"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -30,6 +30,7 @@
     "updater:default",
     "process:default",
     "dialog:default",
-    "autostart:default"
+    "autostart:default",
+    "notification:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ use tauri::{
     tray::TrayIconBuilder,
     AppHandle, Emitter, Manager, RunEvent, State,
 };
+use tauri_plugin_notification::NotificationExt;
 use tauri_plugin_shell::{process::CommandEvent, ShellExt};
 use tauri_plugin_updater::UpdaterExt;
 use tokio::sync::Mutex;
@@ -571,6 +572,20 @@ async fn download_and_install_update(pending: State<'_, PendingUpdate>) -> Resul
     }
 }
 
+/// Show a system notification that an update is ready to install.
+#[tauri::command]
+async fn show_update_notification(app: AppHandle, version: String) -> Result<(), String> {
+    app.notification()
+        .builder()
+        .title("Endara Desktop Update Ready")
+        .body(format!(
+            "Version {} is ready to install. Open Endara to restart.",
+            version
+        ))
+        .show()
+        .map_err(|e| format!("Failed to show notification: {e}"))
+}
+
 #[derive(Deserialize)]
 struct AddEndpointArgs {
     name: String,
@@ -1034,6 +1049,7 @@ pub fn run() {
                 builder.macos_launcher(tauri_plugin_autostart::MacosLauncher::LaunchAgent);
             builder.build()
         })
+        .plugin(tauri_plugin_notification::init())
         .manage(relay_state)
         .manage(pending_update)
         .invoke_handler(tauri::generate_handler![
@@ -1054,6 +1070,7 @@ pub fn run() {
             set_update_channel,
             check_for_update,
             download_and_install_update,
+            show_update_notification,
             get_autostart,
             set_autostart,
         ])

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -4,7 +4,7 @@
   import { invoke } from '@tauri-apps/api/core';
   import { getStatus, getConfig, reloadConfig } from '$lib/api';
   import { canRetryRelay, restartRelay } from '$lib/relaySidecarUi';
-  import { checkForUpdate, downloadAndInstall, restartApp, getUpdateChannel, setUpdateChannel } from '$lib/updater';
+  import { checkAndAutoDownload, restartApp, getUpdateChannel, setUpdateChannel } from '$lib/updater';
   import { onMount, onDestroy } from 'svelte';
   import { toast } from 'svelte-sonner';
 
@@ -85,8 +85,8 @@
       if (previousChannel === 'beta' && channel === 'stable') {
         toast.info("You're now on the stable channel. You'll stay on your current version until a stable release newer than your current version is available.");
       }
-      // Immediately check for updates on the new channel
-      await checkForUpdate();
+      // Immediately check for updates on the new channel (auto-downloads if available)
+      await checkAndAutoDownload();
     } catch (e) {
       console.error('Failed to set update channel:', e);
     } finally {
@@ -416,7 +416,7 @@
       {#if $updateStatus === 'idle'}
         <button
           class="px-3 py-1.5 text-xs rounded-lg border border-(--color-border) hover:bg-(--color-surface-hover) transition-colors"
-          onclick={() => checkForUpdate()}
+          onclick={() => checkAndAutoDownload()}
         >
           Check for Updates
         </button>
@@ -428,27 +428,27 @@
           </svg>
           Checking for updates...
         </div>
-      {:else if $updateStatus === 'available'}
-        <div class="space-y-2">
-          <p class="text-xs">Version <span class="font-mono font-medium">{$updateVersion}</span> available</p>
-          <button
-            class="px-3 py-1.5 text-xs rounded-lg bg-(--color-accent) text-white hover:opacity-90 transition-opacity"
-            onclick={() => downloadAndInstall()}
-          >
-            Download &amp; Install
-          </button>
-        </div>
-      {:else if $updateStatus === 'downloading'}
+      {:else if $updateStatus === 'available' || $updateStatus === 'downloading'}
         <div class="flex items-center gap-2 text-xs text-(--color-text-secondary)">
           <svg class="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24">
             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
             <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
           </svg>
-          Downloading update...
+          {#if $updateVersion}
+            Downloading version {$updateVersion}...
+          {:else}
+            Downloading update...
+          {/if}
         </div>
       {:else if $updateStatus === 'ready'}
         <div class="space-y-2">
-          <p class="text-xs">Update ready! Restart to apply.</p>
+          <p class="text-xs">
+            {#if $updateVersion}
+              Version <span class="font-mono font-medium">{$updateVersion}</span> downloaded, restart to apply.
+            {:else}
+              Update downloaded, restart to apply.
+            {/if}
+          </p>
           <button
             class="px-3 py-1.5 text-xs rounded-lg bg-(--color-accent) text-white hover:opacity-90 transition-opacity"
             onclick={() => restartApp()}
@@ -463,7 +463,7 @@
           <p class="text-xs text-red-600 dark:text-red-400">Update check failed: {$updateError}</p>
           <button
             class="px-3 py-1.5 text-xs rounded-lg border border-(--color-border) hover:bg-(--color-surface-hover) transition-colors"
-            onclick={() => checkForUpdate()}
+            onclick={() => checkAndAutoDownload()}
           >
             Retry
           </button>

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,6 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
 import { relaunch } from '@tauri-apps/plugin-process';
 import { updateStatus, updateVersion, updateError } from './stores';
+import { get } from 'svelte/store';
 
 interface UpdateMetadata {
   version: string;
@@ -9,7 +10,11 @@ interface UpdateMetadata {
   date: string | null;
 }
 
-export async function checkForUpdate() {
+/**
+ * Check for updates. If an update is available, returns true.
+ * Does not automatically download - call checkAndAutoDownload() for that behavior.
+ */
+export async function checkForUpdate(): Promise<boolean> {
   updateStatus.set('checking');
   updateError.set(null);
   try {
@@ -17,24 +22,69 @@ export async function checkForUpdate() {
     if (metadata) {
       updateVersion.set(metadata.version);
       updateStatus.set('available');
+      return true;
     } else {
       updateStatus.set('up-to-date');
       setTimeout(() => updateStatus.set('idle'), 10000);
+      return false;
     }
   } catch (e) {
     updateError.set(e instanceof Error ? e.message : String(e));
     updateStatus.set('error');
+    return false;
   }
 }
 
-export async function downloadAndInstall() {
+/**
+ * Download and install a pending update.
+ * Returns true if download succeeded, false otherwise.
+ */
+export async function downloadAndInstall(): Promise<boolean> {
   updateStatus.set('downloading');
   try {
     await invoke('download_and_install_update');
     updateStatus.set('ready');
+    return true;
   } catch (e) {
     updateError.set(e instanceof Error ? e.message : String(e));
     updateStatus.set('error');
+    return false;
+  }
+}
+
+/**
+ * Show a system notification that an update is ready to install.
+ */
+export async function showUpdateNotification(version: string): Promise<void> {
+  try {
+    await invoke('show_update_notification', { version });
+  } catch (e) {
+    console.error('Failed to show update notification:', e);
+  }
+}
+
+/**
+ * Check for updates and automatically download if available.
+ * Shows a system notification when the update is ready.
+ * Skips if already downloading or ready.
+ */
+export async function checkAndAutoDownload(): Promise<void> {
+  const currentStatus = get(updateStatus);
+
+  // Skip if already downloading or ready
+  if (currentStatus === 'downloading' || currentStatus === 'ready') {
+    return;
+  }
+
+  const hasUpdate = await checkForUpdate();
+  if (hasUpdate) {
+    const downloadSuccess = await downloadAndInstall();
+    if (downloadSuccess) {
+      const version = get(updateVersion);
+      if (version) {
+        await showUpdateNotification(version);
+      }
+    }
   }
 }
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,21 +2,21 @@
   import '../app.css';
   import { onMount } from 'svelte';
   import { listen } from '@tauri-apps/api/event';
-  import { checkForUpdate } from '$lib/updater';
+  import { checkAndAutoDownload } from '$lib/updater';
   import { Toaster } from 'svelte-sonner';
 
   let { children } = $props();
 
   onMount(() => {
-    // Check for updates 5s after launch
-    const initialTimeout = setTimeout(() => checkForUpdate(), 5000);
+    // Check for updates and auto-download 5s after launch
+    const initialTimeout = setTimeout(() => checkAndAutoDownload(), 5000);
 
     // Re-check every 4 hours
-    const interval = setInterval(() => checkForUpdate(), 4 * 60 * 60 * 1000);
+    const interval = setInterval(() => checkAndAutoDownload(), 4 * 60 * 60 * 1000);
 
     // Listen for tray "Check for Updates" event
     const unlisten = listen('check-for-update', () => {
-      checkForUpdate();
+      checkAndAutoDownload();
     });
 
     return () => {


### PR DESCRIPTION
## Summary
Implement auto-download updates with system notification for the Endara Desktop app.

## Changes

### Rust Backend
- Add `tauri-plugin-notification` dependency to `Cargo.toml`
- Add notification permissions to `capabilities/default.json`
- Add `show_update_notification` command in `lib.rs` to show system notifications via Tauri

### Frontend Flow
- **updater.ts**: Add `checkAndAutoDownload()` function that:
  1. Checks for updates
  2. If available, immediately downloads (no user click needed)
  3. Shows system notification when ready
  - Skips if already downloading or ready
- **+layout.svelte**: Use `checkAndAutoDownload()` instead of `checkForUpdate()` for the initial 5s check, 4h interval, and tray trigger
- **Settings.svelte**:
  - Remove the "Download & Install" button (updates auto-download now)
  - Combine `available` and `downloading` states into a single downloading spinner UI
  - Keep "Restart Now" button for when update is ready
  - Update "Check for Updates" and "Retry" buttons to use auto-download flow

### Behavior
- When an update is detected, it auto-downloads in background
- System notification shows: **"Endara Desktop Update Ready"** / **"Version X.Y.Z is ready to install. Open Endara to restart."**
- User can restart from Settings page or via tray
- Manual "Check for Updates" from tray still works (triggers auto-download)

### Notes on Notification Actions
The Tauri notification plugin's action buttons API is mobile-only. On desktop (macOS/Windows/Linux), we show a basic notification. Clicking the notification may not trigger an event consistently across platforms, so the Settings page remains the primary place to trigger restart.

## Verification
- `cargo check --manifest-path src-tauri/Cargo.toml` ✅
- `npm run check && npm run build` ✅

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author