### PR TITLE
fix: navigate to Settings tab when Check for Updates is clicked from tray

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
   import { onMount } from 'svelte';
   import { listen } from '@tauri-apps/api/event';
   import { checkAndAutoDownload } from '$lib/updater';
+  import { activeTopLevelTab } from '$lib/stores';
   import { Toaster } from 'svelte-sonner';
 
   let { children } = $props();
@@ -16,6 +17,7 @@
 
     // Listen for tray "Check for Updates" event
     const unlisten = listen('check-for-update', () => {
+      activeTopLevelTab.set('settings');
       checkAndAutoDownload();
     });
 


### PR DESCRIPTION
## Summary

Fixes the "Check for Updates" tray menu item so that it navigates to the Settings tab before running the update check.

## Changes

- Import `activeTopLevelTab` from `$lib/stores` in `+layout.svelte`
- Set `activeTopLevelTab.set('settings')` in the `check-for-update` event listener before calling `checkAndAutoDownload()`

## Testing

- `npm run check` passes with 0 errors and 0 warnings
- Manual testing: Click "Check for Updates" from tray → app opens to Settings tab with update spinner visible

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author