### PR TITLE
chore: add prepare script to run svelte-kit sync after install

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "vitest run",
     "test:catalog": "RUN_LIVE_TESTS=1 vitest run src/lib/catalog.test.ts",
     "test:watch": "vitest",
+    "prepare": "svelte-kit sync",
     "tauri": "tauri"
   },
   "license": "MIT",


### PR DESCRIPTION
## Summary

Adds `"prepare": "svelte-kit sync"` to `package.json` scripts so SvelteKit's generated files are produced automatically after `npm install`.

## Why

On a fresh checkout (or after `rm -rf .svelte-kit`), users see this warning on the first build:

```
▲ [WARNING] Cannot find base config file "./.svelte-kit/tsconfig.json" [tsconfig.json]
```

`tsconfig.json` extends `./.svelte-kit/tsconfig.json`, a file generated by `svelte-kit sync`. Until `sync` runs the extended file doesn't exist, so Vite/esbuild emit the warning.

npm's `prepare` lifecycle hook is the recommended spot for generated-file tooling: it runs automatically after `npm install`, so the generated `tsconfig.json` is present before anything else references it.

## Verification

```
rm -rf .svelte-kit node_modules
npm install        # prepare fires, .svelte-kit/tsconfig.json is created
npm run build      # "Cannot find base config file" warning no longer emitted
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author