### PR TITLE
fix(desktop): keep update channel UI in sync with backend

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -100,8 +100,18 @@ fn read_config() -> Result<toml::Table, String> {
 }
 
 /// Serialize and write a `toml::Table` back to `~/.endara/config.toml`.
+/// Ensures the parent directory exists before writing so a missing `~/.endara/`
+/// does not surface as an unhelpful "No such file or directory" error.
 fn write_config(table: &toml::Table) -> Result<(), String> {
     let path = config_path()?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            format!(
+                "Failed to create config directory {}: {e}",
+                parent.display()
+            )
+        })?;
+    }
     let new_contents =
         toml::to_string_pretty(table).map_err(|e| format!("Failed to serialize config: {e}"))?;
     std::fs::write(&path, &new_contents).map_err(|e| format!("Failed to write config: {e}"))
@@ -168,6 +178,15 @@ pub struct UpdateMetadata {
     pub current_version: String,
     pub body: Option<String>,
     pub date: Option<String>,
+}
+
+/// Event payload emitted from `check_for_update` so the frontend can display
+/// which channel was actually used for the check (and cannot visually drift
+/// from the persisted value).
+#[derive(Serialize, Clone)]
+pub struct UpdateCheckedPayload {
+    pub channel: String,
+    pub url: String,
 }
 
 async fn emit_sidecar_status(app: &AppHandle, status: &str, error: Option<String>) {
@@ -519,6 +538,16 @@ async fn check_for_update(
     } else {
         STABLE_UPDATE_URL
     };
+
+    // Surface the effective channel so the UI can display which feed was checked
+    // and stay in sync with the persisted backend value on every check.
+    let _ = app.emit(
+        "update://checked",
+        UpdateCheckedPayload {
+            channel: channel.clone(),
+            url: url.to_string(),
+        },
+    );
 
     let update = app
         .updater_builder()

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { theme, jsExecutionMode, relayPort, relayConnected, relaySidecarStatus, relaySidecarError, updateStatus, updateVersion, updateError, updateChannel } from '$lib/stores';
+  import { theme, jsExecutionMode, relayPort, relayConnected, relaySidecarStatus, relaySidecarError, updateStatus, updateVersion, updateError, updateChannel, lastCheckedChannel } from '$lib/stores';
   import type { Theme, RelayStatus } from '$lib/types';
   import { invoke } from '@tauri-apps/api/core';
   import { getStatus, getConfig, reloadConfig } from '$lib/api';
@@ -57,6 +57,15 @@
   let selectedChannel: 'stable' | 'beta' = $state('stable');
   let channelChanging = $state(false);
 
+  // Keep the local toggle state in sync with the `updateChannel` store so any
+  // backend-sourced re-sync (e.g. from `checkAndAutoDownload` or the
+  // `update://checked` event) is reflected in the UI without manual wiring.
+  $effect(() => {
+    if ($updateChannel === 'stable' || $updateChannel === 'beta') {
+      selectedChannel = $updateChannel;
+    }
+  });
+
   function setTheme(t: Theme) {
     theme.set(t);
   }
@@ -65,7 +74,6 @@
     try {
       const channel = await getUpdateChannel();
       if (channel === 'stable' || channel === 'beta') {
-        selectedChannel = channel;
         updateChannel.set(channel);
       }
     } catch (e) {
@@ -77,10 +85,12 @@
     if (channelChanging || channel === selectedChannel) return;
     const previousChannel = selectedChannel;
     channelChanging = true;
+    // Optimistically reflect the change so the toggle feels responsive; we
+    // revert on failure below.
+    selectedChannel = channel;
+    updateChannel.set(channel);
     try {
       await setUpdateChannel(channel);
-      selectedChannel = channel;
-      updateChannel.set(channel);
       // Show info toast when switching from beta to stable
       if (previousChannel === 'beta' && channel === 'stable') {
         toast.info("You're now on the stable channel. You'll stay on your current version until a stable release newer than your current version is available.");
@@ -88,7 +98,12 @@
       // Immediately check for updates on the new channel (auto-downloads if available)
       await checkAndAutoDownload();
     } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
       console.error('Failed to set update channel:', e);
+      toast.error(`Failed to switch update channel: ${message}`);
+      // Revert the optimistic UI change so the toggle reflects persisted truth.
+      selectedChannel = previousChannel;
+      updateChannel.set(previousChannel);
     } finally {
       channelChanging = false;
     }
@@ -468,6 +483,12 @@
             Retry
           </button>
         </div>
+      {/if}
+
+      {#if $lastCheckedChannel}
+        <p class="text-[0.65rem] text-(--color-text-secondary)/70 mt-2">
+          Checked {$lastCheckedChannel} channel
+        </p>
       {/if}
     </div>
   </div>

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -126,4 +126,7 @@ export const updateStatus = writable<string>('idle');
 export const updateVersion = writable<string | null>(null);
 export const updateError = writable<string | null>(null);
 export const updateChannel = writable<'stable' | 'beta'>('stable');
+// The channel that was actually used on the most recent update check, sourced
+// from the Rust `update://checked` event. Null until the first check runs.
+export const lastCheckedChannel = writable<'stable' | 'beta' | null>(null);
 

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,6 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import { relaunch } from '@tauri-apps/plugin-process';
-import { updateStatus, updateVersion, updateError } from './stores';
+import { updateStatus, updateVersion, updateError, updateChannel, lastCheckedChannel } from './stores';
 import { get } from 'svelte/store';
 
 interface UpdateMetadata {
@@ -8,6 +8,24 @@ interface UpdateMetadata {
   current_version: string;
   body: string | null;
   date: string | null;
+}
+
+/**
+ * Read the persisted update channel from the Rust backend and push it into the
+ * `updateChannel` store. Called before every update check so the toggle in
+ * Settings cannot visually drift from the value actually used by the updater.
+ */
+export async function syncUpdateChannel(): Promise<'stable' | 'beta' | null> {
+  try {
+    const channel = await getUpdateChannel();
+    if (channel === 'stable' || channel === 'beta') {
+      updateChannel.set(channel);
+      return channel;
+    }
+  } catch (e) {
+    console.error('Failed to sync update channel from backend:', e);
+  }
+  return null;
 }
 
 /**
@@ -76,6 +94,13 @@ export async function checkAndAutoDownload(): Promise<void> {
     return;
   }
 
+  // Re-read the channel from the backend on every check so the UI can't drift
+  // from the persisted value the updater will actually use.
+  const effectiveChannel = await syncUpdateChannel();
+  if (effectiveChannel) {
+    console.log(`[updater] checking ${effectiveChannel} channel`);
+  }
+
   const hasUpdate = await checkForUpdate();
   if (hasUpdate) {
     const downloadSuccess = await downloadAndInstall();
@@ -86,6 +111,24 @@ export async function checkAndAutoDownload(): Promise<void> {
       }
     }
   }
+}
+
+/**
+ * Register a listener for the `update://checked` event emitted from Rust on
+ * every `check_for_update` call. Populates `lastCheckedChannel` and logs the
+ * effective feed URL. Returns an unlisten function.
+ */
+export async function listenForUpdateChecks(): Promise<() => void> {
+  const { listen } = await import('@tauri-apps/api/event');
+  return listen<{ channel: string; url: string }>('update://checked', (event) => {
+    const { channel, url } = event.payload;
+    if (channel === 'stable' || channel === 'beta') {
+      lastCheckedChannel.set(channel);
+      // Keep the channel store aligned with the channel the backend actually used.
+      updateChannel.set(channel);
+    }
+    console.log(`[updater] backend checked ${channel} feed at ${url}`);
+  });
 }
 
 export async function restartApp() {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,7 +2,7 @@
   import '../app.css';
   import { onMount } from 'svelte';
   import { listen } from '@tauri-apps/api/event';
-  import { checkAndAutoDownload } from '$lib/updater';
+  import { checkAndAutoDownload, listenForUpdateChecks } from '$lib/updater';
   import { activeTopLevelTab } from '$lib/stores';
   import { Toaster } from 'svelte-sonner';
 
@@ -21,10 +21,15 @@
       checkAndAutoDownload();
     });
 
+    // Listen for backend `update://checked` events so the UI reflects the
+    // channel the updater actually used on every check.
+    const unlistenChecked = listenForUpdateChecks();
+
     return () => {
       clearTimeout(initialTimeout);
       clearInterval(interval);
       unlisten.then((fn) => fn());
+      unlistenChecked.then((fn) => fn());
     };
   });
 </script>


### PR DESCRIPTION
## Problem

Users on rc.1 reported `Update check failed: Could not fetch a valid release JSON…` in Settings → Updates while the Beta toggle visually appeared selected. Toggling Stable → Beta fixed it, confirming the backend was reading `stable` from `~/.endara/config.toml` while the UI was showing `beta`. The persisted config was correct (`[desktop] update_channel = "beta"`), so the desync was in the UI↔backend sync pattern plus a few latent error-handling gaps.

## Fixes

1. **UI resyncs on every check (centralized in `updater.ts`).** `checkAndAutoDownload` now calls a new `syncUpdateChannel()` helper that reads the persisted channel from the Rust backend and pushes it into the `updateChannel` store before invoking `check_for_update`. Settings.svelte has a `$effect` that mirrors `$updateChannel` into `selectedChannel`, so the toggle can no longer visually drift from persisted truth on any check path (5s-after-launch timer, 4h timer, tray "Check for Updates", Retry button, channel toggle).

2. **Effective channel is surfaced via event** — *chose the event option over extending `UpdateMetadata`*. Rust `check_for_update` now emits `update://checked` with `{ channel, url }` immediately before building the updater. The frontend registers `listenForUpdateChecks()` in `+layout.svelte`, stores the result in a new `lastCheckedChannel` store, and renders a small caption in the Updates panel (`Checked {channel} channel`). Rationale: the event covers both the update-available and up-to-date cases (where no `UpdateMetadata` is returned) with a single mechanism.

3. **Failures are surfaced.** On `setUpdateChannel` error, Settings.svelte now shows a `toast.error(...)` and reverts both `selectedChannel` and the `updateChannel` store to the previous value. The optimistic UI update is applied first for responsiveness and undone on failure.

4. **`write_config` is defensive.** Added `std::fs::create_dir_all(parent)` before `std::fs::write` in `write_config`, with a useful error message if creation fails. A fresh system without `~/.endara/` can now toggle channels without tripping a "No such file or directory" error.

## No-ops (by design)

- `read_update_channel` default remains `"stable"`.
- Stable and Beta feed URLs, pubkey, and `latest.json` format unchanged.
- Version stays at `0.1.1`.
- No change to the release workflow.
- No redesign of the Settings UI beyond the small caption line.

## Verification

- `cd src-tauri && cargo fmt --check` — ✅ clean.
- `cd src-tauri && cargo check` — ✅ clean (this is what CI runs).
- `npm run build` — ✅ clean.
- `npm run check` — ✅ 0 errors / 0 warnings.
- `npm test` — 204 pass / 1 pre-existing failure in `src/lib/logListener.test.ts > only initializes once` (reproduces on `origin/main`, unrelated to this PR).
- `cd src-tauri && cargo clippy -- -D warnings` — pre-existing `single_match` warning on `src/lib.rs:1226` that also reproduces on `origin/main`. Not fixed here per the scope rule ("do not attempt to fix unrelated breakage"). CI uses `cargo check`, not clippy, so this does not block the build.

### Manual sanity checklist

- [ ] With `~/.endara/config.toml` containing `[desktop] update_channel = "beta"`, open Settings → Updates: Beta toggle reflects persisted value; "Check for Updates" shows `Checked beta channel` caption.
- [ ] With no `[desktop]` section, toggle reads "stable" and a check hits `releases/latest/download/latest.json`.
- [ ] Delete `~/.endara/` entirely, launch app, toggle to Beta — write succeeds (directory is created).
- [ ] Make config file read-only, toggle channel — toast error appears, toggle snaps back.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author