### PR TITLE
fix: baseline-align endpoint row meta

### DIFF
--- a/src/lib/components/EndpointRow.svelte
+++ b/src/lib/components/EndpointRow.svelte
@@ -40,7 +40,7 @@
     <div
       class="text-[13px] font-medium truncate {isFailed ? 'text-(--offline)' : 'text-(--fg1)'}"
     >{endpoint.name}</div>
-    <div class="flex items-center gap-1.5 mt-px">
+    <div class="flex items-baseline gap-1.5 mt-px">
       <TransportBadge transport={endpoint.transport} />
       {#if isFailed}
         <span


### PR DESCRIPTION
Aligns the OAUTH pill and meta text ("needs login" / "N tools" / "Disabled") in the sidebar endpoint row by their text baselines instead of vertical midpoints.

Before: `items-center` → pill baseline sat ~2px below the mono text baseline.
After: `items-baseline` → baselines match.

`TransportBadge`'s internal `items-center` is preserved (centers glyphs inside the pill).

## Verification

- `npm run check` → 0
- `npm run test` → 205 passed / 24 skipped / 0 failed
- Diff: 1 file, 1 line (`items-center` → `items-baseline`).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author