### PR TITLE
feat: add Craft to OAuth catalog

### DIFF
--- a/src/lib/data/oauth-catalog.test.ts
+++ b/src/lib/data/oauth-catalog.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { oauthCatalog } from './oauth-catalog';
 
 describe('oauthCatalog', () => {
-  it('should have exactly 5 entries', () => {
-    expect(oauthCatalog).toHaveLength(5);
+  it('should have exactly 6 entries', () => {
+    expect(oauthCatalog).toHaveLength(6);
   });
 
   it('should not include Google Drive', () => {
@@ -46,6 +46,14 @@ describe('oauthCatalog', () => {
     expect(todoist).toBeDefined();
     expect(todoist!.url).toBe('https://ai.todoist.net/mcp');
     expect(todoist!.supportsDcr).toBe(true);
+  });
+
+  it('should have the correct Craft entry', () => {
+    const craft = oauthCatalog.find((entry) => entry.id === 'craft');
+    expect(craft).toBeDefined();
+    expect(craft!.url).toBe('https://mcp.craft.do/my/mcp');
+    expect(craft!.supportsDiscovery).toBe(true);
+    expect(craft!.supportsDcr).toBe(true);
   });
 });
 

--- a/src/lib/data/oauth-catalog.ts
+++ b/src/lib/data/oauth-catalog.ts
@@ -76,5 +76,17 @@ export const oauthCatalog: OAuthCatalogEntry[] = [
     supportsDcr: true,
     notes: 'Task and project management',
   },
+  {
+    id: 'craft',
+    name: 'Craft',
+    description: 'Docs, notes, and knowledge base',
+    icon: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14 4.5H7a3 3 0 0 0-3 3v5a3 3 0 0 0 3 3h7M14 4.5a3 3 0 0 1 0 6H7M14 4.5v6"/></svg>',
+    category: 'productivity',
+    url: 'https://mcp.craft.do/my/mcp',
+    defaultScopes: ['read', 'write'],
+    supportsDiscovery: true,
+    supportsDcr: true,
+    notes: 'Docs and notes from your Craft workspace',
+  },
 ];
 


### PR DESCRIPTION
Adds a new OAuth-based suggested server entry for [Craft](https://www.craft.do/) at `https://mcp.craft.do/my/mcp`.

## Verification

Discovery confirmed via `curl`:
- Protected-resource metadata at `https://mcp.craft.do/.well-known/oauth-protected-resource/my/mcp` returns `authorization_servers: ["https://mcp.craft.do/my/auth"]` → `supportsDiscovery: true`.
- Authorization-server metadata at `https://mcp.craft.do/my/auth/.well-known/oauth-authorization-server` exposes `registration_endpoint: https://mcp.craft.do/my/auth/register` → `supportsDcr: true` (no manual client credentials required).
- Grants: `authorization_code`, `refresh_token`. PKCE S256.

## Changes

- `src/lib/data/oauth-catalog.ts`: append `craft` entry (productivity, `['read', 'write']` scopes, discovery + DCR enabled, inline 20×20 SVG icon).
- `src/lib/data/oauth-catalog.test.ts`: bump count assertion `5 → 6` and add a Craft-specific assertion mirroring the Linear/Notion blocks.

No changes to `AddEndpointModal.svelte` / `AddEndpointModal.test.ts` — they read `oauthCatalog.length` dynamically.

## Tests

All three pass locally from `packages/desktop`:

```bash
npx vitest run src/lib/data/oauth-catalog.test.ts   # 8 passed
npx vitest run src/lib/components/AddEndpointModal.test.ts   # 22 passed
npm run check   # 0 errors, 0 warnings
```


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author