### PR TITLE
refactor(add-endpoint): move OAuth Scopes into Advanced and collapse by default

### DIFF
--- a/src/lib/components/AddEndpointModal.svelte
+++ b/src/lib/components/AddEndpointModal.svelte
@@ -694,19 +694,19 @@
             <input id="modal-ep-url" type="text" bind:value={url} placeholder="https://mcp.linear.app/sse"
               class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent)" />
           </div>
-          <div>
-            <label for="modal-ep-scopes" class="block text-xs font-medium mb-1 text-(--fg2)">Scopes <span class="text-(--fg2)/50">(optional, space-separated)</span></label>
-            <input id="modal-ep-scopes" type="text" bind:value={scopes} placeholder="read write"
-              class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent)" />
-            <p class="text-[11px] text-(--fg2) mt-0.5">Space-separated. Leave blank for server defaults.</p>
-          </div>
 
-          <!-- Collapsible Advanced section — collapsed by default when from catalog -->
-          <details class="border border-(--border) rounded-lg" open={!selectedOAuthEntry}>
+          <!-- Collapsible Advanced section — collapsed by default for all OAuth flows -->
+          <details class="border border-(--border) rounded-lg">
             <summary class="px-3 py-2 text-xs font-medium text-(--fg2) cursor-pointer hover:bg-(--surface-hover) rounded-lg select-none">
               Advanced
             </summary>
             <div class="px-3 pb-3 space-y-3">
+              <div>
+                <label for="modal-ep-scopes" class="block text-xs font-medium mb-1 text-(--fg2)">Scopes <span class="text-(--fg2)/50">(optional, space-separated)</span></label>
+                <input id="modal-ep-scopes" type="text" bind:value={scopes} placeholder="read write"
+                  class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent)" />
+                <p class="text-[11px] text-(--fg2) mt-0.5">Space-separated. Leave blank for server defaults.</p>
+              </div>
               <div>
                 <label for="modal-ep-oauth-url" class="block text-xs font-medium mb-1 text-(--fg2)">OAuth Server URL</label>
                 <input id="modal-ep-oauth-url" type="text" bind:value={oauthServerUrl} placeholder="Auto-discovered"


### PR DESCRIPTION
## Summary

Reduce clutter in the OAuth endpoint form by moving the **Scopes** field into the **Advanced** collapsible section, and ensure Advanced starts collapsed for both catalog-selected and custom OAuth flows.

## Changes

- `src/lib/components/AddEndpointModal.svelte`
  - Move the Scopes label / input (`#modal-ep-scopes`) / helper text inside the `<details>` Advanced block, placed above OAuth Server URL.
  - Remove the conditional `open={!selectedOAuthEntry}` on `<details>` so Advanced starts collapsed for every OAuth flow.

No changes to scopes binding (`bind:value={scopes}`), default scope population from `service.defaultScopes`, or submit serialization.

## Verification

From `packages/desktop`:

- ✅ `npm run check` — 0 errors, 0 warnings
- ✅ `npm run lint` — no linter configured (script is a no-op)
- ✅ `npm test -- AddEndpointModal` — 22/22 passed

### Manual smoke test

1. Open Add Endpoint → Custom Server → OAuth → confirm **Advanced** section is collapsed and the **Scopes** field is no longer visible at the top.
2. Expand Advanced → confirm Scopes input renders, accepts input, and binds to the `scopes` state.
3. Select an OAuth catalog entry (e.g., Linear, GitHub) → confirm Advanced is collapsed; expand and confirm Scopes is pre-populated from `service.defaultScopes`.
4. Submit the form → confirm scopes are serialized as before.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author