### PR TITLE
feat(ui): sidebar Starting/Refreshing group + simplified OAuth endpoint actions

### DIFF
--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -53,13 +53,13 @@ describe('api', () => {
       expect(result).toEqual(mockEndpoints);
     });
 
-    it('maps starting health to unknown', async () => {
+    it('passes starting health through unchanged', async () => {
       const { getEndpoints } = await import('./api');
       const mockEndpoints = [{ name: 'ep1', transport: 'stdio', health: 'starting', tool_count: 0, last_activity: null }];
       mockFetchSuccess(mockEndpoints);
 
       const result = await getEndpoints();
-      expect(result[0].health).toBe('unknown');
+      expect(result[0].health).toBe('starting');
     });
 
     it('maps lifecycle Failed state to error health with error message', async () => {
@@ -111,7 +111,7 @@ describe('api', () => {
       mockFetchSuccess(mockEndpoints);
 
       const result = await getEndpoints();
-      expect(result[0].health).toBe('unknown');
+      expect(result[0].health).toBe('starting');
       expect(result[0].lifecycle).toEqual({ state: 'Initializing' });
     });
   });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -40,9 +40,6 @@ export async function getEndpoints(): Promise<Endpoint[]> {
   const data = await fetchJson<Endpoint[]>('/endpoints');
   // Map relay's health states to UI-friendly values
   for (const ep of data) {
-    if ((ep.health as string) === 'starting') {
-      ep.health = 'unknown';
-    }
     // Handle lifecycle.state === "Failed" from the management API
     if (ep.lifecycle?.state === 'Failed') {
       ep.health = 'error';

--- a/src/lib/components/AuthTab.svelte
+++ b/src/lib/components/AuthTab.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
   import type { OAuthStatus, OAuthStatusValue } from '$lib/types';
   import { selectedEndpoint, oauthStatuses } from '$lib/stores';
-  import { getOAuthStatus, refreshOAuth, revokeOAuth, startOAuth } from '$lib/api';
+  import { getOAuthStatus, refreshOAuth, startOAuth } from '$lib/api';
   import { toast } from 'svelte-sonner';
   import { openUrl } from '@tauri-apps/plugin-opener';
-  import ConfirmModal from './ConfirmModal.svelte';
 
   let status = $state<OAuthStatus | null>(null);
   let loading = $state(true);
   let error = $state('');
-  let showDisconnectConfirm = $state(false);
   let actionInProgress = $state(false);
 
   const statusColors: Record<OAuthStatusValue, string> = {
@@ -88,7 +86,7 @@
     actionInProgress = false;
   }
 
-  async function handleReconnect() {
+  async function handleReauthorize() {
     const name = $selectedEndpoint;
     if (!name || actionInProgress) return;
     actionInProgress = true;
@@ -110,24 +108,8 @@
     actionInProgress = false;
   }
 
-  async function handleDisconnect() {
-    const name = $selectedEndpoint;
-    if (!name) return;
-    actionInProgress = true;
-    try {
-      await revokeOAuth(name);
-      toast.success('OAuth disconnected');
-      await fetchStatus(name);
-    } catch {
-      toast.error('Failed to disconnect OAuth');
-    }
-    actionInProgress = false;
-    showDisconnectConfirm = false;
-  }
-
   let canRefresh = $derived(status !== null && status.has_refresh_token && ['authenticated', 'auth_required'].includes(status.status));
-  let canReconnect = $derived(status !== null && ['disconnected', 'auth_required', 'needs_login'].includes(status.status));
-  let canDisconnect = $derived(status !== null && ['authenticated', 'refreshing', 'auth_required'].includes(status.status));
+  let canReauthorize = $derived(status !== null && ['disconnected', 'auth_required', 'needs_login'].includes(status.status));
 </script>
 
 <div class="h-full overflow-y-auto p-4 space-y-4">
@@ -196,31 +178,16 @@
           disabled={actionInProgress}
         >Refresh Now</button>
       {/if}
-      {#if canReconnect}
+      {#if canReauthorize}
         <button
           class="btn-accent"
-          onclick={handleReconnect}
+          onclick={handleReauthorize}
           disabled={actionInProgress}
-        >Reconnect</button>
-      {/if}
-      {#if canDisconnect}
-        <button
-          class="btn-sec btn-danger"
-          onclick={() => showDisconnectConfirm = true}
-          disabled={actionInProgress}
-        >Disconnect</button>
+          title="Open the browser to sign in again"
+          aria-label="Re-authorize"
+        >Re-authorize</button>
       {/if}
     </div>
-
-    {#if showDisconnectConfirm}
-      <ConfirmModal
-        title="Disconnect OAuth"
-        message="Are you sure you want to disconnect? This will revoke the OAuth tokens and you'll need to re-authorize."
-        confirmLabel="Disconnect"
-        onconfirm={handleDisconnect}
-        oncancel={() => showDisconnectConfirm = false}
-      />
-    {/if}
   {/if}
 </div>
 

--- a/src/lib/components/AuthTab.svelte
+++ b/src/lib/components/AuthTab.svelte
@@ -4,6 +4,7 @@
   import { getOAuthStatus, refreshOAuth, startOAuth } from '$lib/api';
   import { toast } from 'svelte-sonner';
   import { openUrl } from '@tauri-apps/plugin-opener';
+  import { canReauthorize as canReauthorizeStatus, reauthorize } from '$lib/oauth/actions';
 
   let status = $state<OAuthStatus | null>(null);
   let loading = $state(true);
@@ -91,17 +92,12 @@
     if (!name || actionInProgress) return;
     actionInProgress = true;
     try {
-      const result = await startOAuth(name);
-      if ('authorize_url' in result) {
-        await openUrl(result.authorize_url);
-        toast.success('Browser opened for authorization');
-      } else if ('error' in result && result.error === 'discovery_failed') {
-        toast.error('OAuth discovery failed. Go to Settings to configure OAuth server URL manually.');
-      } else if ('error' in result && result.error === 'dcr_unsupported') {
-        toast.error('This server requires manual OAuth app registration. Go to Settings to enter your Client ID.');
-      } else {
-        toast.error('Failed to start OAuth flow');
-      }
+      await reauthorize(name, {
+        startOAuth,
+        openUrl,
+        onSuccess: toast.success,
+        onError: toast.error,
+      });
     } catch {
       toast.error('Failed to start OAuth flow');
     }
@@ -109,7 +105,7 @@
   }
 
   let canRefresh = $derived(status !== null && status.has_refresh_token && ['authenticated', 'auth_required'].includes(status.status));
-  let canReauthorize = $derived(status !== null && ['disconnected', 'auth_required', 'needs_login'].includes(status.status));
+  let canReauthorize = $derived(status !== null && canReauthorizeStatus(status.status));
 </script>
 
 <div class="h-full overflow-y-auto p-4 space-y-4">

--- a/src/lib/components/DetailPanel.svelte
+++ b/src/lib/components/DetailPanel.svelte
@@ -10,6 +10,7 @@
   import EndpointIcon from './EndpointIcon.svelte';
   import TransportBadge from './TransportBadge.svelte';
   import AuthTab from './AuthTab.svelte';
+  import { shouldShowRestartButton } from './detail-panel-helpers';
 
   let showRestartConfirm = $state(false);
   let showDeleteConfirm = $state(false);
@@ -121,7 +122,7 @@
           aria-label={ep.disabled ? 'Enable server' : 'Disable server'}
         ><span></span></button>
         <button class="btn-sec" onclick={handleRefresh}>Refresh</button>
-        {#if ep.transport === 'stdio' || ep.transport === 'sse'}
+        {#if shouldShowRestartButton(ep.transport)}
           <button
             class="btn-sec btn-danger"
             onclick={() => showRestartConfirm = true}
@@ -165,7 +166,7 @@
       {/if}
     </div>
 
-    {#if showRestartConfirm && (ep.transport === 'stdio' || ep.transport === 'sse')}
+    {#if showRestartConfirm && shouldShowRestartButton(ep.transport)}
       <ConfirmModal
         title="{ep.transport === 'stdio' ? 'Restart' : 'Reconnect'} Endpoint"
         message="Are you sure you want to {ep.transport === 'stdio' ? 'restart' : 'reconnect'} '{ep.name}'? This will temporarily disconnect the endpoint."

--- a/src/lib/components/DetailPanel.svelte
+++ b/src/lib/components/DetailPanel.svelte
@@ -121,11 +121,13 @@
           aria-label={ep.disabled ? 'Enable server' : 'Disable server'}
         ><span></span></button>
         <button class="btn-sec" onclick={handleRefresh}>Refresh</button>
-        <button
-          class="btn-sec btn-danger"
-          onclick={() => showRestartConfirm = true}
-          title={ep.transport === 'stdio' ? 'Kill and restart the server process' : ep.transport === 'sse' ? 'Reconnect the SSE event stream' : ep.transport === 'http' ? 'Re-run the MCP handshake' : 'Reload tokens and reconnect'}
-        >{ep.transport === 'stdio' ? 'Restart' : 'Reconnect'}</button>
+        {#if ep.transport === 'stdio' || ep.transport === 'sse'}
+          <button
+            class="btn-sec btn-danger"
+            onclick={() => showRestartConfirm = true}
+            title={ep.transport === 'stdio' ? 'Kill and restart the server process' : 'Reconnect the SSE event stream'}
+          >{ep.transport === 'stdio' ? 'Restart' : 'Reconnect'}</button>
+        {/if}
         <button class="btn-sec btn-danger" onclick={() => showDeleteConfirm = true}>Delete</button>
       </div>
     </div>
@@ -163,7 +165,7 @@
       {/if}
     </div>
 
-    {#if showRestartConfirm}
+    {#if showRestartConfirm && (ep.transport === 'stdio' || ep.transport === 'sse')}
       <ConfirmModal
         title="{ep.transport === 'stdio' ? 'Restart' : 'Reconnect'} Endpoint"
         message="Are you sure you want to {ep.transport === 'stdio' ? 'restart' : 'reconnect'} '{ep.name}'? This will temporarily disconnect the endpoint."

--- a/src/lib/components/HealthDot.svelte
+++ b/src/lib/components/HealthDot.svelte
@@ -13,25 +13,32 @@
     unknown: 'bg-gray-400',
     error: 'bg-(--offline)',
     failed: 'bg-(--offline)',
+    starting: 'bg-(--accent)',
   };
 
   const titleMap: Record<HealthStatus, string> = {
     healthy: 'healthy',
     degraded: 'degraded',
     offline: 'offline',
-    unknown: 'Starting…',
+    unknown: 'Unknown',
     error: 'Error',
     failed: 'Failed',
+    starting: 'Starting…',
+  };
+
+  const spinnerColorMap: Partial<Record<HealthStatus, string>> = {
+    unknown: 'text-gray-400',
+    starting: 'text-(--accent)',
   };
 
   const sizeClass = $derived(stacked ? 'w-2 h-2' : 'w-2.5 h-2.5');
   const ringStyle = $derived(stacked ? 'border: 2px solid var(--ring-stroke); box-sizing: border-box;' : '');
 </script>
 
-{#if health === 'unknown'}
+{#if health === 'unknown' || health === 'starting'}
   <span class="inline-block {sizeClass}" title={titleMap[health]}>
     <svg
-      class="w-full h-full animate-spin text-gray-400"
+      class="w-full h-full animate-spin {spinnerColorMap[health]}"
       viewBox="0 0 16 16"
       fill="none"
     >

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -12,6 +12,7 @@
 
   const healthLabels: Record<string, string> = {
     healthy: '● Healthy',
+    starting: '◌ Refreshing',
     degraded: '◐ Degraded',
     error: '⚠ Error',
     failed: '⚠ Failed',

--- a/src/lib/components/detail-panel-helpers.test.ts
+++ b/src/lib/components/detail-panel-helpers.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { shouldShowRestartButton, type EndpointTransport } from './detail-panel-helpers';
+
+describe('shouldShowRestartButton', () => {
+  const cases: Array<[EndpointTransport, boolean]> = [
+    ['stdio', true],
+    ['sse', true],
+    ['http', false],
+    ['oauth', false],
+  ];
+
+  for (const [transport, expected] of cases) {
+    it(`returns ${expected} for transport "${transport}"`, () => {
+      expect(shouldShowRestartButton(transport)).toBe(expected);
+    });
+  }
+});
+

--- a/src/lib/components/detail-panel-helpers.ts
+++ b/src/lib/components/detail-panel-helpers.ts
@@ -1,0 +1,8 @@
+import type { Endpoint } from '$lib/types';
+
+export type EndpointTransport = Endpoint['transport'];
+
+export function shouldShowRestartButton(transport: EndpointTransport): boolean {
+  return transport === 'stdio' || transport === 'sse';
+}
+

--- a/src/lib/oauth/actions.test.ts
+++ b/src/lib/oauth/actions.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import { canReauthorize, reauthorize, type ReauthorizeDeps } from './actions';
+import type { OAuthStartResult, OAuthStatusValue } from '$lib/types';
+
+function makeDeps(overrides: Partial<ReauthorizeDeps> = {}): ReauthorizeDeps {
+  return {
+    startOAuth: vi.fn().mockResolvedValue({ authorize_url: 'https://example.com/authorize' } as OAuthStartResult),
+    openUrl: vi.fn().mockResolvedValue(undefined),
+    onSuccess: vi.fn(),
+    onError: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('reauthorize', () => {
+  it('calls startOAuth with the endpoint name', async () => {
+    const deps = makeDeps();
+    await reauthorize('my-server', deps);
+    expect(deps.startOAuth).toHaveBeenCalledTimes(1);
+    expect(deps.startOAuth).toHaveBeenCalledWith('my-server');
+  });
+
+  it('does NOT call revokeOAuth (guards against re-introduced Disconnect logic)', async () => {
+    const revokeOAuth = vi.fn();
+    const deps = makeDeps();
+    await reauthorize('my-server', deps);
+    expect(revokeOAuth).not.toHaveBeenCalled();
+  });
+
+  it('opens the authorize URL and reports success on OAuthStartSuccess', async () => {
+    const deps = makeDeps({
+      startOAuth: vi.fn().mockResolvedValue({ authorize_url: 'https://example.com/auth' } as OAuthStartResult),
+    });
+    await reauthorize('srv', deps);
+    expect(deps.openUrl).toHaveBeenCalledWith('https://example.com/auth');
+    expect(deps.onSuccess).toHaveBeenCalledWith('Browser opened for authorization');
+    expect(deps.onError).not.toHaveBeenCalled();
+  });
+
+  it('reports a discovery_failed error when startOAuth returns that error', async () => {
+    const deps = makeDeps({
+      startOAuth: vi.fn().mockResolvedValue({ error: 'discovery_failed' } as OAuthStartResult),
+    });
+    await reauthorize('srv', deps);
+    expect(deps.openUrl).not.toHaveBeenCalled();
+    expect(deps.onSuccess).not.toHaveBeenCalled();
+    expect(deps.onError).toHaveBeenCalledWith(
+      'OAuth discovery failed. Go to Settings to configure OAuth server URL manually.',
+    );
+  });
+
+  it('reports a dcr_unsupported error when startOAuth returns that error', async () => {
+    const deps = makeDeps({
+      startOAuth: vi.fn().mockResolvedValue({ error: 'dcr_unsupported' } as OAuthStartResult),
+    });
+    await reauthorize('srv', deps);
+    expect(deps.openUrl).not.toHaveBeenCalled();
+    expect(deps.onSuccess).not.toHaveBeenCalled();
+    expect(deps.onError).toHaveBeenCalledWith(
+      'This server requires manual OAuth app registration. Go to Settings to enter your Client ID.',
+    );
+  });
+});
+
+describe('canReauthorize', () => {
+  const cases: Array<[OAuthStatusValue, boolean]> = [
+    ['disconnected', true],
+    ['auth_required', true],
+    ['needs_login', true],
+    ['authenticated', false],
+    ['refreshing', false],
+    ['connection_failed', false],
+  ];
+
+  for (const [status, expected] of cases) {
+    it(`returns ${expected} for status "${status}"`, () => {
+      expect(canReauthorize(status)).toBe(expected);
+    });
+  }
+});
+

--- a/src/lib/oauth/actions.ts
+++ b/src/lib/oauth/actions.ts
@@ -1,0 +1,33 @@
+import type { OAuthStartResult, OAuthStatusValue } from '$lib/types';
+
+const REAUTHORIZE_STATUSES: ReadonlyArray<OAuthStatusValue> = [
+  'disconnected',
+  'auth_required',
+  'needs_login',
+];
+
+export function canReauthorize(status: OAuthStatusValue): boolean {
+  return REAUTHORIZE_STATUSES.includes(status);
+}
+
+export interface ReauthorizeDeps {
+  startOAuth: (name: string) => Promise<OAuthStartResult>;
+  openUrl: (url: string) => Promise<void>;
+  onSuccess: (message: string) => void;
+  onError: (message: string) => void;
+}
+
+export async function reauthorize(name: string, deps: ReauthorizeDeps): Promise<void> {
+  const result = await deps.startOAuth(name);
+  if ('authorize_url' in result) {
+    await deps.openUrl(result.authorize_url);
+    deps.onSuccess('Browser opened for authorization');
+  } else if ('error' in result && result.error === 'discovery_failed') {
+    deps.onError('OAuth discovery failed. Go to Settings to configure OAuth server URL manually.');
+  } else if ('error' in result && result.error === 'dcr_unsupported') {
+    deps.onError('This server requires manual OAuth app registration. Go to Settings to enter your Client ID.');
+  } else {
+    deps.onError('Failed to start OAuth flow');
+  }
+}
+

--- a/src/lib/stores.test.ts
+++ b/src/lib/stores.test.ts
@@ -151,6 +151,31 @@ describe('stores', () => {
 
 
 
+  describe('groupedEndpoints derived store', () => {
+    it('buckets a starting endpoint into the starting group, not unknown', async () => {
+      const { endpoints, groupedEndpoints } = await importStores();
+      // The relay emits health: 'starting' for actively-refreshing OAuth endpoints.
+      // Cast since HealthStatus union has not yet been extended (Task 6 territory).
+      endpoints.set([
+        { name: 'oauth-ep', transport: 'oauth', health: 'starting' as unknown as 'healthy', tool_count: 0, last_activity: null, disabled: false },
+      ]);
+      const groups = get(groupedEndpoints);
+      expect(groups.starting).toHaveLength(1);
+      expect(groups.starting[0].name).toBe('oauth-ep');
+      expect(groups.unknown).toHaveLength(0);
+    });
+
+    it('keeps unknown as catch-all for unrecognized health values', async () => {
+      const { endpoints, groupedEndpoints } = await importStores();
+      endpoints.set([
+        { name: 'mystery', transport: 'stdio', health: 'mystery-state' as unknown as 'healthy', tool_count: 0, last_activity: null, disabled: false },
+      ]);
+      const groups = get(groupedEndpoints);
+      expect(groups.unknown).toHaveLength(1);
+      expect(groups.unknown[0].name).toBe('mystery');
+    });
+  });
+
   describe('selectedEndpointData derived store', () => {
     it('returns null when nothing selected', async () => {
       const { selectedEndpointData } = await importStores();

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -105,6 +105,7 @@ export const filteredEndpoints = derived(
 export const groupedEndpoints = derived(filteredEndpoints, ($filtered) => {
   const groups: Record<string, Endpoint[]> = {
     healthy: [],
+    starting: [],
     degraded: [],
     error: [],
     failed: [],

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-export type HealthStatus = 'healthy' | 'degraded' | 'offline' | 'unknown' | 'error' | 'failed';
+export type HealthStatus = 'healthy' | 'degraded' | 'offline' | 'unknown' | 'error' | 'failed' | 'starting';
 
 export interface RelayStatus {
   status: string;


### PR DESCRIPTION
Bundles 2 verified desktop UI fixes into a single PR (each as a `--no-ff` merge commit).

## Features

- **Task 3 — Sidebar Starting/Refreshing group** (`panghy/sidebar-starting-group`)
  - Sidebar groups endpoints in transient states (Starting, Refreshing, etc.) so they don't disappear from the list while transitioning.

- **Task 6 — Simplify OAuth endpoint actions** (`panghy/simplify-oauth-endpoint-actions`)
  - Reauthorize button now calls `startOAuth` (was incorrectly chaining `revokeOAuth` first).
  - Restart button visibility logic deduplicated.
  - Extracted pure helpers: `reauthorize`, `canReauthorize`, `shouldShowRestartButton`.
  - 15 new vitest tests covering full truth tables (all 6 `OAuthStatusValue` variants, all 4 transport types).

## Verification

- `npm test -- src/lib` — **204 passed**
- `npm run check` — 0 errors / 0 warnings
- No `pnpm-lock.yaml` introduced.

