### PR TITLE
fix(ui): eliminate Welcome flash on startup

### DIFF
--- a/src/lib/stores.test.ts
+++ b/src/lib/stores.test.ts
@@ -115,37 +115,53 @@ describe('stores', () => {
   });
 
   describe('showOnboarding derived store', () => {
-    it('shows when no endpoints, not dismissed, and initial load complete', async () => {
-      const { endpoints, onboardingDismissed, initialLoadComplete, showOnboarding } = await importStores();
+    it('shows when no endpoints, not dismissed, initial load complete, and relay connected', async () => {
+      const { endpoints, onboardingDismissed, initialLoadComplete, relayConnected, showOnboarding } = await importStores();
       endpoints.set([]);
       onboardingDismissed.set(false);
       initialLoadComplete.set(true);
+      relayConnected.set(true);
       expect(get(showOnboarding)).toBe(true);
     });
 
     it('hides when dismissed', async () => {
-      const { endpoints, onboardingDismissed, initialLoadComplete, showOnboarding } = await importStores();
+      const { endpoints, onboardingDismissed, initialLoadComplete, relayConnected, showOnboarding } = await importStores();
       endpoints.set([]);
       onboardingDismissed.set(true);
       initialLoadComplete.set(true);
+      relayConnected.set(true);
       expect(get(showOnboarding)).toBe(false);
     });
 
     it('hides before initial load completes', async () => {
-      const { endpoints, onboardingDismissed, initialLoadComplete, showOnboarding } = await importStores();
+      const { endpoints, onboardingDismissed, initialLoadComplete, relayConnected, showOnboarding } = await importStores();
       endpoints.set([]);
       onboardingDismissed.set(false);
       initialLoadComplete.set(false);
+      relayConnected.set(true);
       expect(get(showOnboarding)).toBe(false);
     });
 
-    it('shows even when relay sidecar has failed', async () => {
-      const { endpoints, onboardingDismissed, initialLoadComplete, relaySidecarStatus, showOnboarding } = await importStores();
+    it('hides while the relay is not connected, even if initial load was marked complete', async () => {
+      // Regression: a failed pre-startup poll used to flip initialLoadComplete to true,
+      // which briefly satisfied showOnboarding and flashed Welcome before the relay came up.
+      const { endpoints, onboardingDismissed, initialLoadComplete, relayConnected, showOnboarding } = await importStores();
       endpoints.set([]);
       onboardingDismissed.set(false);
       initialLoadComplete.set(true);
+      relayConnected.set(false);
+      expect(get(showOnboarding)).toBe(false);
+    });
+
+    it('hides when relay sidecar has failed and we are not connected', async () => {
+      // The dedicated relay-startup-failure UI should take precedence here; Welcome must not flash.
+      const { endpoints, onboardingDismissed, initialLoadComplete, relayConnected, relaySidecarStatus, showOnboarding } = await importStores();
+      endpoints.set([]);
+      onboardingDismissed.set(false);
+      initialLoadComplete.set(true);
+      relayConnected.set(false);
       relaySidecarStatus.set('failed');
-      expect(get(showOnboarding)).toBe(true);
+      expect(get(showOnboarding)).toBe(false);
     });
   });
 

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -82,10 +82,19 @@ function createRelayPortStore() {
 }
 export const relayPort = createRelayPortStore();
 
+// Welcome ("Onboarding") should only appear once we have a definitive answer
+// from the relay: the initial poll succeeded (`initialLoadComplete`), the relay
+// is reachable (`relayConnected`), and it reported zero endpoints. Otherwise
+// during cold-start we'd flash Welcome between a blank list and the real list.
 export const showOnboarding = derived(
-  [endpoints, onboardingDismissed, initialLoadComplete],
-  ([$endpoints, $onboardingDismissed, $initialLoadComplete]) => {
-    return $initialLoadComplete && $endpoints.length === 0 && !$onboardingDismissed;
+  [endpoints, onboardingDismissed, initialLoadComplete, relayConnected],
+  ([$endpoints, $onboardingDismissed, $initialLoadComplete, $relayConnected]) => {
+    return (
+      $initialLoadComplete &&
+      $relayConnected &&
+      $endpoints.length === 0 &&
+      !$onboardingDismissed
+    );
   }
 );
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -55,10 +55,13 @@
 
   async function pollEndpoints() {
     const currentStatus = get(relaySidecarStatus);
-    // If sidecar failed (e.g., port conflict), don't poll — we're not managing what's on that port
+    // If sidecar failed (e.g., port conflict), don't poll — we're not managing what's on that port.
+    // Treat that as a definitive load so the UI can route to the failure screen instead of
+    // showing the loading spinner indefinitely.
     if (shouldSkipEndpointPolling(currentStatus)) {
       relayConnected.set(false);
       endpoints.set([]);
+      initialLoadComplete.set(true);
       return;
     }
     try {
@@ -84,11 +87,24 @@
       if (inferredStatus === 'starting' || inferredStatus === 'unknown') {
         relaySidecarStatus.set('running');
       }
+      // Only mark the initial load complete once we've actually heard back from
+      // the relay — otherwise a failed pre-startup poll would briefly satisfy
+      // showOnboarding's gate and flash the Welcome screen.
+      initialLoadComplete.set(true);
     } catch {
       relayConnected.set(false);
       endpoints.set([]);
     }
   }
+
+  // Show a "Starting relay…" loading state on the servers tab while the sidecar
+  // is still coming up and we haven't yet successfully connected. This replaces
+  // the prior empty Sidebar/DetailPanel flash before the first poll succeeds.
+  const showServersLoading = $derived(
+    !$relayConnected &&
+    !$initialLoadComplete &&
+    ($relaySidecarStatus === 'starting' || $relaySidecarStatus === 'unknown')
+  );
 
   onMount(() => {
     // Sync the relay port FROM the Rust backend (config.toml is the source of truth)
@@ -98,7 +114,7 @@
       }
     }).catch(() => {});
     initRelayLogListener();
-    pollEndpoints().then(() => initialLoadComplete.set(true));
+    pollEndpoints();
     pollInterval = setInterval(pollEndpoints, 2000);
   });
 
@@ -227,12 +243,25 @@
 
     <!-- Tab content -->
     <div class="flex-1 overflow-hidden">
-      <div class="h-full" style:display={$activeTopLevelTab === 'servers' ? ($showOnboarding ? 'block' : 'flex') : 'none'}>
+      <div class="h-full" style:display={$activeTopLevelTab === 'servers' ? 'block' : 'none'}>
         {#if $showOnboarding}
           <Onboarding />
+        {:else if showServersLoading}
+          <div class="flex h-full items-center justify-center">
+            <div class="flex flex-col items-center gap-3 text-(--fg3)">
+              <div
+                class="h-6 w-6 animate-spin rounded-full border-2 border-(--border) border-t-(--accent)"
+                role="status"
+                aria-label="Starting relay"
+              ></div>
+              <p class="text-sm">Starting relay…</p>
+            </div>
+          </div>
         {:else}
-          <Sidebar bind:this={sidebar} />
-          <DetailPanel />
+          <div class="flex h-full">
+            <Sidebar bind:this={sidebar} />
+            <DetailPanel />
+          </div>
         {/if}
       </div>
       <div class="h-full" style:display={$activeTopLevelTab === 'unified-catalog' ? 'block' : 'none'}>


### PR DESCRIPTION
## Summary

Fixes the cold-start flicker on the desktop app where the UI sequenced through three states: blank server list (1–2 s) → **Welcome to Endara** screen (1–2 s) → real server list. The expected behavior is loading → server list (or loading → Welcome, only for genuinely empty configs).

## Root cause

`initialLoadComplete` was being flipped to `true` after the very first poll attempt regardless of whether the relay was actually reachable. Because `showOnboarding` only gated on `initialLoadComplete && endpoints.length === 0 && !onboardingDismissed`, a single failed pre-startup poll briefly satisfied that gate and flashed the Welcome screen before the real endpoints arrived.

## Changes

- **`src/lib/stores.ts`** — Tighten `showOnboarding` so it also requires `relayConnected === true`. Welcome can only appear after a definitive successful poll.
- **`src/routes/+page.svelte`** —
  - Only set `initialLoadComplete = true` after a poll actually returns a response from the relay, not in the catch path.
  - When sidecar polling is intentionally skipped (sidecar has `failed`/`stopped`), still mark the load complete so the existing relay-startup-failure screen can take over instead of stalling on the loading state.
  - Add a centered `Starting relay…` spinner on the servers tab while sidecar status is `starting`/`unknown` and we have not yet connected. This replaces the empty `<Sidebar/> <DetailPanel/>` flash.
- **`src/lib/stores.test.ts`** — Update `showOnboarding` derived tests for the new gating and add a regression test that covers the "poll failed before relay was up" case.

The existing `shouldShowRelayStartupFailure` flow is unchanged and still takes precedence over both Welcome and the new loading state when the sidecar fails.

## Verification

In `packages/desktop`:

```
npm run check   # 0 errors, 0 warnings
npm run lint    # no linter configured
npm test        # 224 passed, 24 skipped
```

## Bug

startup flicker: blank list → Welcome → server list.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author