### PR TITLE
docs(readme): lead Download with Homebrew Cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,17 @@ The app provides a visual interface for everything the relay exposes: endpoint h
 
 ## Download
 
-Download the latest release from [GitHub Releases](https://github.com/endara-ai/endara-desktop/releases).
+### macOS — Homebrew (recommended)
+
+```bash
+brew install --cask endara-ai/tap/endara
+```
+
+This installs the latest signed & notarized DMG from the [`endara-ai/homebrew-tap`](https://github.com/endara-ai/homebrew-tap) tap and registers the app for `brew upgrade`. Tauri's built-in updater also continues to work, so you'll get new versions whichever way you prefer.
+
+### Direct downloads
+
+Or grab an installer directly from [GitHub Releases](https://github.com/endara-ai/endara-desktop/releases) — useful on Windows / Linux, or if you don't use Homebrew.
 
 | Platform | Format | File |
 |----------|--------|------|


### PR DESCRIPTION
Restructures the `## Download` section to lead with the Homebrew Cask install on macOS (recommended), keeping the existing direct-download installer table below as the alternative for Windows / Linux users (or anyone who doesn't use Homebrew).

`brew install --cask endara-ai/tap/endara` has been live and working since v0.1.1 — this just surfaces it as the preferred path in the README.

Tap repo: https://github.com/endara-ai/homebrew-tap

README-only; no code, workflow, or version changes.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author