### PR TITLE
fix: update Linear MCP URL from /sse to /mcp

### DIFF
--- a/src/lib/components/AddEndpointModal.svelte
+++ b/src/lib/components/AddEndpointModal.svelte
@@ -691,7 +691,7 @@
         {:else if transport === 'oauth'}
           <div>
             <label for="modal-ep-url" class="block text-xs font-medium mb-1 text-(--fg2)">Server URL</label>
-            <input id="modal-ep-url" type="text" bind:value={url} placeholder="https://mcp.linear.app/sse"
+            <input id="modal-ep-url" type="text" bind:value={url} placeholder="https://mcp.linear.app/mcp"
               class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent)" />
           </div>
 

--- a/src/lib/data/oauth-catalog.test.ts
+++ b/src/lib/data/oauth-catalog.test.ts
@@ -36,7 +36,7 @@ describe('oauthCatalog', () => {
   it('should have the correct Linear URL', () => {
     const linear = oauthCatalog.find((entry) => entry.id === 'linear');
     expect(linear).toBeDefined();
-    expect(linear!.url).toBe('https://mcp.linear.app/sse');
+    expect(linear!.url).toBe('https://mcp.linear.app/mcp');
     expect(linear!.supportsDiscovery).toBe(true);
     expect(linear!.supportsDcr).toBe(true);
   });

--- a/src/lib/data/oauth-catalog.ts
+++ b/src/lib/data/oauth-catalog.ts
@@ -20,7 +20,7 @@ export const oauthCatalog: OAuthCatalogEntry[] = [
     description: 'Issue tracking and project management',
     icon: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3.5 16.5l2.8-2.8a7 7 0 0 1-.8-3.2A7 7 0 0 1 12.5 3.5l.5.5a7 7 0 0 1-7 7 7 7 0 0 1-3.2-.8L3.5 16.5z" fill="currentColor" stroke="none"/></svg>',
     category: 'developer',
-    url: 'https://mcp.linear.app/sse',
+    url: 'https://mcp.linear.app/mcp',
     defaultScopes: ['read', 'write'],
     supportsDiscovery: true,
     supportsDcr: true,


### PR DESCRIPTION
Standardize Linear MCP catalog entry on the streamable HTTP `/mcp` endpoint to match other catalog entries (Notion, Slack, Todoist, etc.).

## Changes

- `src/lib/data/oauth-catalog.ts` — Linear entry `url`: `/sse` → `/mcp`
- `src/lib/data/oauth-catalog.test.ts` — assertion updated to match
- `src/lib/components/AddEndpointModal.svelte` — placeholder text updated for consistency

## Verification

- `npm test` — all 224 tests pass (24 skipped)
- `npm run check` — 0 errors, 0 warnings
- `npm run lint` — passes (no linter configured)

Linear MCP server publishes both `/sse` (SSE) and `/mcp` (streamable HTTP); standardizing on `/mcp`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author