### PR TITLE
feat: allow cancelling in-flight OAuth browser attempt

### DIFF
--- a/src/lib/components/AddEndpointModal.svelte
+++ b/src/lib/components/AddEndpointModal.svelte
@@ -44,6 +44,7 @@
   let dcrClientId = $state('');
   let dcrClientSecret = $state('');
   let pendingSetupSessionId: string | null = $state(null);
+  let setupAuthCancelled = $state(false);
 
   let prefixPreview = $derived(prefix ? `${prefix}__tool` : 'prefix__tool');
 
@@ -351,6 +352,7 @@
   }
 
   async function handleOAuthSubmit() {
+    setupAuthCancelled = false;
     error = '';
     if (!name.trim()) { error = 'Name is required'; return; }
     if (!url.trim()) { error = 'Server URL is required'; return; }
@@ -409,8 +411,10 @@
     const maxAttempts = 120;
     for (let i = 0; i < maxAttempts; i++) {
       await new Promise((r) => setTimeout(r, 1000));
+      if (setupAuthCancelled) return;
       try {
         const statusResult = await oauthSetupStatus(sessionId);
+        if (setupAuthCancelled) return;
         if (statusResult.status === 'authorized') {
           // Authorization complete — commit the endpoint to config.toml
           try {
@@ -439,12 +443,23 @@
         // Polling error, continue
       }
     }
+    if (setupAuthCancelled) return;
     error = 'OAuth authorization timed out. Please try again.';
     // Clean up on timeout — no config was ever written
     if (pendingSetupSessionId) {
       try { await oauthSetupCancel(pendingSetupSessionId); } catch { /* best effort */ }
       pendingSetupSessionId = null;
     }
+  }
+
+  async function handleCancelAuth() {
+    setupAuthCancelled = true;
+    if (pendingSetupSessionId) {
+      try { await oauthSetupCancel(pendingSetupSessionId); } catch { /* best effort */ }
+      pendingSetupSessionId = null;
+    }
+    submitting = false;
+    error = 'OAuth attempt cancelled. Edit the fields and try again.';
   }
 
   async function handleDcrFallbackSubmit() {
@@ -938,6 +953,18 @@
         {/if}
 
         {#if !showingDcrFallback}
+          {#if submitting && pendingSetupSessionId}
+            <div class="flex items-center justify-between gap-2 pt-1">
+              <p class="text-[11px] text-(--fg2)">Waiting for browser authorization…</p>
+              <button
+                type="button"
+                class="text-xs text-(--accent) hover:text-(--accent-hover) underline"
+                onclick={handleCancelAuth}
+              >
+                Cancel auth attempt
+              </button>
+            </div>
+          {/if}
           <div class="flex justify-end gap-2 pt-2">
             <button
               class="px-3 py-1.5 text-sm rounded-lg border border-(--border) hover:bg-(--surface-hover) transition-colors"


### PR DESCRIPTION
## Summary

Adds a **Cancel auth attempt** control to `AddEndpointModal` that appears while the user is waiting on the browser to complete OAuth (`submitting && pendingSetupSessionId`). Clicking it:

1. Cancels the relay setup session via `oauthSetupCancel`.
2. Sets a `setupAuthCancelled` flag so the polling loop exits within ~1s.
3. Re-enables the form (clears `submitting`, clears `pendingSetupSessionId`).
4. Shows a friendly hint: _“OAuth attempt cancelled. Edit the fields and try again.”_
5. Does **not** close the modal and does **not** clear any form fields, so the user can fix a typo and retry.

A small _“Waiting for browser authorization…”_ hint is rendered next to the Cancel auth button.

The existing footer **Cancel** button keeps its current behavior (cancel session + close modal).

## Scope

- One file changed: `src/lib/components/AddEndpointModal.svelte` (+27 lines).
- No relay changes — `DELETE /api/oauth/setup/{id}` already exists.
- Touches `pollForSetupAuth()` only to add cancellation checks; `handleOAuthSubmit()` and `handleDcrFallbackSubmit()` bodies are otherwise untouched (only a single line at the very top of `handleOAuthSubmit` resets the cancel flag, intentionally coordinated with the parallel Wave 1 work on the same component).

## Verification

```
cd packages/desktop
npm run check  # 0 errors / 0 warnings
npm test       # 224 passed | 24 skipped
```

## Manual test plan

1. Start a Custom OAuth connection.
2. When the browser opens, return to the app.
3. Click **Cancel auth attempt** — within ~1s the form is editable, the hint is shown, and all entered values are preserved.
4. Edit a field, click Save & Connect again — flow proceeds normally.
5. Verify footer **Cancel** still closes the modal and cancels the session.

Part of the OAuth setup fix tracked alongside the Advanced-fields end-to-end task.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author