### PR TITLE
feat(oauth): pass advanced OAuth fields through to setup API

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -269,6 +269,9 @@ export interface OAuthSetupParams {
   url: string;
   scopes?: string[];
   tool_prefix?: string;
+  oauth_server_url?: string;
+  client_id?: string;
+  client_secret?: string;
 }
 
 export async function oauthSetup(params: OAuthSetupParams): Promise<OAuthSetupResponse> {

--- a/src/lib/components/AddEndpointModal.svelte
+++ b/src/lib/components/AddEndpointModal.svelte
@@ -370,6 +370,15 @@
     if (scopes.trim()) {
       setupParams.scopes = scopes.trim().split(/\s+/);
     }
+    if (oauthServerUrl.trim()) {
+      setupParams.oauth_server_url = oauthServerUrl.trim();
+    }
+    if (clientId.trim()) {
+      setupParams.client_id = clientId.trim();
+    }
+    if (clientSecret.trim()) {
+      setupParams.client_secret = clientSecret.trim();
+    }
 
     submitting = true;
     try {
@@ -377,13 +386,14 @@
       pendingSetupSessionId = result.session_id;
 
       if (result.status === 'awaiting_credentials' && result.dcr_error) {
-        // DCR failed — show manual credentials form
+        // DCR failed — show manual credentials form, prefilled from any
+        // advanced-section values the user already typed
         showingDcrFallback = true;
         dcrFallbackData = {
           authorization_endpoint: result.discovery?.auth_server,
         };
-        dcrClientId = '';
-        dcrClientSecret = '';
+        dcrClientId = clientId.trim();
+        dcrClientSecret = clientSecret.trim();
         submitting = false;
         return;
       }


### PR DESCRIPTION
## Summary

Forward the user-supplied **Client ID**, **Client Secret**, and **OAuth Server URL** from the Custom Server (OAUTH) Advanced section through `OAuthSetupParams` into the relay's `POST /api/oauth/setup` request.

Paired with [endara-relay#40](https://github.com/endara-ai/endara-relay/pull/40), which teaches the relay to skip Dynamic Client Registration when the caller provides an explicit `client_id`. End-to-end behaviour after both PRs merge:

- **With** Client ID + Client Secret filled in (e.g. Gmail): clicking *Save & Connect* opens the browser directly. No second "manual client registration" prompt.
- **Without** Client ID (e.g. Linear, which supports DCR): unchanged — DCR runs server-side as before, and the fallback panel still appears if DCR fails.

## Defensive UX bonus

If the DCR-fallback panel still ends up shown (e.g. relay returns `awaiting_credentials` for some other reason), `dcrClientId` / `dcrClientSecret` are now prefilled from the advanced-section values the user already typed, so they don't have to re-enter them.

## Scope

- `src/lib/api.ts`: extend `OAuthSetupParams` with optional `oauth_server_url`, `client_id`, `client_secret`.
- `src/lib/components/AddEndpointModal.svelte`: only `handleOAuthSubmit()` body is touched (plus the existing `dcrClientId/dcrClientSecret = ''` lines, which now copy from advanced-section state). `handleDcrFallbackSubmit`, `pollForSetupAuth`, `handleCancel`, the footer button layout, and all other modal behaviour are unchanged.

## Tests

- `npm run check` — 0 errors, 0 warnings.
- `npm test` — 224 passed / 24 skipped, no regressions.
- `npm run lint` — (no linter configured; passes trivially).

## Backwards compatibility

New fields on `OAuthSetupParams` are all optional and only included in the JSON body when the user actually filled them in. The relay-side fields use `#[serde(default)]`, so old desktop builds talking to a new relay (and vice-versa) continue to work.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author