### PR TITLE
feat: add Google MCP servers and disabled-server UX polish

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -158,6 +158,11 @@
   --degraded: var(--status-degraded);
   --offline:  var(--status-offline);
 
+  /* Needs-your-attention / manual-setup signal. NOT a live status —
+     used for things like "this OAuth provider needs manual client
+     registration". Distinct from --offline (runtime health). */
+  --attention: #DC2626;
+
   /* Desktop kit — chrome + window tokens (light) */
   --win-bg:        var(--paper-0);
   --win-border:    var(--paper-200);
@@ -211,6 +216,10 @@
   --healthy:  var(--status-healthy-dark);
   --degraded: var(--status-degraded-dark);
   --offline:  var(--status-offline-dark);
+
+  /* Needs-your-attention / manual-setup signal — lighter red so it
+     stays legible on dark surfaces. See light-mode comment above. */
+  --attention: #F87171;
 
   --shadow-1: 0 0 0 1px rgb(255 255 255 / 0.02);
   --shadow-2: 0 4px 12px rgb(0 0 0 / 0.4);

--- a/src/lib/components/AddEndpointModal.svelte
+++ b/src/lib/components/AddEndpointModal.svelte
@@ -4,6 +4,7 @@
   import { toast } from 'svelte-sonner';
   import { CATALOG_SERVERS, type CatalogServer } from '$lib/catalog';
   import { oauthCatalog, type OAuthCatalogEntry } from '$lib/data/oauth-catalog';
+  import { buildScopesPayload, shouldShowManualOAuthStar } from './add-endpoint-helpers';
   import { sanitizeName } from '$lib/utils';
   import { openUrl } from '@tauri-apps/plugin-opener';
   import { open as dialogOpen } from '@tauri-apps/plugin-dialog';
@@ -38,6 +39,7 @@
   let clientId = $state('');
   let clientSecret = $state('');
   let scopes = $state('');
+  let selectedScopes: Set<string> = $state(new Set());
   let selectedOAuthEntry: OAuthCatalogEntry | null = $state(null);
   let showingDcrFallback = $state(false);
   let dcrFallbackData: { authorization_endpoint?: string } = $state({});
@@ -48,6 +50,11 @@
   let cancelHint = $state('');
 
   let prefixPreview = $derived(prefix ? `${prefix}__tool` : 'prefix__tool');
+
+  let scopeMode: 'free' | 'checkbox' = $derived.by(() => {
+    const opts = selectedOAuthEntry?.availableScopes;
+    return opts && opts.length > 0 ? 'checkbox' : 'free';
+  });
 
   $effect(() => {
     if (!prefixCustom) {
@@ -111,7 +118,13 @@
     oauthServerUrl = service.oauthServerUrl || '';
     clientId = '';
     clientSecret = '';
-    scopes = service.defaultScopes.join(' ');
+    if (service.availableScopes && service.availableScopes.length > 0) {
+      scopes = '';
+      selectedScopes = new Set(service.defaultScopes);
+    } else {
+      scopes = service.defaultScopes.join(' ');
+      selectedScopes = new Set();
+    }
     envVars = [];
     headerVars = [];
     catalogEnvValues = {};
@@ -141,6 +154,7 @@
     clientId = '';
     clientSecret = '';
     scopes = '';
+    selectedScopes = new Set();
     showingDcrFallback = false;
     error = '';
     step = 'configure';
@@ -165,6 +179,7 @@
     clientId = '';
     clientSecret = '';
     scopes = '';
+    selectedScopes = new Set();
     showingDcrFallback = false;
     error = '';
     step = 'configure';
@@ -300,7 +315,11 @@
       if (oauthServerUrl.trim()) params.oauth_server_url = oauthServerUrl.trim();
       if (clientId.trim()) params.client_id = clientId.trim();
       if (clientSecret.trim()) params.client_secret = clientSecret.trim();
-      if (scopes.trim()) params.scopes = scopes.trim();
+      const scopesPayload = buildScopesPayload(
+        scopeMode,
+        scopeMode === 'checkbox' ? selectedScopes : scopes,
+      );
+      if (scopesPayload.string) params.scopes = scopesPayload.string;
     } else {
       if (!url.trim()) { error = 'URL is required'; return; }
       params.url = url.trim();
@@ -370,8 +389,12 @@
     if (prefixCustom && prefix !== defaultPrefix) {
       setupParams.tool_prefix = prefix;
     }
-    if (scopes.trim()) {
-      setupParams.scopes = scopes.trim().split(/\s+/);
+    const scopesPayload = buildScopesPayload(
+      scopeMode,
+      scopeMode === 'checkbox' ? selectedScopes : scopes,
+    );
+    if (scopesPayload.array) {
+      setupParams.scopes = scopesPayload.array;
     }
     if (oauthServerUrl.trim()) {
       setupParams.oauth_server_url = oauthServerUrl.trim();
@@ -567,7 +590,7 @@
       />
 
       <!-- Filter toggles -->
-      <div class="flex gap-2 mb-4">
+      <div class="flex gap-2 mb-2">
         <button
           class="px-3 py-1 text-xs rounded-full border transition-colors {showOAuth
             ? 'border-(--accent) bg-(--accent)/10 text-(--accent)'
@@ -585,6 +608,15 @@
           Local
         </button>
       </div>
+      {#if showOAuth}
+        <p class="text-[11px] text-(--fg2) mb-3 flex items-center gap-1">
+          <span
+            class="text-base text-(--attention) font-bold inline-flex items-center justify-center leading-none translate-y-[0.15em]"
+            aria-hidden="true"
+          >*</span>
+          <span>Requires OAuth Client ID and Secret</span>
+        </p>
+      {/if}
 
       <!-- Unified server list -->
       <div class="flex flex-col gap-2 mb-3">
@@ -597,6 +629,13 @@
             >
               <span class="w-5 h-5 flex-shrink-0 text-(--fg2)">{@html service.icon}</span>
               <span class="text-sm font-medium text-(--fg1) flex-shrink-0">{service.name}</span>
+              {#if shouldShowManualOAuthStar(service)}
+                <span
+                  class="text-base font-bold leading-none text-(--attention) flex-shrink-0 inline-flex items-center justify-center translate-y-[0.15em]"
+                  aria-label="Manual OAuth client registration required"
+                  title="Requires manual OAuth client registration — you'll need to create an OAuth client and provide Client ID/Secret"
+                >*</span>
+              {/if}
               <p class="text-xs text-(--fg2) line-clamp-1 flex-1 min-w-0">{service.description}</p>
               <div class="flex items-center gap-1.5 flex-shrink-0">
                 <span class="inline-block text-[10px] px-1.5 py-0.5 rounded-full bg-(--accent)/10 text-(--accent) font-medium">
@@ -746,18 +785,58 @@
               class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent)" />
           </div>
 
+          <!-- Curated scope checkbox list (only when the catalog entry exposes availableScopes) -->
+          {#if scopeMode === 'checkbox' && selectedOAuthEntry?.availableScopes}
+            <div>
+              <span class="block text-xs font-medium mb-1 text-(--fg2)">Scopes</span>
+              <div class="space-y-1.5">
+                {#each selectedOAuthEntry.availableScopes as opt (opt.scope)}
+                  <label class="flex items-start gap-2 text-sm text-(--fg1) cursor-pointer">
+                    <input
+                      type="checkbox"
+                      class="mt-0.5 accent-(--accent)"
+                      checked={selectedScopes.has(opt.scope)}
+                      onchange={(e) => {
+                        const next = new Set(selectedScopes);
+                        if ((e.currentTarget as HTMLInputElement).checked) next.add(opt.scope);
+                        else next.delete(opt.scope);
+                        selectedScopes = next;
+                      }}
+                    />
+                    <span class="flex-1">{opt.name}</span>
+                    <span
+                      class="text-(--fg2) cursor-help select-none flex-shrink-0"
+                      aria-label={`${opt.name}: ${opt.description} (scope: ${opt.scope})`}
+                      title={`${opt.description}\n${opt.scope}`}
+                    >ⓘ</span>
+                  </label>
+                {/each}
+              </div>
+              <p class="text-[11px] text-(--fg2) mt-1">Uncheck any scope you don't want to grant. Clearing all is equivalent to leaving scopes blank.</p>
+            </div>
+          {/if}
+
+          <!-- Manual-registration hint for OAuth providers that don't support DCR -->
+          {#if selectedOAuthEntry && selectedOAuthEntry.supportsDcr === false}
+            <p class="text-[11px] text-(--attention)">
+              * Requires an OAuth client created in your provider's console — paste the Client ID and Secret in Advanced below.
+            </p>
+          {/if}
+
           <!-- Collapsible Advanced section — collapsed by default for all OAuth flows -->
           <details class="border border-(--border) rounded-lg">
             <summary class="px-3 py-2 text-xs font-medium text-(--fg2) cursor-pointer hover:bg-(--surface-hover) rounded-lg select-none">
               Advanced
             </summary>
             <div class="px-3 pb-3 space-y-3">
-              <div>
-                <label for="modal-ep-scopes" class="block text-xs font-medium mb-1 text-(--fg2)">Scopes <span class="text-(--fg2)/50">(optional, space-separated)</span></label>
-                <input id="modal-ep-scopes" type="text" bind:value={scopes} placeholder="read write"
-                  class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent)" />
-                <p class="text-[11px] text-(--fg2) mt-0.5">Space-separated. Leave blank for server defaults.</p>
-              </div>
+              {#if scopeMode === 'free'}
+                <div>
+                  <label for="modal-ep-scopes" class="block text-xs font-medium mb-1 text-(--fg2)">Scopes <span class="text-(--fg2)/50">(optional, space-separated)</span></label>
+                  <input id="modal-ep-scopes" type="text" bind:value={scopes} placeholder="read write"
+                    class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent)" />
+                  <p class="text-[11px] text-(--fg2) mt-0.5">Space-separated. Leave blank for server defaults.</p>
+                </div>
+              {/if}
               <div>
                 <label for="modal-ep-oauth-url" class="block text-xs font-medium mb-1 text-(--fg2)">OAuth Server URL</label>
                 <input id="modal-ep-oauth-url" type="text" bind:value={oauthServerUrl} placeholder="Auto-discovered"

--- a/src/lib/components/AddEndpointModal.test.ts
+++ b/src/lib/components/AddEndpointModal.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { sanitizeName } from '$lib/utils';
 import { CATALOG_SERVERS, type CatalogServer } from '$lib/catalog';
 import { oauthCatalog, type OAuthCatalogEntry } from '$lib/data/oauth-catalog';
+import { buildScopesPayload, shouldShowManualOAuthStar } from './add-endpoint-helpers';
 
 describe('sanitizeName', () => {
   it('handles basic lowercase name', () => {
@@ -329,6 +330,114 @@ describe('AddEndpointModal unified browse list', () => {
       expect(oauthServerUrl).toBe('https://github.com/login/oauth');
       expect(scopeStr).toBe('repo read:user');
     });
+  });
+});
+
+describe('Scope handling', () => {
+  describe('buildScopesPayload — free-text mode', () => {
+    it('collapses internal whitespace and trims for the string form', () => {
+      const out = buildScopesPayload('free', '  read   write  ');
+      expect(out.string).toBe('read write');
+    });
+
+    it('splits on whitespace for the array form', () => {
+      const out = buildScopesPayload('free', '  read   write  ');
+      expect(out.array).toEqual(['read', 'write']);
+    });
+
+    it('returns undefined for empty input', () => {
+      expect(buildScopesPayload('free', '')).toEqual({ string: undefined, array: undefined });
+    });
+
+    it('returns undefined for whitespace-only input', () => {
+      expect(buildScopesPayload('free', '   \t  ')).toEqual({ string: undefined, array: undefined });
+    });
+
+    it('handles a single token', () => {
+      expect(buildScopesPayload('free', 'read')).toEqual({ string: 'read', array: ['read'] });
+    });
+  });
+
+  describe('buildScopesPayload — checkbox mode', () => {
+    it('joins Set members with single spaces in insertion order', () => {
+      // Order rule: the array follows Set insertion order; the modal seeds
+      // the Set from defaultScopes so the on-the-wire order matches the
+      // catalog entry.
+      const out = buildScopesPayload('checkbox', new Set(['a', 'b']));
+      expect(out.string).toBe('a b');
+      expect(out.array).toEqual(['a', 'b']);
+    });
+
+    it('preserves insertion order for arbitrary scope strings', () => {
+      const out = buildScopesPayload(
+        'checkbox',
+        new Set([
+          'https://www.googleapis.com/auth/gmail.readonly',
+          'https://www.googleapis.com/auth/gmail.compose',
+        ]),
+      );
+      expect(out.array).toEqual([
+        'https://www.googleapis.com/auth/gmail.readonly',
+        'https://www.googleapis.com/auth/gmail.compose',
+      ]);
+      expect(out.string).toBe(
+        'https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose',
+      );
+    });
+
+    it('returns undefined for an empty Set', () => {
+      expect(buildScopesPayload('checkbox', new Set())).toEqual({
+        string: undefined,
+        array: undefined,
+      });
+    });
+  });
+});
+
+describe('OAuth manual-registration flag', () => {
+  it('shouldShowManualOAuthStar returns true exactly for entries with supportsDcr === false', () => {
+    for (const entry of oauthCatalog) {
+      expect(shouldShowManualOAuthStar(entry)).toBe(entry.supportsDcr === false);
+    }
+  });
+
+  it('flags every catalog entry that lacks DCR support', () => {
+    const flagged = oauthCatalog.filter(shouldShowManualOAuthStar).map((e) => e.id);
+    const expected = oauthCatalog.filter((e) => e.supportsDcr === false).map((e) => e.id);
+    expect(flagged).toEqual(expected);
+  });
+
+  it('does not flag DCR-supporting entries', () => {
+    for (const entry of oauthCatalog) {
+      if (entry.supportsDcr === true) {
+        expect(shouldShowManualOAuthStar(entry)).toBe(false);
+      }
+    }
+  });
+});
+
+describe('Scope option shape', () => {
+  it('every availableScopes option appears in defaultScopes for the same entry', () => {
+    const entriesWithScopes = oauthCatalog.filter(
+      (e) => e.availableScopes && e.availableScopes.length > 0,
+    );
+    expect(entriesWithScopes.length).toBeGreaterThan(0);
+    for (const entry of entriesWithScopes) {
+      for (const opt of entry.availableScopes!) {
+        expect(entry.defaultScopes).toContain(opt.scope);
+      }
+    }
+  });
+
+  it('every availableScopes option has non-empty name and description', () => {
+    for (const entry of oauthCatalog) {
+      if (!entry.availableScopes) continue;
+      for (const opt of entry.availableScopes) {
+        expect(opt.scope.trim().length).toBeGreaterThan(0);
+        expect(opt.name.trim().length).toBeGreaterThan(0);
+        expect(opt.description.trim().length).toBeGreaterThan(0);
+      }
+    }
   });
 });
 

--- a/src/lib/components/DetailPanel.svelte
+++ b/src/lib/components/DetailPanel.svelte
@@ -10,23 +10,24 @@
   import EndpointIcon from './EndpointIcon.svelte';
   import TransportBadge from './TransportBadge.svelte';
   import AuthTab from './AuthTab.svelte';
-  import { shouldShowRestartButton } from './detail-panel-helpers';
+  import { shouldShowRestartButton, shouldShowRefreshButton, visibleTabs } from './detail-panel-helpers';
 
   let showRestartConfirm = $state(false);
   let showDeleteConfirm = $state(false);
   let toggling = $state(false);
 
-  const baseTabs = [
-    { id: 'tools' as const, label: 'Tools' },
-    { id: 'logs' as const, label: 'Logs' },
-    { id: 'config' as const, label: 'Config' },
-  ];
-
   let tabs = $derived(
-    $selectedEndpointData?.transport === 'oauth'
-      ? [...baseTabs, { id: 'auth' as const, label: 'Auth' }]
-      : baseTabs
+    $selectedEndpointData
+      ? visibleTabs($selectedEndpointData.transport, !!$selectedEndpointData.disabled)
+      : []
   );
+
+  $effect(() => {
+    const ep = $selectedEndpointData;
+    if (ep?.disabled && ($activeTab === 'tools' || $activeTab === 'logs')) {
+      activeTab.set('config');
+    }
+  });
 
   async function handleRestart() {
     const name = $selectedEndpoint;
@@ -121,8 +122,10 @@
           title={ep.disabled ? 'Enable server' : 'Disable server'}
           aria-label={ep.disabled ? 'Enable server' : 'Disable server'}
         ><span></span></button>
-        <button class="btn-sec" onclick={handleRefresh}>Refresh</button>
-        {#if shouldShowRestartButton(ep.transport)}
+        {#if shouldShowRefreshButton(!!ep.disabled)}
+          <button class="btn-sec" onclick={handleRefresh}>Refresh</button>
+        {/if}
+        {#if shouldShowRestartButton(ep.transport, !!ep.disabled)}
           <button
             class="btn-sec btn-danger"
             onclick={() => showRestartConfirm = true}
@@ -155,9 +158,9 @@
     </div>
 
     <div class="flex-1 overflow-hidden">
-      {#if $activeTab === 'tools'}
+      {#if $activeTab === 'tools' && !ep.disabled}
         <ToolsTab />
-      {:else if $activeTab === 'logs'}
+      {:else if $activeTab === 'logs' && !ep.disabled}
         <LogsTab />
       {:else if $activeTab === 'auth' && ep.transport === 'oauth'}
         <AuthTab />
@@ -166,7 +169,7 @@
       {/if}
     </div>
 
-    {#if showRestartConfirm && shouldShowRestartButton(ep.transport)}
+    {#if showRestartConfirm && shouldShowRestartButton(ep.transport, !!ep.disabled)}
       <ConfirmModal
         title="{ep.transport === 'stdio' ? 'Restart' : 'Reconnect'} Endpoint"
         message="Are you sure you want to {ep.transport === 'stdio' ? 'restart' : 'reconnect'} '{ep.name}'? This will temporarily disconnect the endpoint."

--- a/src/lib/components/add-endpoint-helpers.ts
+++ b/src/lib/components/add-endpoint-helpers.ts
@@ -1,0 +1,55 @@
+import type { OAuthCatalogEntry } from '$lib/data/oauth-catalog';
+
+export type ScopeMode = 'free' | 'checkbox';
+
+export interface ScopesPayload {
+  /** Space-separated form, used by `testConnection` / `AddEndpointParams.scopes`. */
+  string: string | undefined;
+  /** Array form, used by `oauthSetup` / `OAuthSetupParams.scopes`. */
+  array: string[] | undefined;
+}
+
+/**
+ * Serialize the user-edited scopes into the two shapes the rest of the modal
+ * needs.
+ *
+ * Free-text mode (no `availableScopes` on the catalog entry):
+ *   - whitespace-collapsed and trimmed for the string form
+ *   - `split(/\s+/)` for the array form
+ *   - empty/whitespace-only input → `undefined` for both (omit from payload)
+ *
+ * Checkbox mode (catalog entry exposes `availableScopes`):
+ *   - the array form is built directly from the Set; iteration order
+ *     is the Set's insertion order, which the modal seeds from
+ *     `defaultScopes` so the on-the-wire order matches the catalog
+ *   - the string form joins that array with single spaces
+ *   - empty Set → `undefined` for both (treated like blank scopes)
+ */
+export function buildScopesPayload(
+  mode: ScopeMode,
+  value: string | Set<string>,
+): ScopesPayload {
+  if (mode === 'free') {
+    const raw = typeof value === 'string' ? value : '';
+    const trimmed = raw.trim();
+    if (!trimmed) return { string: undefined, array: undefined };
+    const arr = trimmed.split(/\s+/);
+    return { string: arr.join(' '), array: arr };
+  }
+
+  const set = value instanceof Set ? value : new Set<string>();
+  if (set.size === 0) return { string: undefined, array: undefined };
+  const arr = Array.from(set);
+  return { string: arr.join(' '), array: arr };
+}
+
+/**
+ * Returns true when an OAuth catalog entry should display the red star
+ * indicator in the Add Server modal browse list — i.e. the provider does
+ * not support Dynamic Client Registration and the user has to bring their
+ * own Client ID/Secret.
+ */
+export function shouldShowManualOAuthStar(entry: OAuthCatalogEntry): boolean {
+  return entry.supportsDcr === false;
+}
+

--- a/src/lib/components/detail-panel-helpers.test.ts
+++ b/src/lib/components/detail-panel-helpers.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { shouldShowRestartButton, type EndpointTransport } from './detail-panel-helpers';
+import {
+  shouldShowRestartButton,
+  shouldShowRefreshButton,
+  visibleTabs,
+  type EndpointTransport,
+} from './detail-panel-helpers';
 
 describe('shouldShowRestartButton', () => {
   const cases: Array<[EndpointTransport, boolean]> = [
@@ -10,9 +15,73 @@ describe('shouldShowRestartButton', () => {
   ];
 
   for (const [transport, expected] of cases) {
-    it(`returns ${expected} for transport "${transport}"`, () => {
-      expect(shouldShowRestartButton(transport)).toBe(expected);
+    it(`returns ${expected} for transport "${transport}" when enabled`, () => {
+      expect(shouldShowRestartButton(transport, false)).toBe(expected);
     });
   }
+
+  describe('when disabled', () => {
+    const transports: EndpointTransport[] = ['stdio', 'sse', 'http', 'oauth'];
+    for (const transport of transports) {
+      it(`returns false for transport "${transport}" when disabled`, () => {
+        expect(shouldShowRestartButton(transport, true)).toBe(false);
+      });
+    }
+  });
+});
+
+describe('shouldShowRefreshButton', () => {
+  it('returns true when enabled', () => {
+    expect(shouldShowRefreshButton(false)).toBe(true);
+  });
+  it('returns false when disabled', () => {
+    expect(shouldShowRefreshButton(true)).toBe(false);
+  });
+});
+
+describe('visibleTabs', () => {
+  it('returns tools, logs, config for stdio when enabled', () => {
+    expect(visibleTabs('stdio', false)).toEqual([
+      { id: 'tools', label: 'Tools' },
+      { id: 'logs', label: 'Logs' },
+      { id: 'config', label: 'Config' },
+    ]);
+  });
+
+  it('returns tools, logs, config for http when enabled', () => {
+    expect(visibleTabs('http', false)).toEqual([
+      { id: 'tools', label: 'Tools' },
+      { id: 'logs', label: 'Logs' },
+      { id: 'config', label: 'Config' },
+    ]);
+  });
+
+  it('returns tools, logs, config, auth for oauth when enabled', () => {
+    expect(visibleTabs('oauth', false)).toEqual([
+      { id: 'tools', label: 'Tools' },
+      { id: 'logs', label: 'Logs' },
+      { id: 'config', label: 'Config' },
+      { id: 'auth', label: 'Auth' },
+    ]);
+  });
+
+  it('returns config only for stdio when disabled', () => {
+    expect(visibleTabs('stdio', true)).toEqual([{ id: 'config', label: 'Config' }]);
+  });
+
+  it('returns config, auth for oauth when disabled', () => {
+    expect(visibleTabs('oauth', true)).toEqual([
+      { id: 'config', label: 'Config' },
+      { id: 'auth', label: 'Auth' },
+    ]);
+  });
+
+  it('preserves stable tab order across transports when enabled', () => {
+    const order = (t: EndpointTransport) => visibleTabs(t, false).map((tab) => tab.id);
+    expect(order('stdio')).toEqual(['tools', 'logs', 'config']);
+    expect(order('sse')).toEqual(['tools', 'logs', 'config']);
+    expect(order('http')).toEqual(['tools', 'logs', 'config']);
+    expect(order('oauth')).toEqual(['tools', 'logs', 'config', 'auth']);
+  });
 });
 

--- a/src/lib/components/detail-panel-helpers.ts
+++ b/src/lib/components/detail-panel-helpers.ts
@@ -2,7 +2,39 @@ import type { Endpoint } from '$lib/types';
 
 export type EndpointTransport = Endpoint['transport'];
 
-export function shouldShowRestartButton(transport: EndpointTransport): boolean {
+export type DetailTabId = 'tools' | 'logs' | 'config' | 'auth';
+
+export interface DetailTab {
+  id: DetailTabId;
+  label: string;
+}
+
+const BASE_TABS: readonly DetailTab[] = [
+  { id: 'tools', label: 'Tools' },
+  { id: 'logs', label: 'Logs' },
+  { id: 'config', label: 'Config' },
+];
+
+export function visibleTabs(transport: EndpointTransport, disabled: boolean): DetailTab[] {
+  if (disabled) {
+    const tabs: DetailTab[] = [{ id: 'config', label: 'Config' }];
+    if (transport === 'oauth') {
+      tabs.push({ id: 'auth', label: 'Auth' });
+    }
+    return tabs;
+  }
+  const tabs: DetailTab[] = [...BASE_TABS];
+  if (transport === 'oauth') {
+    tabs.push({ id: 'auth', label: 'Auth' });
+  }
+  return tabs;
+}
+
+export function shouldShowRestartButton(transport: EndpointTransport, disabled: boolean): boolean {
+  if (disabled) return false;
   return transport === 'stdio' || transport === 'sse';
 }
 
+export function shouldShowRefreshButton(disabled: boolean): boolean {
+  return !disabled;
+}

--- a/src/lib/data/oauth-catalog.test.ts
+++ b/src/lib/data/oauth-catalog.test.ts
@@ -2,13 +2,69 @@ import { describe, it, expect } from 'vitest';
 import { oauthCatalog } from './oauth-catalog';
 
 describe('oauthCatalog', () => {
-  it('should have exactly 6 entries', () => {
-    expect(oauthCatalog).toHaveLength(6);
+  it('should have exactly 9 entries', () => {
+    expect(oauthCatalog).toHaveLength(9);
   });
 
-  it('should not include Google Drive', () => {
-    const googleDrive = oauthCatalog.find((entry) => entry.id === 'google-drive');
-    expect(googleDrive).toBeUndefined();
+  it('should include the Gmail entry with curated scopes', () => {
+    const gmail = oauthCatalog.find((entry) => entry.id === 'gmail');
+    expect(gmail).toBeDefined();
+    expect(gmail!.url).toBe('https://gmailmcp.googleapis.com/mcp/v1');
+    expect(gmail!.supportsDcr).toBe(false);
+    expect(gmail!.defaultScopes).toEqual([
+      'https://www.googleapis.com/auth/gmail.readonly',
+      'https://www.googleapis.com/auth/gmail.compose',
+    ]);
+    expect(gmail!.availableScopes).toBeDefined();
+    expect(gmail!.availableScopes!.length).toBeGreaterThan(0);
+    const availableScopeValues = gmail!.availableScopes!.map((s) => s.scope);
+    expect(availableScopeValues).toHaveLength(gmail!.defaultScopes.length);
+    expect(new Set(availableScopeValues)).toEqual(new Set(gmail!.defaultScopes));
+  });
+
+  it('should include the Google Calendar entry with curated scopes', () => {
+    const calendar = oauthCatalog.find((entry) => entry.id === 'google-calendar');
+    expect(calendar).toBeDefined();
+    expect(calendar!.url).toBe('https://calendarmcp.googleapis.com/mcp/v1');
+    expect(calendar!.supportsDcr).toBe(false);
+    expect(calendar!.defaultScopes).toEqual([
+      'https://www.googleapis.com/auth/calendar.calendarlist.readonly',
+      'https://www.googleapis.com/auth/calendar.events.freebusy',
+      'https://www.googleapis.com/auth/calendar.events.readonly',
+    ]);
+    expect(calendar!.availableScopes).toBeDefined();
+    expect(calendar!.availableScopes!.length).toBeGreaterThan(0);
+    const availableScopeValues = calendar!.availableScopes!.map((s) => s.scope);
+    expect(availableScopeValues).toHaveLength(calendar!.defaultScopes.length);
+    expect(new Set(availableScopeValues)).toEqual(new Set(calendar!.defaultScopes));
+  });
+
+  it('should include the Google Drive entry with curated scopes', () => {
+    const drive = oauthCatalog.find((entry) => entry.id === 'google-drive');
+    expect(drive).toBeDefined();
+    expect(drive!.url).toBe('https://drivemcp.googleapis.com/mcp/v1');
+    expect(drive!.supportsDcr).toBe(false);
+    expect(drive!.defaultScopes).toEqual([
+      'https://www.googleapis.com/auth/drive.readonly',
+      'https://www.googleapis.com/auth/drive.file',
+    ]);
+    expect(drive!.availableScopes).toBeDefined();
+    expect(drive!.availableScopes!.length).toBeGreaterThan(0);
+    const availableScopeValues = drive!.availableScopes!.map((s) => s.scope);
+    expect(availableScopeValues).toHaveLength(drive!.defaultScopes.length);
+    expect(new Set(availableScopeValues)).toEqual(new Set(drive!.defaultScopes));
+  });
+
+  it('should have well-formed availableScopes entries everywhere they are defined', () => {
+    for (const entry of oauthCatalog) {
+      if (!entry.availableScopes) continue;
+      for (const option of entry.availableScopes) {
+        expect(option.name.length).toBeGreaterThan(0);
+        expect(option.description.length).toBeGreaterThan(0);
+        expect(option.scope.startsWith('https://')).toBe(true);
+        expect(() => new URL(option.scope)).not.toThrow();
+      }
+    }
   });
 
   it('should have the correct GitHub URL', () => {

--- a/src/lib/data/oauth-catalog.ts
+++ b/src/lib/data/oauth-catalog.ts
@@ -1,3 +1,12 @@
+export interface OAuthScopeOption {
+  /** Exact OAuth scope value sent on the wire. */
+  scope: string;
+  /** Short human-readable label shown next to the checkbox. */
+  name: string;
+  /** Longer description shown in the info tooltip alongside the exact scope. */
+  description: string;
+}
+
 export interface OAuthCatalogEntry {
   id: string;
   name: string;
@@ -7,6 +16,7 @@ export interface OAuthCatalogEntry {
   url: string;
   oauthServerUrl?: string;
   defaultScopes: string[];
+  availableScopes?: OAuthScopeOption[];
   supportsDiscovery: boolean;
   supportsDcr: boolean;
   tokenEndpoint?: string;
@@ -87,6 +97,94 @@ export const oauthCatalog: OAuthCatalogEntry[] = [
     supportsDiscovery: true,
     supportsDcr: true,
     notes: 'Docs and notes from your Craft workspace',
+  },
+  {
+    id: 'gmail',
+    name: 'Gmail',
+    description: 'Read mail and manage drafts',
+    icon: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 5.5h14v9a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1v-9zm0 0l7 5 7-5"/></svg>',
+    category: 'productivity',
+    url: 'https://gmailmcp.googleapis.com/mcp/v1',
+    defaultScopes: [
+      'https://www.googleapis.com/auth/gmail.readonly',
+      'https://www.googleapis.com/auth/gmail.compose',
+    ],
+    availableScopes: [
+      {
+        scope: 'https://www.googleapis.com/auth/gmail.readonly',
+        name: 'Read mail',
+        description: 'Read all messages and threads in your mailbox.',
+      },
+      {
+        scope: 'https://www.googleapis.com/auth/gmail.compose',
+        name: 'Compose drafts',
+        description:
+          'Create, read, update, and send drafts (does not include sending sent mail beyond drafts).',
+      },
+    ],
+    supportsDiscovery: true,
+    supportsDcr: false,
+    notes: 'Requires a Google Cloud OAuth client — Client ID and Secret needed',
+  },
+  {
+    id: 'google-calendar',
+    name: 'Google Calendar',
+    description: 'Calendars, events, and free/busy',
+    icon: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="4.5" width="14" height="12" rx="1.5"/><path d="M3 8.5h14M7 3v3M13 3v3"/></svg>',
+    category: 'productivity',
+    url: 'https://calendarmcp.googleapis.com/mcp/v1',
+    defaultScopes: [
+      'https://www.googleapis.com/auth/calendar.calendarlist.readonly',
+      'https://www.googleapis.com/auth/calendar.events.freebusy',
+      'https://www.googleapis.com/auth/calendar.events.readonly',
+    ],
+    availableScopes: [
+      {
+        scope: 'https://www.googleapis.com/auth/calendar.calendarlist.readonly',
+        name: 'List calendars',
+        description: 'View the list of calendars on your account.',
+      },
+      {
+        scope: 'https://www.googleapis.com/auth/calendar.events.freebusy',
+        name: 'Free/busy',
+        description: 'View free/busy information for events on your calendars.',
+      },
+      {
+        scope: 'https://www.googleapis.com/auth/calendar.events.readonly',
+        name: 'Read events',
+        description: 'View events on your calendars.',
+      },
+    ],
+    supportsDiscovery: true,
+    supportsDcr: false,
+    notes: 'Requires a Google Cloud OAuth client — Client ID and Secret needed',
+  },
+  {
+    id: 'google-drive',
+    name: 'Google Drive',
+    description: 'Files and folders in your Drive',
+    icon: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"><path d="M7.5 3h5l5 8.5-2.5 4.5H5L2.5 11.5 7.5 3zM7.5 3l5 8.5h5M5 16l2.5-4.5h10"/></svg>',
+    category: 'productivity',
+    url: 'https://drivemcp.googleapis.com/mcp/v1',
+    defaultScopes: [
+      'https://www.googleapis.com/auth/drive.readonly',
+      'https://www.googleapis.com/auth/drive.file',
+    ],
+    availableScopes: [
+      {
+        scope: 'https://www.googleapis.com/auth/drive.readonly',
+        name: 'Read files',
+        description: 'View metadata and content of files in your Drive.',
+      },
+      {
+        scope: 'https://www.googleapis.com/auth/drive.file',
+        name: 'Per-file access',
+        description: 'Per-file access to files created or opened with this app.',
+      },
+    ],
+    supportsDiscovery: true,
+    supportsDcr: false,
+    notes: 'Requires a Google Cloud OAuth client — Client ID and Secret needed',
   },
 ];
 


### PR DESCRIPTION
## Summary

Adds Gmail, Calendar, and Drive entries to the OAuth MCP catalog, and a few UX polish changes around the Add Endpoint modal and disabled-server detail panel.

## Commits

1. **`feat(catalog): add Google MCP servers (Gmail, Calendar, Drive) with structured scope metadata`**
   - New entries in `src/lib/data/oauth-catalog.ts` for Gmail, Google Calendar, and Google Drive.
   - Each carries structured scope metadata so the modal can render curated scope checkboxes.
   - Catalog tests updated.

2. **`feat(modal): add --attention token, manual-OAuth indicator, and curated scope checkboxes`**
   - New `--attention` design token in `app.css`.
   - `AddEndpointModal.svelte` now surfaces a manual-OAuth indicator/filter hint and renders curated scope checkboxes when the catalog entry exposes structured scope metadata.
   - Helper logic extracted into `add-endpoint-helpers.ts`.
   - Tests updated/added.

3. **`feat(detail-panel): hide Tools/Logs tabs and Refresh/Restart buttons when server is disabled`**
   - `DetailPanel.svelte` and `detail-panel-helpers.ts` now hide Tools/Logs tabs and the Refresh/Restart buttons when the selected server is disabled, since they would no-op anyway.
   - Helper tests updated.

## Verification

- `npx vitest run` → **259 passed / 24 skipped (283 total), 16 files**
- `npx tsc --noEmit` → **clean**
- `npx svelte-check --tsconfig ./tsconfig.json` → **0 errors, 0 warnings**

No Rust changes in this PR.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author