### PR TITLE
chore: bump version to 0.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@endara/desktop",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@endara/desktop",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endara/desktop",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "description": "Endara Desktop — Tauri + Svelte tray app for relay management",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "endara-desktop"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "dirs 5.0.1",
  "hostname",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endara-desktop"
-version = "0.1.2"
+version = "0.1.3"
 description = "Endara Desktop — relay management tray app"
 authors = ["Endara"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Endara Desktop",
   "mainBinaryName": "Endara Desktop",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "identifier": "ai.endara.desktop",
   "build": {
     "beforeDevCommand": "ENDARA_DEV_PORT=9500 bash scripts/kill-relay.sh; npm run dev",


### PR DESCRIPTION
Bumps `package.json`, `src-tauri/tauri.conf.json`, and `src-tauri/Cargo.toml` to `0.1.3` (base, no rc suffix per AGENTS.md). Lockfiles refreshed via `npm install` and `cargo check`.

Follow-up: tag `v0.1.3` on `main` after merge to trigger the release workflow.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author