### PR TITLE
chore: bump version to 0.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@endara/desktop",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@endara/desktop",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endara/desktop",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "description": "Endara Desktop — Tauri + Svelte tray app for relay management",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "endara-desktop"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "dirs 5.0.1",
  "hostname",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endara-desktop"
-version = "0.1.3"
+version = "0.1.4"
 description = "Endara Desktop — relay management tray app"
 authors = ["Endara"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Endara Desktop",
   "mainBinaryName": "Endara Desktop",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "identifier": "ai.endara.desktop",
   "build": {
     "beforeDevCommand": "ENDARA_DEV_PORT=9500 bash scripts/kill-relay.sh; npm run dev",


### PR DESCRIPTION
Version bump from 0.1.3 → 0.1.4 in lockstep with [endara-relay v0.1.4](https://github.com/endara-ai/endara-relay/releases/tag/v0.1.4) (already published).

## Changes

- `package.json`: `"version": "0.1.4"`
- `src-tauri/tauri.conf.json`: `"version": "0.1.4"` (committed plain; release workflow patches the rc suffix at build time if any)
- `src-tauri/Cargo.toml`: `version = "0.1.4"`
- `src-tauri/Cargo.lock`: regen for the new version
- `package-lock.json`: regen for the new version

Diff shape (5 files, +6/-6) matches the v0.1.3 bump [endara-ai/endara-desktop#67](https://github.com/endara-ai/endara-desktop/pull/67) exactly.

## What's new in 0.1.4

No functional changes in `endara-desktop` since [v0.1.3](https://github.com/endara-ai/endara-desktop/releases/tag/v0.1.3) — the bump exists to keep base versions in lockstep with relay (per [AGENTS.md](https://github.com/endara-ai/monorepo/blob/main/AGENTS.md)) and to give users a coherent v0.1.4 across both binaries via the auto-updater.

The v0.1.4 *user-visible* improvement comes from relay [#45](https://github.com/endara-ai/endara-relay/pull/45) — `execute_tools` description now teaches `call()` unwrapping correctly to LLMs.

## Next steps

After merge, the `v0.1.4` tag will be pushed to `main` and the release workflow auto-publishes desktop binaries. Preflight check for `endara-ai/endara-relay@v0.1.4` will pass (already live).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author