### PR TITLE
fix(security): R1 quick wins — bump vulnerable deps, strict CSP, harden release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,12 @@ jobs:
       - name: Validate relay release exists
         id: check
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [[ "${{ github.ref_name }}" == v* ]]; then
-            RELAY_VERSION="${{ github.ref_name }}"
+          if [[ "$REF_NAME" == v* ]]; then
+            RELAY_VERSION="$REF_NAME"
           else
             RELAY_VERSION="latest"
           fi
@@ -45,8 +48,6 @@ jobs:
             echo "::error::Relay release '$RELAY_VERSION' not found in endara-ai/endara-relay. Release the relay first!"
             exit 1
           fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish:
     needs: [preflight]
@@ -96,10 +97,13 @@ jobs:
 
       - name: Download relay binary
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELAY_TARGET: ${{ matrix.relay_target }}
         run: |
           mkdir -p src-tauri/binaries
-          RELAY_BINARY="endara-relay-${{ matrix.relay_target }}"
-          if [[ "${{ matrix.relay_target }}" == *"windows"* ]]; then
+          RELAY_BINARY="endara-relay-${RELAY_TARGET}"
+          if [[ "$RELAY_TARGET" == *"windows"* ]]; then
             RELAY_BINARY="${RELAY_BINARY}.exe"
           fi
           if [[ "$RELAY_VERSION" == "latest" ]]; then
@@ -108,8 +112,6 @@ jobs:
             gh release download "$RELAY_VERSION" --repo endara-ai/endara-relay --pattern "$RELAY_BINARY" --dir src-tauri/binaries
           fi
           chmod +x "src-tauri/binaries/$RELAY_BINARY" 2>/dev/null || true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Patch tauri.conf.json version from git tag (e.g., v0.1.0-rc8 → 0.1.0-rc8)
       # This ensures the built app reports the correct version for the updater
@@ -135,9 +137,13 @@ jobs:
       - name: Set build args
         id: build-args
         shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+          PLATFORM: ${{ matrix.platform }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          ARGS="--target ${{ matrix.target }}"
-          if [[ "${{ matrix.platform }}" == "windows-latest" ]] && [[ "${{ github.ref_name }}" == *"rc"* ]]; then
+          ARGS="--target ${TARGET}"
+          if [[ "$PLATFORM" == "windows-latest" ]] && [[ "$REF_NAME" == *"rc"* ]]; then
             ARGS="$ARGS --bundles nsis"
           fi
           echo "args=$ARGS" >> "$GITHUB_OUTPUT"
@@ -182,11 +188,12 @@ jobs:
         run: sleep 30
 
       - name: Download latest.json from release
-        run: |
-          mkdir -p gh-pages-deploy
-          gh release download "${{ github.ref_name }}" --pattern "latest.json" --dir gh-pages-deploy
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          mkdir -p gh-pages-deploy
+          gh release download "$REF_NAME" --pattern "latest.json" --dir gh-pages-deploy
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
@@ -211,8 +218,9 @@ jobs:
         id: version
         env:
           INPUT_VERSION: ${{ inputs.version }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             tag="${INPUT_VERSION}"
           else
             tag="${GITHUB_REF_NAME}"
@@ -229,22 +237,24 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.version.outputs.tag }}
           VERSION: ${{ steps.version.outputs.version }}
+          REPO: ${{ github.repository }}
         run: |
           mkdir -p dmgs
           for arch in aarch64 x64; do
             asset="Endara.Desktop_${VERSION}_${arch}.dmg"
             echo "Downloading ${asset} from release ${TAG}..."
             gh release download "${TAG}" \
-              --repo "${{ github.repository }}" \
+              --repo "${REPO}" \
               --pattern "${asset}" \
               --dir dmgs
           done
       - name: Compute SHA256 sums
         id: sha
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          v="${{ steps.version.outputs.version }}"
-          sha_arm64=$(shasum -a 256 "dmgs/Endara.Desktop_${v}_aarch64.dmg" | awk '{print $1}')
-          sha_x64=$(shasum -a 256 "dmgs/Endara.Desktop_${v}_x64.dmg" | awk '{print $1}')
+          sha_arm64=$(shasum -a 256 "dmgs/Endara.Desktop_${VERSION}_aarch64.dmg" | awk '{print $1}')
+          sha_x64=$(shasum -a 256 "dmgs/Endara.Desktop_${VERSION}_x64.dmg" | awk '{print $1}')
           {
             echo "arm64=${sha_arm64}"
             echo "x64=${sha_x64}"
@@ -264,12 +274,16 @@ jobs:
         with:
           python-version: '3.12'
       - name: Update cask
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          SHA_ARM64: ${{ steps.sha.outputs.arm64 }}
+          SHA_X64: ${{ steps.sha.outputs.x64 }}
         run: |
           mkdir -p homebrew-tap/Casks
           python3 desktop/scripts/update-cask.py \
-            --version "${{ steps.version.outputs.version }}" \
-            --sha256-arm64 "${{ steps.sha.outputs.arm64 }}" \
-            --sha256-x64 "${{ steps.sha.outputs.x64 }}" \
+            --version "${VERSION}" \
+            --sha256-arm64 "${SHA_ARM64}" \
+            --sha256-x64 "${SHA_X64}" \
             --cask-path homebrew-tap/Casks/endara.rb
       - name: Commit and push to homebrew-tap
         working-directory: homebrew-tap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,11 +72,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-05-08
         with:
           targets: ${{ matrix.target }}
 
-      - uses: swatinem/rust-cache@v2
+      - uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           workspaces: './src-tauri -> target'
 
@@ -90,7 +90,7 @@ jobs:
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
           version: 1.0
@@ -148,7 +148,7 @@ jobs:
           fi
           echo "args=$ARGS" >> "$GITHUB_OUTPUT"
 
-      - uses: tauri-apps/tauri-action@v0
+      - uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # action-v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Build info for About section — picked up by build.rs
@@ -196,7 +196,7 @@ jobs:
           gh release download "$REF_NAME" --pattern "latest.json" --dir gh-pages-deploy
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./gh-pages-deploy

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       },
       "devDependencies": {
         "@sveltejs/adapter-static": "^3.0.6",
-        "@sveltejs/kit": "^2.9.0",
+        "@sveltejs/kit": "^2.59.1",
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
         "@tailwindcss/vite": "^4",
         "@tauri-apps/cli": "^2",
@@ -912,9 +912,9 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "2.55.0",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.55.0.tgz",
-      "integrity": "sha512-MdFRjevVxmAknf2NbaUkDF16jSIzXMWd4Nfah0Qp8TtQVoSp3bV4jKt8mX7z7qTUTWvgSaxtR0EG5WJf53gcuA==",
+      "version": "2.59.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.59.1.tgz",
+      "integrity": "sha512-d8OON70AphLdDesuTIl//M2O6fRTIicX8aYv8vhCiYEhTTI2OboKqey0Hu1A4VFhqwgqtq0vKDmPFGkw8kKmgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -941,7 +941,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0",
         "svelte": "^4.0.0 || ^5.0.0-next.0",
-        "typescript": "^5.3.3",
+        "typescript": "^5.3.3 || ^6.0.0",
         "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.6",
-    "@sveltejs/kit": "^2.9.0",
+    "@sveltejs/kit": "^2.59.1",
     "@sveltejs/vite-plugin-svelte": "^5.0.0",
     "@tailwindcss/vite": "^4",
     "@tauri-apps/cli": "^2",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3910,9 +3910,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: asset: http://asset.localhost; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost http://localhost:* http://127.0.0.1:*; object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
     }
   },
   "plugins": {


### PR DESCRIPTION
## Summary

R1 ("quick wins") batch from the consolidated security audit. Five independent low-risk patches that close one High npm advisory, one High Rust advisory, the missing webview CSP, and the script-injection / mutable-action-ref classes on the release pipeline.

Audit context: see `vulnerability-security` workspace, note `ea8f07a5-957d-422f-8478-ac19187212aa` (consolidated report) and recommendations #2, #4, #9, #10. Task note `83d090ed-3600-42ef-b5f7-6254604aeb4d`.

## Commits (one per finding, deliberately small)

1. **`fix(deps): bump rustls-webpki to 0.103.13`** — closes RUSTSEC NET-005 (`rustls-webpki <0.103.13` cert-name validation bug). `cargo update -p rustls-webpki` only; no `Cargo.toml` changes. Confirmed via `cargo audit`: 0 vulnerabilities, only the pre-existing gtk-rs / proc-macro-error / unic-char-* unmaintained warnings remain.
2. **`fix(deps): bump @sveltejs/kit to ^2.59.1`** — closes SUPPLY-001 (the only npm advisory that reaches the production bundle, redirect-DoS). `npm audit --omit=dev` now reports 0 vulnerabilities.
3. **`fix(security): set strict Content Security Policy for the webview`** — closes DESK-001. Replaces `"csp": null` with a deny-by-default policy: `default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: asset: http://asset.localhost; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost http://localhost:* http://127.0.0.1:*; object-src 'none'; base-uri 'self'; frame-ancestors 'none'`. `'unsafe-inline'` is intentionally NOT on `script-src` — Tauri auto-injects nonces / hashes for SvelteKit's bundled inline bootstrap script at compile time. `'unsafe-inline'` IS on `style-src` because Svelte component-scoped styles + style:/class: directives + Tailwind v4 utilities emit inline `<style>` blocks. `connect-src` allows the dynamic relay port (DEFAULT 9400 / DEV 9500 / user-set via `set_relay_port`) on both `localhost` and `127.0.0.1`.
4. **`fix(ci): move github context vars out of inline shell expansions (CI-002)`** — every `${{ github.* | matrix.* | steps.*.outputs.* }}` that was being expanded directly into a `run: |` shell block is now exported through an `env:` block and dereferenced as `"$VAR"`. Touched all 7 affected steps in `release.yml`. `with:` blocks on third-party actions and `runs-on:` / `targets:` on rust-toolchain are out of scope (action inputs, not shell).
5. **`fix(ci): SHA-pin third-party actions in release workflow (CI-003/CI-005)`** — pins the 5 third-party signing-scope actions (`dtolnay/rust-toolchain`, `Swatinem/rust-cache`, `awalsh128/cache-apt-pkgs-action` (was `@latest`!), `tauri-apps/tauri-action`, `peaceiris/actions-gh-pages`) to immutable SHAs with the human-readable tag preserved as a trailing comment so future Dependabot bumps stay readable. `actions/*` first-party actions are deferred to a follow-up CI hardening PR that will also add `.github/dependabot.yml` for `github-actions`.

## Out of scope (intentional, separate PRs)

- Vite / postcss / cookie dev-only npm advisories (audit recommendation #9 marked as optional cleanup; bumping vite is potentially breaking and warrants its own PR with a build smoke).
- `actions/checkout`, `actions/setup-node`, `actions/setup-python` SHA-pins + `dependabot.yml` — separate CI hardening PR per task scope.
- `.github/workflows/ci.yml` — does not hold release secrets; not in CI-002/CI-003 priority list.
- All Cluster 1 / Cluster 2 / Cluster 5 / Cluster 8 work — those are R2..R5 PRs.

## Verification

```
npm run check                              -> 0 errors, 0 warnings
npm run build                              -> ok (vite + adapter-static)
npm audit --omit=dev                       -> 0 vulnerabilities
cargo build (src-tauri)                    -> ok
cargo test  (src-tauri)                    -> 23 passed; 0 failed
cargo audit (src-tauri)                    -> 0 vulnerabilities
                                              (only pre-existing gtk-rs
                                              / proc-macro-error /
                                              unic-char-* unmaintained
                                              warnings)
cargo fmt --check (src-tauri)              -> ok (no Rust changes)
yaml.safe_load(release.yml)                -> OK
```

Webview CSP smoke (`cargo tauri dev`) deferred to reviewer — needs an interactive GUI session that this PR-prep run could not perform. The CSP is intentionally generous on `style-src` (`'unsafe-inline'`) to avoid breaking Svelte / Tailwind, so the realistic regression risk is on `connect-src` if the dev relay port ever moves outside `localhost:* / 127.0.0.1:*`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author