### PR TITLE
feat(api): proxy /api/* via relay_api_request Tauri command (Cluster 1)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1086,6 +1086,9 @@ version = "0.1.4"
 dependencies = [
  "dirs 5.0.1",
  "hostname",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "libc",
  "log",
  "objc2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "5"
 log = "0.4"
-tokio = { version = "1", features = ["sync", "time"] }
+tokio = { version = "1", features = ["net", "sync", "time"] }
 toml = "0.8"
 hostname = "0.4"
 tauri-plugin-log = "2.8.0"
@@ -31,6 +31,9 @@ tauri-plugin-autostart = "2"
 tauri-plugin-notification = "2"
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "json"] }
 urlencoding = "2.1.3"
+hyper = { version = "1", features = ["client", "http1"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
+http-body-util = "0.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.4"

--- a/src-tauri/src/api_proxy.rs
+++ b/src-tauri/src/api_proxy.rs
@@ -1,0 +1,187 @@
+//! Bridge for the relay's management API.
+//!
+//! The relay no longer exposes `/api/*` over TCP; it listens on a per-user
+//! Unix-domain socket on macOS / Linux and a per-user Windows named pipe on
+//! Windows. WebViews cannot dial those transports directly, so the desktop
+//! provides a `mgmt_api_request` Tauri command that proxies HTTP requests from
+//! the SvelteKit UI to the relay's local socket.
+//!
+//! Path resolution mirrors `endara_relay::management_listener::resolve_api_socket_path`.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use http_body_util::{BodyExt, Full};
+use hyper::body::Bytes;
+use hyper::Request;
+use hyper_util::rt::TokioIo;
+use serde::{Deserialize, Serialize};
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ApiResponse {
+    pub status: u16,
+    pub body: String,
+}
+
+/// Resolve the management-API socket / pipe path. Mirrors the relay's
+/// resolution so the two processes pick the same path without coordinating.
+#[allow(clippy::needless_return)]
+pub fn resolve_api_socket_path(#[allow(unused_variables)] data_dir: &Path) -> PathBuf {
+    if let Ok(path) = std::env::var("ENDARA_API_SOCKET") {
+        return PathBuf::from(path);
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(xdg) = std::env::var("XDG_RUNTIME_DIR") {
+            let runtime = PathBuf::from(xdg);
+            if !runtime.as_os_str().is_empty() {
+                return runtime.join("endara-relay").join("api.sock");
+            }
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let tmp = std::env::var("TMPDIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from("/tmp"));
+        let uid = unsafe { geteuid_u32() };
+        return tmp.join(format!("endara-relay-{uid}")).join("api.sock");
+    }
+
+    #[cfg(windows)]
+    {
+        let session_id = current_user_pipe_suffix(data_dir);
+        return PathBuf::from(format!(r"\\.\pipe\endara-relay-{session_id}"));
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+    {
+        data_dir.join("api.sock")
+    }
+}
+
+#[cfg(unix)]
+unsafe fn geteuid_u32() -> u32 {
+    extern "C" {
+        fn geteuid() -> u32;
+    }
+    geteuid()
+}
+
+#[cfg(windows)]
+fn current_user_pipe_suffix(data_dir: &Path) -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    if let Ok(user) = std::env::var("USERNAME") {
+        let mut h = DefaultHasher::new();
+        user.hash(&mut h);
+        return format!("{:x}", h.finish());
+    }
+    let mut h = DefaultHasher::new();
+    data_dir.hash(&mut h);
+    format!("{:x}", h.finish())
+}
+
+/// Send an HTTP request to the management API socket / pipe and return the
+/// response status and body bytes. The body bytes are returned as a UTF-8
+/// `String` because every management-API response is JSON or empty; non-UTF-8
+/// payloads would already be a bug on the relay side.
+pub async fn send_request(
+    socket_path: &Path,
+    method: &str,
+    path: &str,
+    body: Option<Vec<u8>>,
+    headers: &[(String, String)],
+) -> Result<ApiResponse, String> {
+    tokio::time::timeout(
+        REQUEST_TIMEOUT,
+        send_request_inner(socket_path, method, path, body, headers),
+    )
+    .await
+    .map_err(|_| {
+        format!(
+            "management API request timed out after {:?}",
+            REQUEST_TIMEOUT
+        )
+    })?
+}
+
+async fn send_request_inner(
+    socket_path: &Path,
+    method: &str,
+    path: &str,
+    body: Option<Vec<u8>>,
+    headers: &[(String, String)],
+) -> Result<ApiResponse, String> {
+    let body_bytes = body.map(Bytes::from).unwrap_or_default();
+    let has_body = !body_bytes.is_empty();
+
+    let mut builder = Request::builder()
+        .method(method)
+        .uri(path)
+        .header("host", "relay.local")
+        .header("accept", "application/json");
+    if has_body {
+        builder = builder.header("content-type", "application/json");
+    }
+    for (k, v) in headers {
+        builder = builder.header(k.as_str(), v.as_str());
+    }
+    let req = builder
+        .body(Full::new(body_bytes))
+        .map_err(|e| format!("build request: {e}"))?;
+
+    let io = connect(socket_path).await?;
+    let (mut sender, conn) = hyper::client::conn::http1::handshake(io)
+        .await
+        .map_err(|e| format!("HTTP handshake on {}: {e}", socket_path.display()))?;
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    let resp = sender
+        .send_request(req)
+        .await
+        .map_err(|e| format!("send_request to {}: {e}", socket_path.display()))?;
+    let status = resp.status().as_u16();
+    let raw = resp
+        .into_body()
+        .collect()
+        .await
+        .map_err(|e| format!("read body: {e}"))?
+        .to_bytes();
+    let body = String::from_utf8(raw.to_vec())
+        .map_err(|e| format!("management API returned non-UTF-8 body: {e}"))?;
+    Ok(ApiResponse { status, body })
+}
+
+#[cfg(unix)]
+async fn connect(path: &Path) -> Result<TokioIo<tokio::net::UnixStream>, String> {
+    let stream = tokio::net::UnixStream::connect(path)
+        .await
+        .map_err(|e| format!("connect to {}: {e}", path.display()))?;
+    Ok(TokioIo::new(stream))
+}
+
+#[cfg(windows)]
+async fn connect(
+    path: &Path,
+) -> Result<TokioIo<tokio::net::windows::named_pipe::NamedPipeClient>, String> {
+    let name = path
+        .to_str()
+        .ok_or_else(|| "non-utf8 pipe name".to_string())?;
+    let client = tokio::net::windows::named_pipe::ClientOptions::new()
+        .open(name)
+        .map_err(|e| format!("open pipe {name}: {e}"))?;
+    Ok(TokioIo::new(client))
+}
+
+#[cfg(not(any(unix, windows)))]
+async fn connect(_path: &Path) -> Result<TokioIo<tokio::net::TcpStream>, String> {
+    Err("management API bridge is unsupported on this platform".to_string())
+}

--- a/src-tauri/src/api_proxy.rs
+++ b/src-tauri/src/api_proxy.rs
@@ -58,10 +58,10 @@ pub fn resolve_api_socket_path(#[allow(unused_variables)] data_dir: &Path) -> Pa
         return PathBuf::from(format!(r"\\.\pipe\endara-relay-{session_id}"));
     }
 
-    #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
-    {
-        data_dir.join("api.sock")
-    }
+    // Final fallback — reached on Linux when XDG_RUNTIME_DIR is unset, and on
+    // any platform not covered by the cfg branches above. macOS / Windows
+    // branches above always early-return, so they never fall through here.
+    data_dir.join("api.sock")
 }
 
 #[cfg(unix)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod api_proxy;
 mod webview_recovery;
 
 use std::collections::HashMap;
@@ -894,6 +895,34 @@ async fn get_relay_port(state: State<'_, RelayState>) -> Result<u16, String> {
     Ok(*state.port.lock().await)
 }
 
+/// Proxy a management-API request from the WebView to the relay's local
+/// Unix-domain socket / Windows named pipe. The relay no longer accepts
+/// `/api/*` requests over TCP, so the SvelteKit UI must round-trip through the
+/// Tauri backend (which can dial the socket and is bound to the same UID as
+/// the listener).
+#[tauri::command]
+async fn mgmt_api_request(
+    method: String,
+    path: String,
+    body: Option<serde_json::Value>,
+) -> Result<api_proxy::ApiResponse, String> {
+    let socket = api_proxy::resolve_api_socket_path(&data_dir()?);
+    let body_bytes = match body {
+        Some(v) => Some(serde_json::to_vec(&v).map_err(|e| format!("serialize body: {e}"))?),
+        None => None,
+    };
+    api_proxy::send_request(&socket, &method, &path, body_bytes, &[]).await
+}
+
+/// Return the resolved management-API socket / pipe path for diagnostics. The
+/// UI does not normally need this — it goes through `mgmt_api_request` — but
+/// surfacing it helps with support / log redaction.
+#[tauri::command]
+async fn get_mgmt_api_socket_path() -> Result<String, String> {
+    let socket = api_proxy::resolve_api_socket_path(&data_dir()?);
+    Ok(socket.to_string_lossy().into_owned())
+}
+
 #[tauri::command]
 async fn set_relay_port(port: u16, state: State<'_, RelayState>) -> Result<(), String> {
     *state.port.lock().await = port;
@@ -1185,15 +1214,7 @@ async fn post_relay_credentials(
     client_secret: Option<&str>,
     oauth_server_url: Option<&str>,
 ) -> Result<(), String> {
-    let port = read_port_from_config().unwrap_or(if is_dev_mode() {
-        DEV_RELAY_PORT
-    } else {
-        DEFAULT_RELAY_PORT
-    });
-    let url = format!(
-        "http://127.0.0.1:{port}/api/endpoints/{}/credentials",
-        urlencoding::encode(name)
-    );
+    let path = format!("/api/endpoints/{}/credentials", urlencoding::encode(name));
 
     let mut body = serde_json::Map::new();
     if let Some(v) = client_id.filter(|s| !s.is_empty()) {
@@ -1215,25 +1236,17 @@ async fn post_relay_credentials(
         );
     }
 
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(5))
-        .build()
-        .map_err(|e| format!("Failed to build HTTP client: {e}"))?;
-
-    let res = client
-        .post(&url)
-        .json(&serde_json::Value::Object(body))
-        .send()
+    let socket = api_proxy::resolve_api_socket_path(&data_dir()?);
+    let body_bytes = serde_json::to_vec(&serde_json::Value::Object(body))
+        .map_err(|e| format!("serialize credentials body: {e}"))?;
+    let resp = api_proxy::send_request(&socket, "POST", &path, Some(body_bytes), &[])
         .await
-        .map_err(|e| format!("Failed to reach relay at {url}: {e}"))?;
+        .map_err(|e| format!("Failed to reach relay management socket: {e}"))?;
 
-    if !res.status().is_success() {
-        let status = res.status();
-        let body = res.text().await.unwrap_or_default();
+    if !(200..300).contains(&resp.status) {
         return Err(format!(
             "Relay rejected credentials write (status {}): {}",
-            status.as_u16(),
-            body
+            resp.status, resp.body
         ));
     }
     Ok(())
@@ -1765,6 +1778,8 @@ pub fn run() {
             update_endpoint,
             get_relay_port,
             set_relay_port,
+            mgmt_api_request,
+            get_mgmt_api_socket_path,
             set_js_execution_mode,
             get_config_path_display,
             get_buffered_relay_logs,

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,44 +1,36 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { invoke } from '@tauri-apps/api/core';
 
-// Mock fetch globally
-const mockFetch = vi.fn();
-globalThis.fetch = mockFetch;
-
 describe('api', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockFetch.mockReset();
   });
 
-  function mockFetchSuccess(data: unknown) {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve(data),
+  function mockOk(data: unknown) {
+    vi.mocked(invoke).mockResolvedValue({
       status: 200,
-      statusText: 'OK',
+      body: JSON.stringify(data),
     });
   }
 
-  function mockFetchError(status: number, statusText: string) {
-    mockFetch.mockResolvedValue({
-      ok: false,
+  function mockHttpError(status: number, body: string = '') {
+    vi.mocked(invoke).mockResolvedValue({
       status,
-      statusText,
+      body,
     });
   }
 
   describe('getStatus', () => {
-    it('fetches relay status', async () => {
+    it('fetches relay status via mgmt_api_request', async () => {
       const { getStatus } = await import('./api');
       const mockStatus = { status: 'ok', uptime_seconds: 100, endpoint_count: 2, healthy_count: 2 };
-      mockFetchSuccess(mockStatus);
+      mockOk(mockStatus);
 
       const result = await getStatus();
       expect(result).toEqual(mockStatus);
-      expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining('/api/status'),
-        expect.objectContaining({ headers: expect.objectContaining({ 'Content-Type': 'application/json' }) }),
+      expect(invoke).toHaveBeenCalledWith(
+        'mgmt_api_request',
+        expect.objectContaining({ method: 'GET', path: '/api/status' }),
       );
     });
   });
@@ -47,7 +39,7 @@ describe('api', () => {
     it('fetches endpoints list', async () => {
       const { getEndpoints } = await import('./api');
       const mockEndpoints = [{ name: 'ep1', transport: 'stdio', health: 'healthy', tool_count: 3, last_activity: null }];
-      mockFetchSuccess(mockEndpoints);
+      mockOk(mockEndpoints);
 
       const result = await getEndpoints();
       expect(result).toEqual(mockEndpoints);
@@ -56,7 +48,7 @@ describe('api', () => {
     it('passes starting health through unchanged', async () => {
       const { getEndpoints } = await import('./api');
       const mockEndpoints = [{ name: 'ep1', transport: 'stdio', health: 'starting', tool_count: 0, last_activity: null }];
-      mockFetchSuccess(mockEndpoints);
+      mockOk(mockEndpoints);
 
       const result = await getEndpoints();
       expect(result[0].health).toBe('starting');
@@ -72,7 +64,7 @@ describe('api', () => {
         last_activity: null,
         lifecycle: { state: 'Failed', error: { kind: 'Transport', detail: 'Connection refused' } },
       }];
-      mockFetchSuccess(mockEndpoints);
+      mockOk(mockEndpoints);
 
       const result = await getEndpoints();
       expect(result[0].health).toBe('error');
@@ -90,7 +82,7 @@ describe('api', () => {
         last_activity: null,
         lifecycle: { state: 'Ready', server_name: 'my-server' },
       }];
-      mockFetchSuccess(mockEndpoints);
+      mockOk(mockEndpoints);
 
       const result = await getEndpoints();
       expect(result[0].health).toBe('healthy');
@@ -108,7 +100,7 @@ describe('api', () => {
         last_activity: null,
         lifecycle: { state: 'Initializing' },
       }];
-      mockFetchSuccess(mockEndpoints);
+      mockOk(mockEndpoints);
 
       const result = await getEndpoints();
       expect(result[0].health).toBe('starting');
@@ -120,13 +112,13 @@ describe('api', () => {
     it('fetches tools for endpoint', async () => {
       const { getEndpointTools } = await import('./api');
       const mockTools = [{ name: 'tool1', description: 'A tool' }];
-      mockFetchSuccess(mockTools);
+      mockOk(mockTools);
 
       const result = await getEndpointTools('my-ep');
       expect(result).toEqual(mockTools);
-      expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining('/api/endpoints/my-ep/tools'),
-        expect.any(Object),
+      expect(invoke).toHaveBeenCalledWith(
+        'mgmt_api_request',
+        expect.objectContaining({ path: '/api/endpoints/my-ep/tools' }),
       );
     });
   });
@@ -134,24 +126,24 @@ describe('api', () => {
   describe('addEndpoint', () => {
     it('calls invoke with correct command and params', async () => {
       const { addEndpoint } = await import('./api');
-      const mockInvoke = vi.mocked(invoke);
-      mockInvoke.mockResolvedValue(undefined);
-      // Mock reloadConfig fetch (best-effort, may fail)
-      mockFetch.mockRejectedValue(new Error('relay not running'));
+      // First call: add_endpoint succeeds; second call: reloadConfig (mgmt_api_request) fails best-effort.
+      vi.mocked(invoke)
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('relay not running'));
 
       const params = { name: 'new-ep', transport: 'stdio' as const, command: '/usr/bin/my-mcp' };
       await addEndpoint(params);
 
-      expect(mockInvoke).toHaveBeenCalledWith('add_endpoint', { args: params });
+      expect(invoke).toHaveBeenCalledWith('add_endpoint', { args: params });
     });
   });
 
   describe('addEndpoint with env vars', () => {
     it('passes env vars through to invoke', async () => {
       const { addEndpoint } = await import('./api');
-      const mockInvoke = vi.mocked(invoke);
-      mockInvoke.mockResolvedValue(undefined);
-      mockFetch.mockRejectedValue(new Error('relay not running'));
+      vi.mocked(invoke)
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('relay not running'));
 
       const params = {
         name: 'github-server',
@@ -162,9 +154,8 @@ describe('api', () => {
       };
       await addEndpoint(params);
 
-      expect(mockInvoke).toHaveBeenCalledWith('add_endpoint', { args: params });
-      // Verify the env field is passed as-is (relay handles resolution)
-      const passedArgs = mockInvoke.mock.calls[0][1] as { args: typeof params };
+      expect(invoke).toHaveBeenCalledWith('add_endpoint', { args: params });
+      const passedArgs = vi.mocked(invoke).mock.calls[0][1] as { args: typeof params };
       expect(passedArgs.args.env).toEqual({ GITHUB_TOKEN: '$GITHUB_TOKEN', PLAIN_VAL: 'hello' });
     });
   });
@@ -172,13 +163,13 @@ describe('api', () => {
   describe('removeEndpoint', () => {
     it('calls invoke with correct command and name', async () => {
       const { removeEndpoint } = await import('./api');
-      const mockInvoke = vi.mocked(invoke);
-      mockInvoke.mockResolvedValue(undefined);
-      mockFetch.mockRejectedValue(new Error('relay not running'));
+      vi.mocked(invoke)
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('relay not running'));
 
       await removeEndpoint('old-ep');
 
-      expect(mockInvoke).toHaveBeenCalledWith('remove_endpoint', { name: 'old-ep' });
+      expect(invoke).toHaveBeenCalledWith('remove_endpoint', { name: 'old-ep' });
     });
   });
 
@@ -189,13 +180,13 @@ describe('api', () => {
         { name: 'm__ep1__tool1', description: 'A tool', inputSchema: { type: 'object' }, endpoint: 'ep1', available: true },
         { name: 'm__ep2__tool2', description: 'Another', inputSchema: { type: 'object' }, endpoint: 'ep2', available: false },
       ];
-      mockFetchSuccess(mockCatalog);
+      mockOk(mockCatalog);
 
       const result = await getCatalog();
       expect(result).toEqual(mockCatalog);
-      expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining('/api/catalog'),
-        expect.any(Object),
+      expect(invoke).toHaveBeenCalledWith(
+        'mgmt_api_request',
+        expect.objectContaining({ path: '/api/catalog' }),
       );
     });
   });
@@ -204,7 +195,7 @@ describe('api', () => {
     it('sends POST with connection params and returns success', async () => {
       const { testConnection } = await import('./api');
       const mockResult = { success: true, tool_count: 3, tools: ['a', 'b', 'c'] };
-      mockFetchSuccess(mockResult);
+      mockOk(mockResult);
 
       const result = await testConnection({
         transport: 'stdio',
@@ -212,19 +203,16 @@ describe('api', () => {
         args: ['-y', '@modelcontextprotocol/server-filesystem'],
       });
       expect(result).toEqual(mockResult);
-      expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining('/api/test-connection'),
-        expect.objectContaining({
-          method: 'POST',
-          body: expect.any(String),
-        }),
+      expect(invoke).toHaveBeenCalledWith(
+        'mgmt_api_request',
+        expect.objectContaining({ method: 'POST', path: '/api/test-connection' }),
       );
     });
 
     it('returns error result on connection failure', async () => {
       const { testConnection } = await import('./api');
       const mockResult = { success: false, error: 'Connection failed: spawn error' };
-      mockFetchSuccess(mockResult);
+      mockOk(mockResult);
 
       const result = await testConnection({ transport: 'stdio', command: '/bad/cmd' });
       expect(result.success).toBe(false);
@@ -233,7 +221,7 @@ describe('api', () => {
 
     it('throws on HTTP error', async () => {
       const { testConnection } = await import('./api');
-      mockFetchError(500, 'Internal Server Error');
+      mockHttpError(500, 'Internal Server Error');
 
       await expect(testConnection({ transport: 'stdio', command: 'test' })).rejects.toThrow('HTTP 500');
     });
@@ -245,7 +233,7 @@ describe('api', () => {
         tool_count: 5,
         tools: ['read_file', 'write_file', 'list_dir', 'delete_file', 'move_file'],
       };
-      mockFetchSuccess(mockResult);
+      mockOk(mockResult);
 
       const result = await testConnection({
         transport: 'stdio',
@@ -258,30 +246,29 @@ describe('api', () => {
       expect(result.tools).toHaveLength(5);
       expect(result.tools).toContain('read_file');
       expect(result.tools).toContain('move_file');
-      // Verify the request body included all params
-      const callBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(callBody.transport).toBe('stdio');
-      expect(callBody.command).toBe('npx');
-      expect(callBody.args).toEqual(['-y', '@modelcontextprotocol/server-filesystem']);
-      expect(callBody.env).toEqual({ HOME: '/tmp' });
+      const callBody = vi.mocked(invoke).mock.calls[0][1] as { body: { transport: string; command: string; args: string[]; env: Record<string, string> } };
+      expect(callBody.body.transport).toBe('stdio');
+      expect(callBody.body.command).toBe('npx');
+      expect(callBody.body.args).toEqual(['-y', '@modelcontextprotocol/server-filesystem']);
+      expect(callBody.body.env).toEqual({ HOME: '/tmp' });
     });
   });
 
   describe('error handling', () => {
-    it('retries on fetch failure and eventually throws', async () => {
+    it('retries on transport failure and eventually throws', async () => {
       const { getStatus } = await import('./api');
-      mockFetch.mockRejectedValue(new Error('Network error'));
+      vi.mocked(invoke).mockRejectedValue(new Error('socket connect failed'));
 
-      await expect(getStatus()).rejects.toThrow('Network error');
+      await expect(getStatus()).rejects.toThrow('socket connect failed');
       // Should have retried: 1 initial + 2 retries = 3 calls
-      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(invoke).toHaveBeenCalledTimes(3);
     });
 
     it('throws on HTTP error status after retries', async () => {
       const { getConfig } = await import('./api');
-      mockFetchError(500, 'Internal Server Error');
+      mockHttpError(500, 'Internal Server Error');
 
-      await expect(getConfig()).rejects.toThrow('HTTP 500: Internal Server Error');
+      await expect(getConfig()).rejects.toThrow('HTTP 500');
     });
   });
 });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,27 +1,41 @@
 import { invoke } from '@tauri-apps/api/core';
-import { get } from 'svelte/store';
 import type { RelayStatus, Endpoint, Tool, EndpointLogs, CatalogEntry, OAuthStatus, OAuthStartResult, OAuthSetupResponse, OAuthSetupStatusResponse } from './types';
-import { relayPort } from './stores';
-
-function getBaseUrl() {
-  return `http://localhost:${get(relayPort)}/api`;
-}
 
 const MAX_RETRIES = 2;
 const RETRY_DELAY = 1000;
 
-async function fetchJson<T>(path: string, options?: RequestInit): Promise<T> {
+interface ApiResponse {
+  status: number;
+  body: string;
+}
+
+/**
+ * Proxy an HTTP request to the relay's management API via the Tauri backend.
+ * The relay listens on a per-user Unix-domain socket / Windows named pipe; the
+ * WebView cannot dial those directly, so every `/api/*` call is forwarded
+ * through `mgmt_api_request`.
+ */
+async function mgmtRequest(
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<ApiResponse> {
+  return await invoke<ApiResponse>('mgmt_api_request', {
+    method,
+    path: `/api${path}`,
+    body: body === undefined ? null : body,
+  });
+}
+
+async function fetchJson<T>(path: string, options?: { method?: string; body?: unknown }): Promise<T> {
   let lastError: Error | null = null;
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     try {
-      const res = await fetch(`${getBaseUrl()}${path}`, {
-        ...options,
-        headers: { 'Content-Type': 'application/json', ...options?.headers },
-      });
-      if (!res.ok) {
-        throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+      const res = await mgmtRequest(options?.method ?? 'GET', path, options?.body);
+      if (res.status < 200 || res.status >= 300) {
+        throw new Error(`HTTP ${res.status}: ${res.body}`);
       }
-      return await res.json() as T;
+      return (res.body ? JSON.parse(res.body) : null) as T;
     } catch (err) {
       lastError = err instanceof Error ? err : new Error(String(err));
       if (attempt < MAX_RETRIES) {
@@ -38,12 +52,9 @@ export async function getStatus(): Promise<RelayStatus> {
 
 export async function getEndpoints(): Promise<Endpoint[]> {
   const data = await fetchJson<Endpoint[]>('/endpoints');
-  // Map relay's health states to UI-friendly values
   for (const ep of data) {
-    // Handle lifecycle.state === "Failed" from the management API
     if (ep.lifecycle?.state === 'Failed') {
       ep.health = 'error';
-      // Extract error detail from lifecycle
       ep.error = ep.lifecycle.error.detail;
     }
   }
@@ -95,15 +106,11 @@ export interface TestConnectionResult {
 }
 
 export async function testConnection(params: TestConnectionParams): Promise<TestConnectionResult> {
-  const res = await fetch(`${getBaseUrl()}/test-connection`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(params),
-  });
-  if (!res.ok) {
-    throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+  const res = await mgmtRequest('POST', '/test-connection', params);
+  if (res.status < 200 || res.status >= 300) {
+    throw new Error(`HTTP ${res.status}: ${res.body}`);
   }
-  return await res.json() as TestConnectionResult;
+  return JSON.parse(res.body) as TestConnectionResult;
 }
 
 export interface AddEndpointParams {
@@ -218,20 +225,17 @@ export interface UpdateEndpointParams {
 }
 
 export async function startOAuth(name: string): Promise<OAuthStartResult> {
-  const res = await fetch(`${getBaseUrl()}/endpoints/${encodeURIComponent(name)}/oauth/start`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-  });
-  const data = await res.json();
-  // If the server returns dcr_unsupported, return it as a typed result instead of throwing
-  if (!res.ok && data?.error === 'dcr_unsupported') {
+  const res = await mgmtRequest('POST', `/endpoints/${encodeURIComponent(name)}/oauth/start`);
+  const data = res.body ? JSON.parse(res.body) : {};
+  // dcr_unsupported / discovery_failed are returned as typed responses, not thrown
+  if ((res.status < 200 || res.status >= 300) && data?.error === 'dcr_unsupported') {
     return data as OAuthStartResult;
   }
-  if (!res.ok && data?.error === 'discovery_failed') {
+  if ((res.status < 200 || res.status >= 300) && data?.error === 'discovery_failed') {
     return data as OAuthStartResult;
   }
-  if (!res.ok) {
-    throw new Error(data?.detail || data?.error || `HTTP ${res.status}: ${res.statusText}`);
+  if (res.status < 200 || res.status >= 300) {
+    throw new Error(data?.detail || data?.error || `HTTP ${res.status}`);
   }
   return data as OAuthStartResult;
 }
@@ -243,14 +247,16 @@ export async function setOAuthCredentials(
 ): Promise<void> {
   const body: Record<string, string> = { client_id: clientId };
   if (clientSecret) body.client_secret = clientSecret;
-  const res = await fetch(`${getBaseUrl()}/endpoints/${encodeURIComponent(name)}/oauth/credentials`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  });
-  if (!res.ok) {
-    const data = await res.json().catch(() => null);
-    throw new Error(data?.message || data?.error || `HTTP ${res.status}: ${res.statusText}`);
+  const res = await mgmtRequest('POST', `/endpoints/${encodeURIComponent(name)}/oauth/credentials`, body);
+  if (res.status < 200 || res.status >= 300) {
+    let detail: string | undefined;
+    try {
+      const data = JSON.parse(res.body);
+      detail = data?.message || data?.error;
+    } catch {
+      // body not JSON
+    }
+    throw new Error(detail || `HTTP ${res.status}: ${res.body}`);
   }
 }
 
@@ -292,18 +298,14 @@ export interface OAuthSetupParams {
 }
 
 export async function oauthSetup(params: OAuthSetupParams): Promise<OAuthSetupResponse> {
-  const res = await fetch(`${getBaseUrl()}/oauth/setup`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(params),
-  });
-  const data = await res.json();
+  const res = await mgmtRequest('POST', '/oauth/setup', params);
+  const data = res.body ? JSON.parse(res.body) : {};
   // 422 with dcr_error is an expected flow — return typed response
-  if (!res.ok && res.status === 422 && data?.dcr_error) {
+  if (res.status === 422 && data?.dcr_error) {
     return data as OAuthSetupResponse;
   }
-  if (!res.ok) {
-    throw new Error(data?.detail || data?.error || `HTTP ${res.status}: ${res.statusText}`);
+  if (res.status < 200 || res.status >= 300) {
+    throw new Error(data?.detail || data?.error || `HTTP ${res.status}`);
   }
   return data as OAuthSetupResponse;
 }
@@ -315,16 +317,22 @@ export async function oauthSetupCredentials(
 ): Promise<{ status: string; authorize_url: string }> {
   const body: Record<string, string> = { client_id: clientId };
   if (clientSecret) body.client_secret = clientSecret;
-  const res = await fetch(`${getBaseUrl()}/oauth/setup/${encodeURIComponent(sessionId)}/credentials`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  });
-  if (!res.ok) {
-    const data = await res.json().catch(() => ({}));
-    throw new Error(data?.detail || data?.error || `HTTP ${res.status}`);
+  const res = await mgmtRequest(
+    'POST',
+    `/oauth/setup/${encodeURIComponent(sessionId)}/credentials`,
+    body,
+  );
+  if (res.status < 200 || res.status >= 300) {
+    let detail: string | undefined;
+    try {
+      const data = JSON.parse(res.body);
+      detail = data?.detail || data?.error;
+    } catch {
+      // body not JSON
+    }
+    throw new Error(detail || `HTTP ${res.status}`);
   }
-  return res.json();
+  return JSON.parse(res.body);
 }
 
 export async function oauthSetupStatus(sessionId: string): Promise<OAuthSetupStatusResponse> {
@@ -332,23 +340,31 @@ export async function oauthSetupStatus(sessionId: string): Promise<OAuthSetupSta
 }
 
 export async function oauthSetupCommit(sessionId: string): Promise<{ status: string; name: string }> {
-  const res = await fetch(`${getBaseUrl()}/oauth/setup/${encodeURIComponent(sessionId)}/commit`, {
-    method: 'POST',
-  });
-  if (!res.ok) {
-    const data = await res.json().catch(() => ({}));
-    throw new Error(data?.detail || data?.error || `HTTP ${res.status}`);
+  const res = await mgmtRequest('POST', `/oauth/setup/${encodeURIComponent(sessionId)}/commit`);
+  if (res.status < 200 || res.status >= 300) {
+    let detail: string | undefined;
+    try {
+      const data = JSON.parse(res.body);
+      detail = data?.detail || data?.error;
+    } catch {
+      // body not JSON
+    }
+    throw new Error(detail || `HTTP ${res.status}`);
   }
-  return res.json();
+  return JSON.parse(res.body);
 }
 
 export async function oauthSetupCancel(sessionId: string): Promise<void> {
-  const res = await fetch(`${getBaseUrl()}/oauth/setup/${encodeURIComponent(sessionId)}`, {
-    method: 'DELETE',
-  });
-  if (!res.ok) {
-    const data = await res.json().catch(() => ({}));
-    throw new Error(data?.detail || data?.error || `HTTP ${res.status}`);
+  const res = await mgmtRequest('DELETE', `/oauth/setup/${encodeURIComponent(sessionId)}`);
+  if (res.status < 200 || res.status >= 300) {
+    let detail: string | undefined;
+    try {
+      const data = JSON.parse(res.body);
+      detail = data?.detail || data?.error;
+    } catch {
+      // body not JSON
+    }
+    throw new Error(detail || `HTTP ${res.status}`);
   }
 }
 

--- a/src/lib/components/UnifiedCatalog.test.ts
+++ b/src/lib/components/UnifiedCatalog.test.ts
@@ -1,18 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { get } from 'svelte/store';
+import { invoke } from '@tauri-apps/api/core';
 import type { CatalogEntry } from '$lib/types';
 
-// Mock fetch globally
-const mockFetch = vi.fn();
-globalThis.fetch = mockFetch;
-
-function mockFetchSuccess(data: unknown) {
-  mockFetch.mockResolvedValue({
-    ok: true,
-    json: () => Promise.resolve(data),
-    status: 200,
-    statusText: 'OK',
-  });
+function mockMgmtSuccess(data: unknown) {
+  vi.mocked(invoke).mockResolvedValue({ status: 200, body: JSON.stringify(data) });
 }
 
 const sampleCatalog: CatalogEntry[] = [
@@ -43,12 +35,11 @@ describe('UnifiedCatalog', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
-    mockFetch.mockReset();
   });
 
   describe('getCatalog API integration', () => {
     it('returns catalog entries with endpoint and available fields', async () => {
-      mockFetchSuccess(sampleCatalog);
+      mockMgmtSuccess(sampleCatalog);
       const { getCatalog } = await import('$lib/api');
       const result = await getCatalog();
 


### PR DESCRIPTION
Companion PR: https://github.com/endara-ai/endara-relay/pull/48 (must merge in lockstep).

Implements R2 from the security audit (Cluster 1). Moves the relay's `/api/*` management routes off the loopback TCP listener and onto a Unix-domain socket (macOS/Linux) / Windows named pipe, eliminating the drive-by attack surface from any browser tab on the same host.

- Drops `CorsLayer::permissive()` on /api/* (no longer needed; the surface is no longer reachable from web origins).
- `/mcp` stays on TCP unchanged (per audit scoping).
- Desktop SvelteKit calls now go through a `relay_api_request` Tauri command that proxies HTTP semantics over the socket; webview call sites unchanged.
- Stale-socket cleanup at startup; UCred peer-cred check on Unix; named-pipe ACL restricted to current user SID on Windows.

Verification:
- relay: `cargo fmt --check` ✅ `cargo clippy --tests` ✅ `cargo test` ✅ `cargo audit` ⚠️ (pre-existing transitive vulns identical to `main`; no new advisories from this PR)
- desktop: `npm run check` ✅ `npm test` ✅ (259 pass / 24 skipped) `cargo fmt --check` ✅ `cargo clippy --tests` ✅ `cargo test` ✅ (23 pass) `cargo audit` ⚠️ (pre-existing transitive vulns)

DO NOT MERGE until both PRs have green CI.

