### PR TITLE
chore: bump version to 0.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@endara/desktop",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@endara/desktop",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endara/desktop",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "description": "Endara Desktop — Tauri + Svelte tray app for relay management",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "endara-desktop"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "dirs 5.0.1",
  "hostname",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endara-desktop"
-version = "0.1.4"
+version = "0.1.5"
 description = "Endara Desktop — relay management tray app"
 authors = ["Endara"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Endara Desktop",
   "mainBinaryName": "Endara Desktop",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "identifier": "ai.endara.desktop",
   "build": {
     "beforeDevCommand": "ENDARA_DEV_PORT=9500 bash scripts/kill-relay.sh; npm run dev",


### PR DESCRIPTION
Bumps desktop to `0.1.5` to coordinate with relay v0.1.5 release.

- `package.json`: 0.1.4 → 0.1.5
- `src-tauri/tauri.conf.json`: 0.1.4 → 0.1.5
- `src-tauri/Cargo.toml`: 0.1.4 → 0.1.5
- Lockfiles refreshed (`package-lock.json`, `src-tauri/Cargo.lock`)

Relay release: https://github.com/endara-ai/endara-relay/releases/tag/v0.1.5

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author