### PR TITLE
chore: bump version to 0.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endara/desktop",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "description": "Endara Desktop — Tauri + Svelte tray app for relay management",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "endara-desktop"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "dirs 5.0.1",
  "hostname",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endara-desktop"
-version = "0.1.5"
+version = "0.1.6"
 description = "Endara Desktop — relay management tray app"
 authors = ["Endara"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Endara Desktop",
   "mainBinaryName": "Endara Desktop",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "identifier": "ai.endara.desktop",
   "build": {
     "beforeDevCommand": "ENDARA_DEV_PORT=9500 bash scripts/kill-relay.sh; npm run dev",


### PR DESCRIPTION
Version bump to prepare the `v0.1.6-rc.1` tag.

Bumps three lockstep version fields to bare `0.1.6` (no `-rc` suffix per [AGENTS.md release-versioning rules](https://github.com/endara-ai/endara-desktop/blob/main/AGENTS.md)) and refreshes `src-tauri/Cargo.lock`:

- `package.json` → `0.1.6`
- `src-tauri/tauri.conf.json` → `0.1.6` (rc suffix is patched in by the release workflow at build time)
- `src-tauri/Cargo.toml` → `0.1.6`
- `src-tauri/Cargo.lock` (workspace crate entry refreshed)

Follows the relay's coordinated `v0.1.6-rc.1` release — see [endara-ai/endara-relay#57](https://github.com/endara-ai/endara-relay/pull/57). Per AGENTS.md, relay must be released first; the desktop tag will be pushed after this PR merges and the matching relay GitHub Release is published.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author