### PR TITLE
feat(desktop): server type override field (Advanced) + per-data-dir socket path coexistence

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -785,13 +785,19 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.2.9"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+checksum = "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98"
 dependencies = [
- "quote",
- "syn 2.0.117",
+ "ctor-proc-macro",
+ "dtor",
 ]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "darling"
@@ -825,6 +831,17 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1038,6 +1055,21 @@ checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
 dependencies = [
  "dtoa",
 ]
+
+[[package]]
+name = "dtor"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dunce"
@@ -2320,6 +2352,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2497,9 +2538,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.17.1"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c1738382f66ed56b3b9c8119e794a2e23148ac8ea214eda86622d4cb9d415a"
+checksum = "0ae8844f63b5b118e334e205585b8c5c17b984121dbdb179d44aeb087ffad3cb"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -2510,10 +2551,10 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png 0.17.16",
+ "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2530,12 +2571,6 @@ dependencies = [
  "raw-window-handle",
  "thiserror 1.0.69",
 ]
-
-[[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
@@ -2706,6 +2741,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-text"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2821,8 +2866,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -2998,7 +3062,6 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros 0.11.3",
  "phf_shared 0.11.3",
 ]
 
@@ -3095,19 +3158,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -4184,9 +4234,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -4577,15 +4627,16 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.34.8"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
+checksum = "a33f7f9e486ade65fcf1e45c440f9236c904f5c1002cdc7fc6ae582777345ce4"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
  "core-foundation",
  "core-graphics",
  "crossbeam-channel",
+ "dbus",
  "dispatch2",
  "dlopen2",
  "dpi",
@@ -4596,13 +4647,14 @@ dependencies = [
  "libc",
  "log",
  "ndk",
- "ndk-context",
  "ndk-sys",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
+ "objc2-ui-kit",
  "once_cell",
  "parking_lot",
+ "percent-encoding",
  "raw-window-handle",
  "tao-macros",
  "unicode-segmentation",
@@ -4649,9 +4701,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.10.3"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da77cc00fb9028caf5b5d4650f75e31f1ef3693459dfca7f7e506d1ecef0ba2d"
+checksum = "b93bd86d231f0a8138f11a02a584769fe4b703dc36ae133d783228dbc4801405"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4701,9 +4753,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.5.6"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bbc990d1dbf57a8e1c7fa2327f2a614d8b757805603c1b9ba5c81bade09fd4d"
+checksum = "3a318b234cc2dea65f575467bafcfb76286bce228ebc3778e337d61d03213007"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -4717,15 +4769,14 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "tauri-winres",
- "toml 0.9.12+spec-1.1.0",
  "walkdir",
 ]
 
 [[package]]
 name = "tauri-codegen"
-version = "2.5.5"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a24476afd977c5d5d169f72425868613d82747916dd29e0a357c84c4bd6d29"
+checksum = "6bd11644962add2549a60b7e7c6800f17d7020156e02f516021d8103e80cc528"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -4750,9 +4801,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.5.5"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39b349a98dadaffebb73f0a40dcd1f23c999211e5a2e744403db384d0c33de7"
+checksum = "fed9d3742a37a355d2e47c9af924e9fbc112abb76f9835d35d4780e318419502"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -4795,9 +4846,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-dialog"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9204b425d9be8d12aa60c2a83a289cf7d1caae40f57f336ed1155b3a5c0e359b"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
 dependencies = [
  "log",
  "raw-window-handle",
@@ -4813,13 +4864,15 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-fs"
-version = "2.4.5"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed390cc669f937afeb8b28032ce837bac8ea023d975a2e207375ec05afaf1804"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
 dependencies = [
  "anyhow",
  "dunce",
  "glob",
+ "log",
+ "objc2-foundation",
  "percent-encoding",
  "schemars 0.8.22",
  "serde",
@@ -4829,7 +4882,7 @@ dependencies = [
  "tauri-plugin",
  "tauri-utils",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "url",
 ]
 
@@ -4962,9 +5015,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.10.1"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2826d79a3297ed08cd6ea7f412644ef58e32969504bc4fbd8d7dbeabc4445ea2"
+checksum = "8fef478ba1d2ac21c2d528740b24d0cb315e1e8b1111aae53fafac34804371fc"
 dependencies = [
  "cookie",
  "dpi",
@@ -4987,9 +5040,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.10.1"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e"
+checksum = "a3989df2ae1c476404fe0a2e8ffc4cfbde97e51efd613c2bb5355fbc9ab52cf0"
 dependencies = [
  "gtk",
  "http",
@@ -5013,14 +5066,15 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.8.3"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219a1f983a2af3653f75b5747f76733b0da7ff03069c7a41901a5eb3ace4557d"
+checksum = "d57200389a2f82b4b0a40ae29ca19b6978116e8f4d4e974c3234ce40c0ffbdec"
 dependencies = [
  "anyhow",
  "brotli",
  "cargo_metadata",
  "ctor",
+ "dom_query",
  "dunce",
  "glob",
  "html5ever 0.29.1",
@@ -5030,7 +5084,8 @@ dependencies = [
  "kuchikiki",
  "log",
  "memchr",
- "phf 0.11.3",
+ "phf 0.13.1",
+ "plist",
  "proc-macro2",
  "quote",
  "regex",
@@ -5273,11 +5328,26 @@ checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
- "serde_spanned 1.1.0",
+ "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -5300,9 +5370,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -5338,25 +5408,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -5436,9 +5506,9 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.21.3"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
+checksum = "15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773"
 dependencies = [
  "crossbeam-channel",
  "dirs 6.0.0",
@@ -5450,10 +5520,10 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png 0.17.16",
+ "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6567,9 +6637,9 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wry"
-version = "0.54.4"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a8135d8676225e5744de000d4dff5a082501bf7db6a1c1495034f8c314edbc"
+checksum = "186f9871daa55fd9c016578b810d149de58367113db7fb72b462d2323ce19514"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1108,6 +1108,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-shell",
  "tauri-plugin-updater",
+ "tempfile",
  "tokio",
  "toml 0.8.2",
  "urlencoding",
@@ -5214,7 +5215,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1108,6 +1108,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-shell",
  "tauri-plugin-updater",
+ "tempfile",
  "tokio",
  "toml 0.8.2",
  "urlencoding",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,4 +45,5 @@ libc = "0.2.184"
 
 [dev-dependencies]
 serial_test = "3.4.0"
+tempfile = "3.27.0"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,4 +45,6 @@ libc = "0.2.184"
 
 [dev-dependencies]
 serial_test = "3.4.0"
+tempfile = "3.27.0"
+tokio = { version = "1", features = ["rt", "macros"] }
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,7 +26,7 @@ tokio = { version = "1", features = ["net", "sync", "time"] }
 toml = "0.8"
 hostname = "0.4"
 tauri-plugin-log = "2.8.0"
-tauri-plugin-dialog = "2.6.0"
+tauri-plugin-dialog = "2.7"
 tauri-plugin-autostart = "2"
 tauri-plugin-notification = "2"
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "json"] }

--- a/src-tauri/src/api_proxy.rs
+++ b/src-tauri/src/api_proxy.rs
@@ -6,7 +6,12 @@
 //! provides a `mgmt_api_request` Tauri command that proxies HTTP requests from
 //! the SvelteKit UI to the relay's local socket.
 //!
-//! Path resolution mirrors `endara_relay::management_listener::resolve_api_socket_path`.
+//! Path resolution mirrors `endara_relay::management_listener::resolve_api_socket_path`
+//! — see that module for details. On macOS / Linux the socket path includes an
+//! 8-char hex hash of the canonicalized `data_dir` so a dev build
+//! (`~/.endara-dev`) and an installed prod build (`~/.endara`) can run side by
+//! side without colliding on the same path. Windows is unchanged — the pipe
+//! name is already keyed on the user/session.
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -27,41 +32,75 @@ pub struct ApiResponse {
 
 /// Resolve the management-API socket / pipe path. Mirrors the relay's
 /// resolution so the two processes pick the same path without coordinating.
-#[allow(clippy::needless_return)]
-pub fn resolve_api_socket_path(#[allow(unused_variables)] data_dir: &Path) -> PathBuf {
+pub fn resolve_api_socket_path(data_dir: &Path) -> PathBuf {
     if let Ok(path) = std::env::var("ENDARA_API_SOCKET") {
         return PathBuf::from(path);
     }
 
     #[cfg(target_os = "linux")]
     {
+        let suffix = data_dir_suffix(data_dir);
         if let Ok(xdg) = std::env::var("XDG_RUNTIME_DIR") {
             let runtime = PathBuf::from(xdg);
             if !runtime.as_os_str().is_empty() {
-                return runtime.join("endara-relay").join("api.sock");
+                return runtime
+                    .join(format!("endara-relay-{suffix}"))
+                    .join("api.sock");
             }
         }
+        data_dir.join("api.sock")
     }
 
     #[cfg(target_os = "macos")]
     {
+        let suffix = data_dir_suffix(data_dir);
         let tmp = std::env::var("TMPDIR")
             .map(PathBuf::from)
             .unwrap_or_else(|_| PathBuf::from("/tmp"));
         let uid = unsafe { geteuid_u32() };
-        return tmp.join(format!("endara-relay-{uid}")).join("api.sock");
+        tmp.join(format!("endara-relay-{uid}-{suffix}"))
+            .join("api.sock")
     }
 
     #[cfg(windows)]
     {
         let session_id = current_user_pipe_suffix(data_dir);
-        return PathBuf::from(format!(r"\\.\pipe\endara-relay-{session_id}"));
+        PathBuf::from(format!(r"\\.\pipe\endara-relay-{session_id}"))
     }
 
-    // Final fallback — reached on Linux when XDG_RUNTIME_DIR is unset, and on
-    // any platform not covered by the cfg branches above. macOS / Windows
-    // branches above always early-return, so they never fall through here.
-    data_dir.join("api.sock")
+    // Final fallback for any other target (e.g. non-macOS unix variants not
+    // covered above). The platform-specific branches above are all single tail
+    // expressions, so this is only compiled where it can actually be reached.
+    #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+    {
+        data_dir.join("api.sock")
+    }
+}
+
+/// Stable 8-char lowercase hex hash of `data_dir`.
+///
+/// Used as a suffix on macOS / Linux socket paths so that two relay processes
+/// running under the same `uid` / `$XDG_RUNTIME_DIR` (e.g. an installed prod
+/// build and a `pnpm tauri dev` instance) get distinct paths.
+///
+/// Lockstep contract with `packages/relay/src/management_listener.rs`'s copy
+/// of this helper: both crates MUST produce the same 8 hex chars for the same
+/// canonicalized path. Keep the algorithm byte-for-byte identical:
+/// 1. `Path::canonicalize` the input; on error, hash the input path as-is.
+/// 2. Hash with `std::collections::hash_map::DefaultHasher`.
+/// 3. Format the resulting `u64` as `format!("{:016x}", hash)`, then take the
+///    first 8 chars. (NOT `format!("{:08x}", hash as u32)` — that's a
+///    different value.)
+#[cfg_attr(windows, allow(dead_code))]
+fn data_dir_suffix(data_dir: &Path) -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let canonical = data_dir.canonicalize().unwrap_or_else(|_| data_dir.into());
+    let mut h = DefaultHasher::new();
+    canonical.hash(&mut h);
+    let full = format!("{:016x}", h.finish());
+    full[..8].to_string()
 }
 
 #[cfg(unix)]
@@ -184,4 +223,65 @@ async fn connect(
 #[cfg(not(any(unix, windows)))]
 async fn connect(_path: &Path) -> Result<TokioIo<tokio::net::TcpStream>, String> {
     Err("management API bridge is unsupported on this platform".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Serializes env-mutating tests in this module. Cargo runs tests in the
+    // same binary in parallel by default; without this, setting/removing
+    // `ENDARA_API_SOCKET` could race between tests sharing the process-wide
+    // env.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn resolve_api_socket_path_honors_env_var() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("ENDARA_API_SOCKET", "/tmp/endara-desktop-test.sock");
+        let p = resolve_api_socket_path(Path::new("/tmp"));
+        assert_eq!(p, PathBuf::from("/tmp/endara-desktop-test.sock"));
+        std::env::remove_var("ENDARA_API_SOCKET");
+    }
+
+    #[test]
+    fn data_dir_suffix_returns_eight_lowercase_hex_chars() {
+        let dir = tempfile::tempdir().unwrap();
+        let s = data_dir_suffix(dir.path());
+        assert_eq!(s.len(), 8, "expected 8 chars, got {s:?}");
+        assert!(
+            s.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f')),
+            "expected lowercase hex, got {s:?}"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn resolve_api_socket_path_macos_differs_per_data_dir() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("ENDARA_API_SOCKET");
+        let a = tempfile::tempdir().unwrap();
+        let b = tempfile::tempdir().unwrap();
+        let pa = resolve_api_socket_path(a.path());
+        let pb = resolve_api_socket_path(b.path());
+        assert_ne!(
+            pa, pb,
+            "different data_dirs should produce different socket paths"
+        );
+        let parent_a = pa.parent().unwrap().file_name().unwrap().to_string_lossy();
+        let parent_b = pb.parent().unwrap().file_name().unwrap().to_string_lossy();
+        assert!(parent_a.starts_with("endara-relay-"));
+        assert!(parent_b.starts_with("endara-relay-"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn resolve_api_socket_path_macos_is_deterministic() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("ENDARA_API_SOCKET");
+        let dir = tempfile::tempdir().unwrap();
+        let p1 = resolve_api_socket_path(dir.path());
+        let p2 = resolve_api_socket_path(dir.path());
+        assert_eq!(p1, p2, "same data_dir should produce the same path");
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1173,6 +1173,10 @@ struct AddEndpointArgs {
     client_secret: Option<String>,
     scopes: Option<String>,
     token_endpoint: Option<String>,
+    /// Optional override for the upstream server name advertised to MCP
+    /// clients. Empty / absent leaves `server_type_override` out of the
+    /// `config.toml` entry.
+    server_type_override: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -1194,6 +1198,9 @@ struct EndpointConfig {
     client_secret_set: bool,
     scopes: Option<String>,
     token_endpoint: Option<String>,
+    /// Mirrors `server_type_override` from `config.toml`; absent when no
+    /// override is configured for this endpoint.
+    server_type_override: Option<String>,
 }
 
 /// Path to the DCR credentials file for an endpoint, e.g.
@@ -1324,6 +1331,11 @@ async fn get_endpoint_config(name: String) -> Result<EndpointConfig, String> {
                     .get("token_endpoint")
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string());
+                let server_type_override = ep
+                    .get("server_type_override")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+                    .filter(|s| !s.is_empty());
 
                 return Ok(EndpointConfig {
                     name: name.clone(),
@@ -1340,6 +1352,7 @@ async fn get_endpoint_config(name: String) -> Result<EndpointConfig, String> {
                     client_secret_set,
                     scopes,
                     token_endpoint,
+                    server_type_override,
                 });
             }
         }
@@ -1365,6 +1378,10 @@ struct UpdateEndpointArgs {
     client_secret: Option<String>,
     scopes: Option<String>,
     token_endpoint: Option<String>,
+    /// Optional override for the upstream server name advertised to MCP
+    /// clients. Empty / absent removes any prior `server_type_override` from
+    /// the endpoint entry on save.
+    server_type_override: Option<String>,
 }
 
 #[tauri::command]
@@ -1479,6 +1496,20 @@ async fn update_endpoint(args: UpdateEndpointArgs) -> Result<(), String> {
                     table.insert(
                         "token_endpoint".to_string(),
                         toml::Value::String(token_endpoint.clone()),
+                    );
+                }
+                // Persist `server_type_override` only when a non-empty value
+                // is supplied; empty / absent omits the key so the relay
+                // falls back to the upstream-reported server name.
+                if let Some(server_type_override) = args
+                    .server_type_override
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                {
+                    table.insert(
+                        "server_type_override".to_string(),
+                        toml::Value::String(server_type_override.to_string()),
                     );
                 }
                 break;
@@ -1614,6 +1645,19 @@ async fn add_endpoint(args: AddEndpointArgs) -> Result<(), String> {
         endpoint.insert(
             "token_endpoint".to_string(),
             toml::Value::String(token_endpoint),
+        );
+    }
+    // Only persist `server_type_override` when a non-empty value is supplied;
+    // otherwise the relay falls back to the upstream-reported server name.
+    if let Some(server_type_override) = args
+        .server_type_override
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        endpoint.insert(
+            "server_type_override".to_string(),
+            toml::Value::String(server_type_override.to_string()),
         );
     }
 
@@ -2265,5 +2309,196 @@ mod relay_watchdog_tests {
         assert!(detect_health_transition(&HealthState::Unknown, &HealthState::Unknown).is_none());
         assert!(detect_health_transition(&HealthState::Healthy, &HealthState::Unknown).is_none());
         assert!(detect_health_transition(&unhealthy("x"), &HealthState::Unknown).is_none());
+    }
+}
+
+#[cfg(test)]
+mod server_type_override_tests {
+    //! Round-trip coverage for the `server_type_override` field across
+    //! `add_endpoint` / `update_endpoint` / `get_endpoint_config`.
+    //!
+    //! Each test pins `$HOME` to a fresh `tempfile::TempDir` so the Tauri
+    //! commands write into an isolated `~/.endara-dev/config.toml`. Tests are
+    //! `serial` because env-var manipulation is process-global.
+    use super::*;
+    use serial_test::serial;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    /// Snapshots `$HOME` on construction and restores it on drop so tests
+    /// cannot leak the override into each other even on panic.
+    struct HomeGuard {
+        prior: Option<String>,
+        _tmp: TempDir,
+    }
+
+    impl HomeGuard {
+        fn new() -> Self {
+            let prior = std::env::var("HOME").ok();
+            let tmp = tempfile::tempdir().expect("create tempdir");
+            std::env::set_var("HOME", tmp.path());
+            Self { prior, _tmp: tmp }
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            match &self.prior {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+    }
+
+    fn rt() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build tokio runtime")
+    }
+
+    fn read_toml() -> String {
+        let path: PathBuf = config_path().expect("config_path");
+        std::fs::read_to_string(&path).expect("read config.toml")
+    }
+
+    fn base_add_args(name: &str, override_: Option<&str>) -> AddEndpointArgs {
+        AddEndpointArgs {
+            name: name.to_string(),
+            transport: "stdio".to_string(),
+            tool_prefix: Some(name.to_string()),
+            command: Some("echo".to_string()),
+            args: Some(vec!["hi".to_string()]),
+            url: None,
+            description: None,
+            env: None,
+            headers: None,
+            oauth_server_url: None,
+            client_id: None,
+            client_secret: None,
+            scopes: None,
+            token_endpoint: None,
+            server_type_override: override_.map(|s| s.to_string()),
+        }
+    }
+
+    fn base_update_args(original: &str, name: &str, override_: Option<&str>) -> UpdateEndpointArgs {
+        UpdateEndpointArgs {
+            original_name: original.to_string(),
+            name: name.to_string(),
+            transport: "stdio".to_string(),
+            tool_prefix: Some(name.to_string()),
+            command: Some("echo".to_string()),
+            args: Some(vec!["hi".to_string()]),
+            url: None,
+            description: None,
+            env: None,
+            headers: None,
+            oauth_server_url: None,
+            client_id: None,
+            client_secret: None,
+            scopes: None,
+            token_endpoint: None,
+            server_type_override: override_.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn add_endpoint_persists_server_type_override() {
+        let _home = HomeGuard::new();
+        let rt = rt();
+        rt.block_on(add_endpoint(base_add_args("gmail-acct", Some("gmail"))))
+            .expect("add_endpoint should succeed");
+
+        let toml = read_toml();
+        assert!(
+            toml.contains("server_type_override = \"gmail\""),
+            "config.toml should contain the override key, got:\n{toml}"
+        );
+
+        let cfg = rt
+            .block_on(get_endpoint_config("gmail-acct".to_string()))
+            .expect("get_endpoint_config");
+        assert_eq!(cfg.server_type_override.as_deref(), Some("gmail"));
+    }
+
+    #[test]
+    #[serial]
+    fn add_endpoint_skips_override_when_empty_or_absent() {
+        let _home = HomeGuard::new();
+        let rt = rt();
+        rt.block_on(add_endpoint_with_empty())
+            .expect("add_endpoint");
+
+        let toml = read_toml();
+        assert!(
+            !toml.contains("server_type_override"),
+            "empty / absent override should not be written, got:\n{toml}"
+        );
+
+        let cfg = rt
+            .block_on(get_endpoint_config("plain".to_string()))
+            .expect("get_endpoint_config");
+        assert!(cfg.server_type_override.is_none());
+    }
+
+    async fn add_endpoint_with_empty() -> Result<(), String> {
+        // Empty string and whitespace-only must both be stripped.
+        add_endpoint(base_add_args("plain", Some(""))).await?;
+        add_endpoint(base_add_args("blanks", Some("   "))).await?;
+        // And `None` should likewise omit the key.
+        add_endpoint(base_add_args("none", None)).await
+    }
+
+    #[test]
+    #[serial]
+    fn update_endpoint_round_trips_override_changes() {
+        let _home = HomeGuard::new();
+        let rt = rt();
+
+        // Seed without an override, then set one via update.
+        rt.block_on(add_endpoint(base_add_args("drive", None)))
+            .expect("seed add_endpoint");
+        rt.block_on(update_endpoint(base_update_args(
+            "drive",
+            "drive",
+            Some("google-drive"),
+        )))
+        .expect("update_endpoint (set)");
+        assert!(read_toml().contains("server_type_override = \"google-drive\""));
+        let cfg = rt
+            .block_on(get_endpoint_config("drive".to_string()))
+            .expect("read after set");
+        assert_eq!(cfg.server_type_override.as_deref(), Some("google-drive"));
+
+        // Change the override.
+        rt.block_on(update_endpoint(base_update_args(
+            "drive",
+            "drive",
+            Some("gdrive"),
+        )))
+        .expect("update_endpoint (change)");
+        let cfg = rt
+            .block_on(get_endpoint_config("drive".to_string()))
+            .expect("read after change");
+        assert_eq!(cfg.server_type_override.as_deref(), Some("gdrive"));
+
+        // Clear via empty string — key must be removed from TOML.
+        rt.block_on(update_endpoint(base_update_args(
+            "drive",
+            "drive",
+            Some(""),
+        )))
+        .expect("update_endpoint (clear)");
+        let toml = read_toml();
+        assert!(
+            !toml.contains("server_type_override"),
+            "clearing should remove the key, got:\n{toml}"
+        );
+        let cfg = rt
+            .block_on(get_endpoint_config("drive".to_string()))
+            .expect("read after clear");
+        assert!(cfg.server_type_override.is_none());
     }
 }

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -271,5 +271,44 @@ describe('api', () => {
       await expect(getConfig()).rejects.toThrow('HTTP 500');
     });
   });
+
+  describe('oauthSetup', () => {
+    // Regression coverage for the `server_type_override` field on
+    // `OAuthSetupParams`. It must round-trip through `mgmt_api_request`'s
+    // request body so the relay's `/oauth/setup` handler can persist it
+    // alongside the rest of the endpoint config on commit.
+    it('forwards server_type_override to invoke when set', async () => {
+      const { oauthSetup } = await import('./api');
+      mockOk({ session_id: 'sess-1', status: 'awaiting_callback' });
+
+      await oauthSetup({
+        name: 'Gmail',
+        url: 'https://example.com/mcp/',
+        server_type_override: 'gmail',
+      });
+
+      expect(invoke).toHaveBeenCalledWith(
+        'mgmt_api_request',
+        expect.objectContaining({
+          method: 'POST',
+          path: '/api/oauth/setup',
+          body: expect.objectContaining({ server_type_override: 'gmail' }),
+        }),
+      );
+    });
+
+    it('omits server_type_override from invoke body when absent', async () => {
+      const { oauthSetup } = await import('./api');
+      mockOk({ session_id: 'sess-2', status: 'awaiting_callback' });
+
+      await oauthSetup({
+        name: 'Gmail',
+        url: 'https://example.com/mcp/',
+      });
+
+      const callBody = vi.mocked(invoke).mock.calls[0][1] as { body: Record<string, unknown> };
+      expect(callBody.body).not.toHaveProperty('server_type_override');
+    });
+  });
 });
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -133,6 +133,13 @@ export interface AddEndpointParams {
   client_secret?: string;
   scopes?: string;
   token_endpoint?: string;
+  /**
+   * Optional override for the server type the relay advertises to MCP clients.
+   * When set, replaces the upstream `serverInfo.name` (useful when an upstream
+   * server returns a placeholder like `statelessserver`). Lowercase letters,
+   * digits, `-`, `_` only — empty/absent leaves the field unset.
+   */
+  server_type_override?: string;
 }
 
 export async function addEndpoint(params: AddEndpointParams): Promise<void> {
@@ -194,6 +201,12 @@ export interface EndpointConfig {
   client_secret_set?: boolean;
   scopes?: string;
   token_endpoint?: string;
+  /**
+   * Optional override that replaces the upstream-reported server name in the
+   * relay's connected-servers advertisement. Persisted to `config.toml` as
+   * `server_type_override`. Absent when no override is configured.
+   */
+  server_type_override?: string;
 }
 
 export async function getEndpointConfig(name: string): Promise<EndpointConfig> {
@@ -222,6 +235,11 @@ export interface UpdateEndpointParams {
   client_secret?: string;
   scopes?: string;
   token_endpoint?: string;
+  /**
+   * Optional override for the server type advertised to MCP clients. Empty
+   * string clears the override; absent leaves the stored value unchanged.
+   */
+  server_type_override?: string;
 }
 
 export async function startOAuth(name: string): Promise<OAuthStartResult> {
@@ -295,6 +313,12 @@ export interface OAuthSetupParams {
   oauth_server_url?: string;
   client_id?: string;
   client_secret?: string;
+  /**
+   * Optional override for the upstream-reported server name; forwarded to the
+   * relay's `/oauth/setup` endpoint so it is persisted alongside the endpoint
+   * config on commit. Lowercase letters, digits, `-`, `_` only.
+   */
+  server_type_override?: string;
 }
 
 export async function oauthSetup(params: OAuthSetupParams): Promise<OAuthSetupResponse> {

--- a/src/lib/catalog.ts
+++ b/src/lib/catalog.ts
@@ -17,6 +17,12 @@ export interface CatalogServer {
   args: string[];
   envVars: CatalogEnvVar[];
   userArgs?: { label: string; placeholder: string; type?: 'directory' | 'file' }[];
+  /**
+   * Optional default for the `server_type_override` field, used when the upstream
+   * MCP server returns a poor or placeholder `serverInfo.name`. Lowercase letters,
+   * digits, `-`, `_` only (mirrors the relay's `sanitize_server_name`).
+   */
+  serverTypeOverride?: string;
 }
 
 export const CATALOG_SERVERS: CatalogServer[] = [

--- a/src/lib/components/AddEndpointModal.svelte
+++ b/src/lib/components/AddEndpointModal.svelte
@@ -48,6 +48,19 @@
   let pendingSetupSessionId: string | null = $state(null);
   let setupAuthCancelled = $state(false);
   let cancelHint = $state('');
+  // Optional override that replaces the upstream-reported server name in the
+  // relay's connected-servers advertisement. Pre-populated from the catalog
+  // entry's `serverTypeOverride` default when one exists.
+  let serverTypeOverride = $state('');
+  // True iff the active catalog entry supplied a default override — drives the
+  // Advanced section's auto-expand behaviour.
+  let serverTypeOverrideHasDefault = $state(false);
+  // Inline-validation flag: true when the user has typed something that
+  // doesn't match the relay's `sanitize_server_name` rules (lowercase ASCII
+  // letters, digits, `-`, `_`). Empty input is considered valid (unset).
+  let serverTypeOverrideInvalid = $derived(
+    serverTypeOverride.trim() !== '' && !/^[a-z0-9_-]+$/.test(serverTypeOverride.trim())
+  );
 
   let prefixPreview = $derived(prefix ? `${prefix}__tool` : 'prefix__tool');
 
@@ -132,6 +145,8 @@
     showingDcrFallback = false;
     dcrClientId = '';
     dcrClientSecret = '';
+    serverTypeOverride = service.serverTypeOverride ?? '';
+    serverTypeOverrideHasDefault = Boolean(service.serverTypeOverride);
     error = '';
     step = 'configure';
   }
@@ -156,6 +171,8 @@
     scopes = '';
     selectedScopes = new Set();
     showingDcrFallback = false;
+    serverTypeOverride = server.serverTypeOverride ?? '';
+    serverTypeOverrideHasDefault = Boolean(server.serverTypeOverride);
     error = '';
     step = 'configure';
   }
@@ -181,6 +198,8 @@
     scopes = '';
     selectedScopes = new Set();
     showingDcrFallback = false;
+    serverTypeOverride = '';
+    serverTypeOverrideHasDefault = false;
     error = '';
     step = 'configure';
   }
@@ -353,6 +372,11 @@
       }
     }
 
+    const overrideValue = sanitizeName(serverTypeOverride);
+    if (overrideValue) {
+      params.server_type_override = overrideValue;
+    }
+
     submitting = true;
     try {
       await addEndpoint(params);
@@ -404,6 +428,10 @@
     }
     if (clientSecret.trim()) {
       setupParams.client_secret = clientSecret.trim();
+    }
+    const overrideValue = sanitizeName(serverTypeOverride);
+    if (overrideValue) {
+      setupParams.server_type_override = overrideValue;
     }
 
     submitting = true;
@@ -823,8 +851,9 @@
             </p>
           {/if}
 
-          <!-- Collapsible Advanced section — collapsed by default for all OAuth flows -->
-          <details class="border border-(--border) rounded-lg">
+          <!-- Collapsible Advanced section — auto-expanded when the catalog
+               entry ships a default `serverTypeOverride`, otherwise collapsed. -->
+          <details class="border border-(--border) rounded-lg" open={serverTypeOverrideHasDefault}>
             <summary class="px-3 py-2 text-xs font-medium text-(--fg2) cursor-pointer hover:bg-(--surface-hover) rounded-lg select-none">
               Advanced
             </summary>
@@ -853,6 +882,19 @@
                 <label for="modal-ep-client-secret" class="block text-xs font-medium mb-1 text-(--fg2)">Client Secret <span class="text-(--fg2)/50">(optional)</span></label>
                 <input id="modal-ep-client-secret" type="password" bind:value={clientSecret} placeholder="Optional"
                   class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent)" />
+              </div>
+              <div>
+                <label for="modal-ep-server-type-override" class="block text-xs font-medium mb-1 text-(--fg2)">Server type override <span class="text-(--fg2)/50">(optional)</span></label>
+                <input
+                  id="modal-ep-server-type-override"
+                  type="text"
+                  bind:value={serverTypeOverride}
+                  placeholder="e.g. gmail"
+                  class="w-full text-sm px-3 py-1.5 rounded-lg border bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) {serverTypeOverrideInvalid ? 'border-(--offline)' : 'border-(--border)'}" />
+                <p class="text-[11px] text-(--fg2) mt-0.5">Optional. Replaces the name this server reports to MCP clients. Useful when an upstream MCP server returns a placeholder like 'statelessserver'.</p>
+                {#if serverTypeOverrideInvalid}
+                  <p class="text-[11px] text-(--offline) mt-0.5">Only lowercase letters, digits, and <code>-</code>/<code>_</code> are allowed.</p>
+                {/if}
               </div>
             </div>
           </details>
@@ -980,6 +1022,31 @@
               </div>
             {/each}
           </div>
+        {/if}
+
+        <!-- Generic Advanced section for non-OAuth transports. Auto-expanded
+             when the catalog entry ships a default `serverTypeOverride`. -->
+        {#if transport !== 'oauth'}
+          <details class="border border-(--border) rounded-lg" open={serverTypeOverrideHasDefault}>
+            <summary class="px-3 py-2 text-xs font-medium text-(--fg2) cursor-pointer hover:bg-(--surface-hover) rounded-lg select-none">
+              Advanced
+            </summary>
+            <div class="px-3 pb-3 space-y-3">
+              <div>
+                <label for="modal-ep-server-type-override-generic" class="block text-xs font-medium mb-1 text-(--fg2)">Server type override <span class="text-(--fg2)/50">(optional)</span></label>
+                <input
+                  id="modal-ep-server-type-override-generic"
+                  type="text"
+                  bind:value={serverTypeOverride}
+                  placeholder="e.g. my-server"
+                  class="w-full text-sm px-3 py-1.5 rounded-lg border bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) {serverTypeOverrideInvalid ? 'border-(--offline)' : 'border-(--border)'}" />
+                <p class="text-[11px] text-(--fg2) mt-0.5">Optional. Replaces the name this server reports to MCP clients. Useful when an upstream MCP server returns a placeholder like 'statelessserver'.</p>
+                {#if serverTypeOverrideInvalid}
+                  <p class="text-[11px] text-(--offline) mt-0.5">Only lowercase letters, digits, and <code>-</code>/<code>_</code> are allowed.</p>
+                {/if}
+              </div>
+            </div>
+          </details>
         {/if}
 
         <!-- Test Connection (not shown for OAuth) -->

--- a/src/lib/components/AddEndpointModal.svelte
+++ b/src/lib/components/AddEndpointModal.svelte
@@ -55,12 +55,27 @@
   // True iff the active catalog entry supplied a default override — drives the
   // Advanced section's auto-expand behaviour.
   let serverTypeOverrideHasDefault = $state(false);
-  // Inline-validation flag: true when the user has typed something that
-  // doesn't match the relay's `sanitize_server_name` rules (lowercase ASCII
-  // letters, digits, `-`, `_`). Empty input is considered valid (unset).
+  // Sanitized projection of the override input — what would actually get
+  // persisted, mirroring relay's `sanitize_server_name`. Used to drive both
+  // the inline preview and the validation state.
+  let serverTypeOverrideSanitized = $derived(sanitizeName(serverTypeOverride));
+  // Inline-validation flag: true only when the user has typed something
+  // that would sanitize to an empty string (i.e. unusable). Inputs that
+  // sanitize cleanly are accepted — the preview hint shows the result.
   let serverTypeOverrideInvalid = $derived(
-    serverTypeOverride.trim() !== '' && !/^[a-z0-9_-]+$/.test(serverTypeOverride.trim())
+    serverTypeOverride.trim() !== '' && serverTypeOverrideSanitized === ''
   );
+  // True when the trimmed input differs from its sanitized form, so we can
+  // show a "Will be saved as: <sanitized>" preview without nagging the user
+  // when the input is already canonical.
+  let serverTypeOverridePreviewVisible = $derived(
+    serverTypeOverrideSanitized !== '' &&
+      serverTypeOverride.trim() !== serverTypeOverrideSanitized
+  );
+  // Defensive overflow flag — `maxlength={64}` on the input should keep the
+  // value at ≤64 chars, but pasted content can occasionally bypass that on
+  // some platforms. Surface a hint if it ever happens.
+  let serverTypeOverrideTooLong = $derived(serverTypeOverride.length > 64);
 
   let prefixPreview = $derived(prefix ? `${prefix}__tool` : 'prefix__tool');
 
@@ -890,10 +905,17 @@
                   type="text"
                   bind:value={serverTypeOverride}
                   placeholder="e.g. gmail"
-                  class="w-full text-sm px-3 py-1.5 rounded-lg border bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) {serverTypeOverrideInvalid ? 'border-(--offline)' : 'border-(--border)'}" />
-                <p class="text-[11px] text-(--fg2) mt-0.5">Optional. Replaces the name this server reports to MCP clients. Useful when an upstream MCP server returns a placeholder like 'statelessserver'.</p>
+                  maxlength={64}
+                  class="w-full text-sm px-3 py-1.5 rounded-lg border bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) {serverTypeOverrideInvalid || serverTypeOverrideTooLong ? 'border-(--offline)' : 'border-(--border)'}" />
+                <p class="text-[11px] text-(--fg2) mt-0.5">Optional. Replaces the name this server reports to MCP clients. Useful when an upstream MCP server returns a placeholder like 'statelessserver'. Max 64 characters.</p>
+                {#if serverTypeOverridePreviewVisible}
+                  <p class="text-[11px] text-(--fg2) mt-0.5">Will be saved as: <code>{serverTypeOverrideSanitized}</code></p>
+                {/if}
                 {#if serverTypeOverrideInvalid}
-                  <p class="text-[11px] text-(--offline) mt-0.5">Only lowercase letters, digits, and <code>-</code>/<code>_</code> are allowed.</p>
+                  <p class="text-[11px] text-(--offline) mt-0.5">No usable characters — please include lowercase letters, digits, <code>-</code>, or <code>_</code>.</p>
+                {/if}
+                {#if serverTypeOverrideTooLong}
+                  <p class="text-[11px] text-(--offline) mt-0.5">Maximum 64 characters.</p>
                 {/if}
               </div>
             </div>
@@ -1039,10 +1061,17 @@
                   type="text"
                   bind:value={serverTypeOverride}
                   placeholder="e.g. my-server"
-                  class="w-full text-sm px-3 py-1.5 rounded-lg border bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) {serverTypeOverrideInvalid ? 'border-(--offline)' : 'border-(--border)'}" />
-                <p class="text-[11px] text-(--fg2) mt-0.5">Optional. Replaces the name this server reports to MCP clients. Useful when an upstream MCP server returns a placeholder like 'statelessserver'.</p>
+                  maxlength={64}
+                  class="w-full text-sm px-3 py-1.5 rounded-lg border bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) {serverTypeOverrideInvalid || serverTypeOverrideTooLong ? 'border-(--offline)' : 'border-(--border)'}" />
+                <p class="text-[11px] text-(--fg2) mt-0.5">Optional. Replaces the name this server reports to MCP clients. Useful when an upstream MCP server returns a placeholder like 'statelessserver'. Max 64 characters.</p>
+                {#if serverTypeOverridePreviewVisible}
+                  <p class="text-[11px] text-(--fg2) mt-0.5">Will be saved as: <code>{serverTypeOverrideSanitized}</code></p>
+                {/if}
                 {#if serverTypeOverrideInvalid}
-                  <p class="text-[11px] text-(--offline) mt-0.5">Only lowercase letters, digits, and <code>-</code>/<code>_</code> are allowed.</p>
+                  <p class="text-[11px] text-(--offline) mt-0.5">No usable characters — please include lowercase letters, digits, <code>-</code>, or <code>_</code>.</p>
+                {/if}
+                {#if serverTypeOverrideTooLong}
+                  <p class="text-[11px] text-(--offline) mt-0.5">Maximum 64 characters.</p>
                 {/if}
               </div>
             </div>

--- a/src/lib/components/AddEndpointModal.test.ts
+++ b/src/lib/components/AddEndpointModal.test.ts
@@ -4,17 +4,21 @@ import { CATALOG_SERVERS, type CatalogServer } from '$lib/catalog';
 import { oauthCatalog, type OAuthCatalogEntry } from '$lib/data/oauth-catalog';
 import { buildScopesPayload, shouldShowManualOAuthStar } from './add-endpoint-helpers';
 
+// `sanitizeName` mirrors the relay's `sanitize_server_name`
+// (`packages/relay/src/adapter/server_name.rs`). The cases below stay in
+// lockstep with that Rust unit test table so the two ends agree on what a
+// freshly-typed override will produce.
 describe('sanitizeName', () => {
   it('handles basic lowercase name', () => {
     expect(sanitizeName('echo-mcp')).toBe('echo-mcp');
   });
 
-  it('converts spaces to underscores', () => {
-    expect(sanitizeName('My MCP Server')).toBe('my_mcp_server');
+  it('converts spaces to dashes (matching relay semantics)', () => {
+    expect(sanitizeName('My MCP Server')).toBe('my-mcp-server');
   });
 
-  it('strips special characters', () => {
-    expect(sanitizeName('server@v2.0!')).toBe('serverv20');
+  it('replaces special characters with collapsed dashes', () => {
+    expect(sanitizeName('server@v2.0!')).toBe('server-v2-0');
   });
 
   it('converts uppercase to lowercase', () => {
@@ -29,13 +33,13 @@ describe('sanitizeName', () => {
     expect(sanitizeName('@#$%^&*')).toBe('');
   });
 
-  it('strips unicode characters', () => {
+  it('replaces unicode with dashes (trimmed at edges)', () => {
     expect(sanitizeName('café')).toBe('caf');
     expect(sanitizeName('日本語')).toBe('');
   });
 
   it('handles mixed input', () => {
-    expect(sanitizeName('My Server - v2.0 (beta)')).toBe('my_server_-_v20_beta');
+    expect(sanitizeName('My Server - v2.0 (beta)')).toBe('my-server-v2-0-beta');
   });
 
   it('preserves hyphens and underscores', () => {
@@ -44,6 +48,44 @@ describe('sanitizeName', () => {
 
   it('preserves digits', () => {
     expect(sanitizeName('server123')).toBe('server123');
+  });
+
+  // ── Additional coverage for relay parity (Wave DT.3) ──
+
+  it('trims leading and trailing whitespace', () => {
+    expect(sanitizeName('  spaces  ')).toBe('spaces');
+  });
+
+  it('collapses internal whitespace runs to a single dash', () => {
+    expect(sanitizeName('Linear   MCP\tServer')).toBe('linear-mcp-server');
+  });
+
+  it('collapses runs of dots/slashes/colons to a single dash', () => {
+    expect(sanitizeName('a..b//c::d')).toBe('a-b-c-d');
+  });
+
+  it('trims leading and trailing dashes after replacement', () => {
+    expect(sanitizeName('---Gmail---')).toBe('gmail');
+  });
+
+  it('truncates to 64 characters', () => {
+    const input = 'a'.repeat(100);
+    const out = sanitizeName(input);
+    expect(out.length).toBe(64);
+    expect(out).toBe('a'.repeat(64));
+  });
+
+  it('passes already-canonical lowercase names through unchanged', () => {
+    expect(sanitizeName('gmail')).toBe('gmail');
+    expect(sanitizeName('google-drive')).toBe('google-drive');
+    expect(sanitizeName('google-calendar')).toBe('google-calendar');
+  });
+
+  it('is idempotent for canonical inputs', () => {
+    const cases = ['gmail', 'my-server-v2', 'a_b-c', 'server123'];
+    for (const c of cases) {
+      expect(sanitizeName(sanitizeName(c))).toBe(sanitizeName(c));
+    }
   });
 });
 

--- a/src/lib/components/ConfigTab.svelte
+++ b/src/lib/components/ConfigTab.svelte
@@ -30,6 +30,15 @@
   let clientSecret = $state('');
   let clientSecretSet = $state(false);
   let scopes = $state('');
+  // Optional override that replaces the upstream-reported server name in the
+  // relay's connected-servers advertisement.
+  let serverTypeOverride = $state('');
+  // Inline-validation flag: true when the user has typed something that
+  // doesn't match the relay's `sanitize_server_name` rules (lowercase ASCII
+  // letters, digits, `-`, `_`). Empty input is considered valid (unset).
+  let serverTypeOverrideInvalid = $derived(
+    serverTypeOverride.trim() !== '' && !/^[a-z0-9_-]+$/.test(serverTypeOverride.trim())
+  );
 
   // Original value snapshots for dirty-state tracking
   let originalTransport: TransportType = $state('stdio');
@@ -44,6 +53,7 @@
   let originalOauthServerUrl = $state('');
   let originalClientId = $state('');
   let originalScopes = $state('');
+  let originalServerTypeOverride = $state('');
 
   function snapshotOriginals() {
     originalTransport = transport;
@@ -58,6 +68,7 @@
     originalOauthServerUrl = oauthServerUrl;
     originalClientId = clientId;
     originalScopes = scopes;
+    originalServerTypeOverride = serverTypeOverride;
   }
 
   let prefixPreview = $derived(prefix ? `${prefix}__tool` : 'prefix__tool');
@@ -80,7 +91,8 @@
     oauthServerUrl !== originalOauthServerUrl ||
     clientId !== originalClientId ||
     clientSecretDirty ||
-    scopes !== originalScopes
+    scopes !== originalScopes ||
+    serverTypeOverride !== originalServerTypeOverride
   );
 
   $effect(() => {
@@ -132,6 +144,7 @@
         clientSecret = '';
         clientSecretSet = config.client_secret_set ?? false;
         scopes = config.scopes ?? '';
+        serverTypeOverride = config.server_type_override ?? '';
         snapshotOriginals();
       })
       .catch(() => {
@@ -212,6 +225,12 @@
         params.headers = headers;
       }
     }
+
+    // Always send the override field so an emptied input clears the stored
+    // value. The Rust handler skips writing on empty / absent. Sanitize so the
+    // value matches the relay's `sanitize_server_name` rules even if the user
+    // typed mixed-case or whitespace.
+    params.server_type_override = sanitizeName(serverTypeOverride);
 
     saving = true;
     try {
@@ -334,7 +353,8 @@
             <input id="config-ep-url" type="text" bind:value={url} placeholder="https://api.githubcopilot.com/mcp/"
               class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent)" />
           </div>
-          <details class="border border-(--border) rounded-lg">
+          <!-- Auto-expanded when a `server_type_override` is currently stored. -->
+          <details class="border border-(--border) rounded-lg" open={originalServerTypeOverride !== ''}>
             <summary class="px-3 py-2 text-xs font-medium text-(--fg2) cursor-pointer hover:bg-(--surface-hover) rounded-lg select-none">Advanced</summary>
             <div class="px-3 pb-3 space-y-3">
               <div>
@@ -358,6 +378,19 @@
                 <label for="config-ep-scopes" class="block text-xs font-medium mb-1 text-(--fg2)">Scopes <span class="text-(--fg2)/50">(space-separated)</span></label>
                 <input id="config-ep-scopes" type="text" bind:value={scopes} placeholder="repo read:user"
                   class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent)" />
+              </div>
+              <div>
+                <label for="config-ep-server-type-override" class="block text-xs font-medium mb-1 text-(--fg2)">Server type override <span class="text-(--fg2)/50">(optional)</span></label>
+                <input
+                  id="config-ep-server-type-override"
+                  type="text"
+                  bind:value={serverTypeOverride}
+                  placeholder="e.g. gmail"
+                  class="w-full text-sm px-3 py-1.5 rounded-lg border bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) {serverTypeOverrideInvalid ? 'border-(--offline)' : 'border-(--border)'}" />
+                <p class="text-[11px] text-(--fg2) mt-0.5">Optional. Replaces the name this server reports to MCP clients. Useful when an upstream MCP server returns a placeholder like 'statelessserver'.</p>
+                {#if serverTypeOverrideInvalid}
+                  <p class="text-[11px] text-(--offline) mt-0.5">Only lowercase letters, digits, and <code>-</code>/<code>_</code> are allowed.</p>
+                {/if}
               </div>
             </div>
           </details>
@@ -429,6 +462,29 @@
               </div>
             {/each}
           </div>
+        {/if}
+
+        <!-- Generic Advanced section for non-OAuth transports. Auto-expanded
+             when a `server_type_override` is currently stored. -->
+        {#if transport !== 'oauth'}
+          <details class="border border-(--border) rounded-lg" open={originalServerTypeOverride !== ''}>
+            <summary class="px-3 py-2 text-xs font-medium text-(--fg2) cursor-pointer hover:bg-(--surface-hover) rounded-lg select-none">Advanced</summary>
+            <div class="px-3 pb-3 space-y-3">
+              <div>
+                <label for="config-ep-server-type-override-generic" class="block text-xs font-medium mb-1 text-(--fg2)">Server type override <span class="text-(--fg2)/50">(optional)</span></label>
+                <input
+                  id="config-ep-server-type-override-generic"
+                  type="text"
+                  bind:value={serverTypeOverride}
+                  placeholder="e.g. my-server"
+                  class="w-full text-sm px-3 py-1.5 rounded-lg border bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) {serverTypeOverrideInvalid ? 'border-(--offline)' : 'border-(--border)'}" />
+                <p class="text-[11px] text-(--fg2) mt-0.5">Optional. Replaces the name this server reports to MCP clients. Useful when an upstream MCP server returns a placeholder like 'statelessserver'.</p>
+                {#if serverTypeOverrideInvalid}
+                  <p class="text-[11px] text-(--offline) mt-0.5">Only lowercase letters, digits, and <code>-</code>/<code>_</code> are allowed.</p>
+                {/if}
+              </div>
+            </div>
+          </details>
         {/if}
 
         {#if error}

--- a/src/lib/components/ConfigTab.svelte
+++ b/src/lib/components/ConfigTab.svelte
@@ -33,12 +33,27 @@
   // Optional override that replaces the upstream-reported server name in the
   // relay's connected-servers advertisement.
   let serverTypeOverride = $state('');
-  // Inline-validation flag: true when the user has typed something that
-  // doesn't match the relay's `sanitize_server_name` rules (lowercase ASCII
-  // letters, digits, `-`, `_`). Empty input is considered valid (unset).
+  // Sanitized projection of the override input — what would actually get
+  // persisted, mirroring relay's `sanitize_server_name`. Drives both the
+  // inline preview and the validation state.
+  let serverTypeOverrideSanitized = $derived(sanitizeName(serverTypeOverride));
+  // Inline-validation flag: true only when the user has typed something
+  // that would sanitize to an empty string (i.e. unusable). Inputs that
+  // sanitize cleanly are accepted — the preview hint shows the result.
   let serverTypeOverrideInvalid = $derived(
-    serverTypeOverride.trim() !== '' && !/^[a-z0-9_-]+$/.test(serverTypeOverride.trim())
+    serverTypeOverride.trim() !== '' && serverTypeOverrideSanitized === ''
   );
+  // True when the trimmed input differs from its sanitized form, so we can
+  // show a "Will be saved as: <sanitized>" preview without nagging the user
+  // when the input is already canonical.
+  let serverTypeOverridePreviewVisible = $derived(
+    serverTypeOverrideSanitized !== '' &&
+      serverTypeOverride.trim() !== serverTypeOverrideSanitized
+  );
+  // Defensive overflow flag — `maxlength={64}` on the input should keep the
+  // value at ≤64 chars, but pasted content can occasionally bypass that on
+  // some platforms. Surface a hint if it ever happens.
+  let serverTypeOverrideTooLong = $derived(serverTypeOverride.length > 64);
 
   // Original value snapshots for dirty-state tracking
   let originalTransport: TransportType = $state('stdio');
@@ -386,10 +401,17 @@
                   type="text"
                   bind:value={serverTypeOverride}
                   placeholder="e.g. gmail"
-                  class="w-full text-sm px-3 py-1.5 rounded-lg border bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) {serverTypeOverrideInvalid ? 'border-(--offline)' : 'border-(--border)'}" />
-                <p class="text-[11px] text-(--fg2) mt-0.5">Optional. Replaces the name this server reports to MCP clients. Useful when an upstream MCP server returns a placeholder like 'statelessserver'.</p>
+                  maxlength={64}
+                  class="w-full text-sm px-3 py-1.5 rounded-lg border bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) {serverTypeOverrideInvalid || serverTypeOverrideTooLong ? 'border-(--offline)' : 'border-(--border)'}" />
+                <p class="text-[11px] text-(--fg2) mt-0.5">Optional. Replaces the name this server reports to MCP clients. Useful when an upstream MCP server returns a placeholder like 'statelessserver'. Max 64 characters.</p>
+                {#if serverTypeOverridePreviewVisible}
+                  <p class="text-[11px] text-(--fg2) mt-0.5">Will be saved as: <code>{serverTypeOverrideSanitized}</code></p>
+                {/if}
                 {#if serverTypeOverrideInvalid}
-                  <p class="text-[11px] text-(--offline) mt-0.5">Only lowercase letters, digits, and <code>-</code>/<code>_</code> are allowed.</p>
+                  <p class="text-[11px] text-(--offline) mt-0.5">No usable characters — please include lowercase letters, digits, <code>-</code>, or <code>_</code>.</p>
+                {/if}
+                {#if serverTypeOverrideTooLong}
+                  <p class="text-[11px] text-(--offline) mt-0.5">Maximum 64 characters.</p>
                 {/if}
               </div>
             </div>
@@ -477,10 +499,17 @@
                   type="text"
                   bind:value={serverTypeOverride}
                   placeholder="e.g. my-server"
-                  class="w-full text-sm px-3 py-1.5 rounded-lg border bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) {serverTypeOverrideInvalid ? 'border-(--offline)' : 'border-(--border)'}" />
-                <p class="text-[11px] text-(--fg2) mt-0.5">Optional. Replaces the name this server reports to MCP clients. Useful when an upstream MCP server returns a placeholder like 'statelessserver'.</p>
+                  maxlength={64}
+                  class="w-full text-sm px-3 py-1.5 rounded-lg border bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) {serverTypeOverrideInvalid || serverTypeOverrideTooLong ? 'border-(--offline)' : 'border-(--border)'}" />
+                <p class="text-[11px] text-(--fg2) mt-0.5">Optional. Replaces the name this server reports to MCP clients. Useful when an upstream MCP server returns a placeholder like 'statelessserver'. Max 64 characters.</p>
+                {#if serverTypeOverridePreviewVisible}
+                  <p class="text-[11px] text-(--fg2) mt-0.5">Will be saved as: <code>{serverTypeOverrideSanitized}</code></p>
+                {/if}
                 {#if serverTypeOverrideInvalid}
-                  <p class="text-[11px] text-(--offline) mt-0.5">Only lowercase letters, digits, and <code>-</code>/<code>_</code> are allowed.</p>
+                  <p class="text-[11px] text-(--offline) mt-0.5">No usable characters — please include lowercase letters, digits, <code>-</code>, or <code>_</code>.</p>
+                {/if}
+                {#if serverTypeOverrideTooLong}
+                  <p class="text-[11px] text-(--offline) mt-0.5">Maximum 64 characters.</p>
                 {/if}
               </div>
             </div>

--- a/src/lib/data/oauth-catalog.ts
+++ b/src/lib/data/oauth-catalog.ts
@@ -21,6 +21,12 @@ export interface OAuthCatalogEntry {
   supportsDcr: boolean;
   tokenEndpoint?: string;
   notes?: string;
+  /**
+   * Optional default for the `server_type_override` field. Used to replace the
+   * upstream-reported server name when the MCP server returns a poor placeholder
+   * (e.g. Google's `statelessserver`). Lowercase letters, digits, `-`, `_` only.
+   */
+  serverTypeOverride?: string;
 }
 
 export const oauthCatalog: OAuthCatalogEntry[] = [
@@ -125,6 +131,7 @@ export const oauthCatalog: OAuthCatalogEntry[] = [
     supportsDiscovery: true,
     supportsDcr: false,
     notes: 'Requires a Google Cloud OAuth client — Client ID and Secret needed',
+    serverTypeOverride: 'gmail',
   },
   {
     id: 'google-calendar',
@@ -158,6 +165,7 @@ export const oauthCatalog: OAuthCatalogEntry[] = [
     supportsDiscovery: true,
     supportsDcr: false,
     notes: 'Requires a Google Cloud OAuth client — Client ID and Secret needed',
+    serverTypeOverride: 'google-calendar',
   },
   {
     id: 'google-drive',
@@ -185,6 +193,7 @@ export const oauthCatalog: OAuthCatalogEntry[] = [
     supportsDiscovery: true,
     supportsDcr: false,
     notes: 'Requires a Google Cloud OAuth client — Client ID and Secret needed',
+    serverTypeOverride: 'google-drive',
   },
 ];
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,9 +1,43 @@
+/**
+ * Sanitize a free-form string into the relay's canonical
+ * `[a-z0-9_-]{1,64}` form, mirroring `sanitize_server_name` in
+ * `packages/relay/src/adapter/server_name.rs`:
+ *
+ * 1. Lowercase.
+ * 2. Trim leading/trailing whitespace.
+ * 3. Replace any character outside `[a-z0-9_]` with `-`,
+ *    collapsing runs of replacements (and existing `-`s) to a single `-`.
+ * 4. Trim leading/trailing `-`.
+ * 5. Truncate to 64 characters (the relay rejects longer; the JS helper
+ *    truncates so the override field cannot produce an invalid value).
+ *
+ * Returns `''` for inputs that reduce to nothing — callers decide what to
+ * do with the empty result (treat as "no override", show validation, etc).
+ */
 export function sanitizeName(name: string): string {
-  const sanitized = name
-    .toLowerCase()
-    .replaceAll(' ', '_')
-    .replace(/[^a-z0-9_-]/g, '');
+  const lowered = name.toLowerCase().trim();
+  if (!lowered) return '';
 
-  return sanitized || '';
+  let out = '';
+  let lastWasDash = false;
+  for (const ch of lowered) {
+    if ((ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch === '_') {
+      out += ch;
+      lastWasDash = false;
+    } else {
+      if (lastWasDash) continue;
+      out += '-';
+      lastWasDash = true;
+    }
+  }
+
+  // Trim leading/trailing dashes
+  let start = 0;
+  let end = out.length;
+  while (start < end && out[start] === '-') start++;
+  while (end > start && out[end - 1] === '-') end--;
+  const trimmed = out.slice(start, end);
+
+  return trimmed.length > 64 ? trimmed.slice(0, 64) : trimmed;
 }
 


### PR DESCRIPTION
## Summary

Desktop-side rc.2 PR. Combines two changes that originally landed on two branches:

1. **Server type override (Wave DT.1)** — optional `serverTypeOverride` field on catalog entries, plumbed through the Tauri endpoint commands so it round-trips to `~/.endara/config.toml`, with an **Advanced** section in the Add Endpoint modal and Configure tab edit form.
2. **Per-data-dir socket path (Wave DT.4)** — `resolve_api_socket_path` in `src-tauri/src/api_proxy.rs` now incorporates a stable 8-char hash of the canonicalized `data_dir` into the macOS / Linux socket path so a dev build (`~/.endara-dev`) and an installed prod build (`~/.endara`) running under the same uid / `$XDG_RUNTIME_DIR` no longer collide on the same Unix-domain socket. The restructuring also drops the long-standing `unreachable_code` warning in `api_proxy.rs`.

This PR supersedes #75 — the socket-path work has been merged into this branch (merge commit `fd29978`). Branch `panghy/socket-path-data-dir-desktop` will be deleted after this PR merges.

The relay-side counterparts are:
- **endara-ai/endara-relay#58** — `server_type_override` config field + `-mcp-server` suffix strip (already merged on relay `main`).
- **endara-ai/endara-relay#59** — matching `resolve_api_socket_path` data-dir-aware change (open; must merge together with this PR so both crates compute byte-identical paths).

## What changed

### Server type override (Wave DT.1)

**Catalog (`src/lib/`)**
- `catalog.ts`: extend `CatalogServer` with `serverTypeOverride?: string`.
- `data/oauth-catalog.ts`: pre-populate defaults for `google-drive`, `gmail`, `google-calendar`.
- `api.ts`: `OAuthSetupParams` carries the field through to `finalize_oauth_setup`.

**Tauri backend (`src-tauri/src/lib.rs`)**
- `AddEndpointArgs`, `UpdateEndpointArgs`, `EndpointConfig` gain `server_type_override: Option<String>`.
- `add_endpoint` / `update_endpoint` write the key to `config.toml` when present and **omit** / **remove** it when empty, whitespace-only, or absent so existing entries are not gratuitously rewritten.
- `get_endpoint_config` returns the persisted value (or `None`).
- New `server_type_override_tests` module covers add / update set / change / clear flows.

**UI (Svelte)**
- `AddEndpointModal.svelte`: collapsible **Advanced** section that auto-expands when the selected catalog entry has a default override; input is sanitized in real time (lowercase, ASCII, `[a-z0-9_-]+`) with an inline hint when illegal characters are stripped.
- `ConfigTab.svelte`: same Advanced section in the edit form, auto-expands when a value is already stored, with dirty tracking against the original.

### Per-data-dir socket path (Wave DT.4)

**`src-tauri/src/api_proxy.rs`**
- New private helper `data_dir_suffix(data_dir) -> String` — 8 lowercase hex chars from a `DefaultHasher` over the canonicalized `data_dir` (or the raw path if `canonicalize` fails — never panics). Copied **verbatim** from `packages/relay/src/management_listener.rs` (relay PR #59) so the two crates produce byte-identical paths.
- **Linux**: `$XDG_RUNTIME_DIR/endara-relay-<suffix>/api.sock` (falls back to `<data_dir>/api.sock` when XDG is unset/empty).
- **macOS**: `$TMPDIR/endara-relay-<uid>-<suffix>/api.sock`.
- **Windows**: unchanged (`\\.\pipe\endara-relay-<sessionid>`).
- `ENDARA_API_SOCKET` still wins over everything.
- Each `cfg` branch is now a single tail expression — the `unreachable_code` warning at `src/api_proxy.rs:64` is gone, and the `#[allow(clippy::needless_return)]` / `#[allow(unused_variables)]` attributes are no longer needed.

**Tests added** (under `#[cfg(test)] mod tests` in `api_proxy.rs`)
- `resolve_api_socket_path_honors_env_var` — `ENDARA_API_SOCKET` override returns the env value verbatim.
- `data_dir_suffix_returns_eight_lowercase_hex_chars` — shape check on the helper.
- `resolve_api_socket_path_macos_differs_per_data_dir` (`#[cfg(target_os = "macos")]`).
- `resolve_api_socket_path_macos_is_deterministic` (`#[cfg(target_os = "macos")]`).
- A `static ENV_LOCK: Mutex<()>` serializes env-touching tests so cargo's default parallel runner cannot race on `ENDARA_API_SOCKET`.

`tempfile = "3.27.0"` added to `[dev-dependencies]`.

### Tauri Rust crate alignment (Wave DT.6)
- Bumped `tauri` 2.10.3 → 2.11.1 and `tauri-plugin-dialog` 2.6.0 → 2.7.1 in `src-tauri/Cargo.{toml,lock}` so Tauri's preflight major/minor check passes against the NPM packages already on `@tauri-apps/api` 2.11.x / `@tauri-apps/plugin-dialog` 2.7.x. Pure version alignment — no behavior change. All three checks remain green (`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` — 30 passed).

## Compatibility / migration

Old prod relays (pre-rc.2) and new prod relays (rc.2) compute different socket paths. After upgrading, the legacy socket file is orphaned at the old path; relay's existing `cleanup_stale_unix_socket` removes it on next bind, and `$TMPDIR` reapers sweep it otherwise. `ENDARA_API_SOCKET` remains the escape hatch for any test or external integration that needs to pin a specific path.

## Lockstep with relay

This PR must land **with relay PR #59**. The two crates share the `data_dir_suffix` / `resolve_api_socket_path` algorithm; if only one merges, dev/prod still collide (or the desktop bridge can't find the relay's socket). The PHASE2-V verifier wave already diffed the two implementations and confirmed they match.

## Verification

```
cd packages/desktop && pnpm check      # passes (0 errors / 0 warnings)
cd packages/desktop && pnpm test       # 268 passed, 24 skipped
cd packages/desktop/src-tauri && cargo fmt --check    # clean
cd packages/desktop/src-tauri && cargo clippy --all-targets -- -D warnings    # clean (no unreachable_code warning)
cd packages/desktop/src-tauri && cargo test --lib    # 30 passed (incl. 4 api_proxy tests + 3 server_type_override round-trip tests)
```

## Scope

Desktop-only. No changes to relay or monorepo in this PR.

## Phase / Wave

Phase 2 / Waves DT.1 + DT.4 + DT.6, consolidated by Wave DT.5.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author.