### PR TITLE
fix(api-proxy): per-data-dir socket path + drop unreachable_code warning

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1108,6 +1108,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-shell",
  "tauri-plugin-updater",
+ "tempfile",
  "tokio",
  "toml 0.8.2",
  "urlencoding",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,4 +45,5 @@ libc = "0.2.184"
 
 [dev-dependencies]
 serial_test = "3.4.0"
+tempfile = "3.27.0"
 

--- a/src-tauri/src/api_proxy.rs
+++ b/src-tauri/src/api_proxy.rs
@@ -6,7 +6,12 @@
 //! provides a `mgmt_api_request` Tauri command that proxies HTTP requests from
 //! the SvelteKit UI to the relay's local socket.
 //!
-//! Path resolution mirrors `endara_relay::management_listener::resolve_api_socket_path`.
+//! Path resolution mirrors `endara_relay::management_listener::resolve_api_socket_path`
+//! — see that module for details. On macOS / Linux the socket path includes an
+//! 8-char hex hash of the canonicalized `data_dir` so a dev build
+//! (`~/.endara-dev`) and an installed prod build (`~/.endara`) can run side by
+//! side without colliding on the same path. Windows is unchanged — the pipe
+//! name is already keyed on the user/session.
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -27,41 +32,75 @@ pub struct ApiResponse {
 
 /// Resolve the management-API socket / pipe path. Mirrors the relay's
 /// resolution so the two processes pick the same path without coordinating.
-#[allow(clippy::needless_return)]
-pub fn resolve_api_socket_path(#[allow(unused_variables)] data_dir: &Path) -> PathBuf {
+pub fn resolve_api_socket_path(data_dir: &Path) -> PathBuf {
     if let Ok(path) = std::env::var("ENDARA_API_SOCKET") {
         return PathBuf::from(path);
     }
 
     #[cfg(target_os = "linux")]
     {
+        let suffix = data_dir_suffix(data_dir);
         if let Ok(xdg) = std::env::var("XDG_RUNTIME_DIR") {
             let runtime = PathBuf::from(xdg);
             if !runtime.as_os_str().is_empty() {
-                return runtime.join("endara-relay").join("api.sock");
+                return runtime
+                    .join(format!("endara-relay-{suffix}"))
+                    .join("api.sock");
             }
         }
+        data_dir.join("api.sock")
     }
 
     #[cfg(target_os = "macos")]
     {
+        let suffix = data_dir_suffix(data_dir);
         let tmp = std::env::var("TMPDIR")
             .map(PathBuf::from)
             .unwrap_or_else(|_| PathBuf::from("/tmp"));
         let uid = unsafe { geteuid_u32() };
-        return tmp.join(format!("endara-relay-{uid}")).join("api.sock");
+        tmp.join(format!("endara-relay-{uid}-{suffix}"))
+            .join("api.sock")
     }
 
     #[cfg(windows)]
     {
         let session_id = current_user_pipe_suffix(data_dir);
-        return PathBuf::from(format!(r"\\.\pipe\endara-relay-{session_id}"));
+        PathBuf::from(format!(r"\\.\pipe\endara-relay-{session_id}"))
     }
 
-    // Final fallback — reached on Linux when XDG_RUNTIME_DIR is unset, and on
-    // any platform not covered by the cfg branches above. macOS / Windows
-    // branches above always early-return, so they never fall through here.
-    data_dir.join("api.sock")
+    // Final fallback for any other target (e.g. non-macOS unix variants not
+    // covered above). The platform-specific branches above are all single tail
+    // expressions, so this is only compiled where it can actually be reached.
+    #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+    {
+        data_dir.join("api.sock")
+    }
+}
+
+/// Stable 8-char lowercase hex hash of `data_dir`.
+///
+/// Used as a suffix on macOS / Linux socket paths so that two relay processes
+/// running under the same `uid` / `$XDG_RUNTIME_DIR` (e.g. an installed prod
+/// build and a `pnpm tauri dev` instance) get distinct paths.
+///
+/// Lockstep contract with `packages/relay/src/management_listener.rs`'s copy
+/// of this helper: both crates MUST produce the same 8 hex chars for the same
+/// canonicalized path. Keep the algorithm byte-for-byte identical:
+/// 1. `Path::canonicalize` the input; on error, hash the input path as-is.
+/// 2. Hash with `std::collections::hash_map::DefaultHasher`.
+/// 3. Format the resulting `u64` as `format!("{:016x}", hash)`, then take the
+///    first 8 chars. (NOT `format!("{:08x}", hash as u32)` — that's a
+///    different value.)
+#[cfg_attr(windows, allow(dead_code))]
+fn data_dir_suffix(data_dir: &Path) -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let canonical = data_dir.canonicalize().unwrap_or_else(|_| data_dir.into());
+    let mut h = DefaultHasher::new();
+    canonical.hash(&mut h);
+    let full = format!("{:016x}", h.finish());
+    full[..8].to_string()
 }
 
 #[cfg(unix)]
@@ -184,4 +223,65 @@ async fn connect(
 #[cfg(not(any(unix, windows)))]
 async fn connect(_path: &Path) -> Result<TokioIo<tokio::net::TcpStream>, String> {
     Err("management API bridge is unsupported on this platform".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Serializes env-mutating tests in this module. Cargo runs tests in the
+    // same binary in parallel by default; without this, setting/removing
+    // `ENDARA_API_SOCKET` could race between tests sharing the process-wide
+    // env.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn resolve_api_socket_path_honors_env_var() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("ENDARA_API_SOCKET", "/tmp/endara-desktop-test.sock");
+        let p = resolve_api_socket_path(Path::new("/tmp"));
+        assert_eq!(p, PathBuf::from("/tmp/endara-desktop-test.sock"));
+        std::env::remove_var("ENDARA_API_SOCKET");
+    }
+
+    #[test]
+    fn data_dir_suffix_returns_eight_lowercase_hex_chars() {
+        let dir = tempfile::tempdir().unwrap();
+        let s = data_dir_suffix(dir.path());
+        assert_eq!(s.len(), 8, "expected 8 chars, got {s:?}");
+        assert!(
+            s.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f')),
+            "expected lowercase hex, got {s:?}"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn resolve_api_socket_path_macos_differs_per_data_dir() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("ENDARA_API_SOCKET");
+        let a = tempfile::tempdir().unwrap();
+        let b = tempfile::tempdir().unwrap();
+        let pa = resolve_api_socket_path(a.path());
+        let pb = resolve_api_socket_path(b.path());
+        assert_ne!(
+            pa, pb,
+            "different data_dirs should produce different socket paths"
+        );
+        let parent_a = pa.parent().unwrap().file_name().unwrap().to_string_lossy();
+        let parent_b = pb.parent().unwrap().file_name().unwrap().to_string_lossy();
+        assert!(parent_a.starts_with("endara-relay-"));
+        assert!(parent_b.starts_with("endara-relay-"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn resolve_api_socket_path_macos_is_deterministic() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("ENDARA_API_SOCKET");
+        let dir = tempfile::tempdir().unwrap();
+        let p1 = resolve_api_socket_path(dir.path());
+        let p2 = resolve_api_socket_path(dir.path());
+        assert_eq!(p1, p2, "same data_dir should produce the same path");
+    }
 }


### PR DESCRIPTION
## What

Mirrors **endara-ai/endara-relay#59** (Wave RF.4) on the desktop side. `resolve_api_socket_path` in `src-tauri/src/api_proxy.rs` now incorporates a stable hash of the canonicalized `data_dir` into the macOS / Linux socket path so a dev build (`~/.endara-dev`) and an installed prod build (`~/.endara`) running under the same uid / `$XDG_RUNTIME_DIR` no longer collide on the same Unix-domain socket.

Before: every desktop build under the same uid resolved to `$TMPDIR/endara-relay-<uid>/api.sock` (macOS) or `$XDG_RUNTIME_DIR/endara-relay/api.sock` (Linux). The first-to-bind won and the other would fail.

After:
- **Linux**: `$XDG_RUNTIME_DIR/endara-relay-<suffix>/api.sock` (falls back to `<data_dir>/api.sock` when XDG is unset/empty).
- **macOS**: `$TMPDIR/endara-relay-<uid>-<suffix>/api.sock`.
- **Windows**: unchanged (`\\.\pipe\endara-relay-<sessionid>`).

`<suffix>` is the first 8 chars of `format!("{:016x}", DefaultHasher hash of canonicalized data_dir)`. Same algorithm as the relay's `data_dir_suffix` helper — copied **verbatim** from `packages/relay/src/management_listener.rs` on branch `panghy/socket-path-data-dir` so the two crates produce byte-identical paths for any given input. `ENDARA_API_SOCKET` still wins over everything (existing test pins that).

## Lockstep with relay

This PR and **endara-ai/endara-relay#59** MUST land in the same release. They share the path-resolution algorithm; if only one merges, dev/prod still collide (or the desktop bridge can't find the relay's socket). The PHASE2-V verifier wave will diff the two `data_dir_suffix` implementations before either merges.

## Bonus: drops a long-standing warning

The pre-change `resolve_api_socket_path` body left a function-level `data_dir.join("api.sock")` tail expression as the Linux-fallback path. On macOS / Windows that tail was unreachable, which produced the existing `unreachable_code` warning:

```
warning: unreachable expression
  --> src/api_proxy.rs:64:5
```

The restructuring required for the suffix change makes each `cfg` block a single tail expression and moves the truly-platform-agnostic fallback under `#[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]`. The warning is gone and the two `#[allow(...)]` attributes on the function (`clippy::needless_return`, `unused_variables`) are no longer needed.

## Tests added

Under `#[cfg(test)] mod tests` in `api_proxy.rs`:

- `resolve_api_socket_path_honors_env_var` — `ENDARA_API_SOCKET` override returns the env value verbatim.
- `data_dir_suffix_returns_eight_lowercase_hex_chars` — shape check on the helper.
- `resolve_api_socket_path_macos_differs_per_data_dir` (`#[cfg(target_os = "macos")]`) — distinct data_dirs produce distinct paths.
- `resolve_api_socket_path_macos_is_deterministic` (`#[cfg(target_os = "macos")]`) — same data_dir produces the same path.

A `static ENV_LOCK: Mutex<()>` serializes the env-touching tests so cargo's default parallel runner cannot race on `ENDARA_API_SOCKET`.

`tempfile = "3.27.0"` added to `[dev-dependencies]` (via `cargo add --dev tempfile`).

## Tauri command

`get_mgmt_api_socket_path` is unchanged — it just forwards into `resolve_api_socket_path`. Free pass.

## Verification (macOS, local)

```bash
cd packages/desktop/src-tauri
cargo fmt --check                              # clean
cargo build                                    # clean, no unreachable_code warning
cargo clippy --all-targets -- -D warnings     # clean
cargo test --lib                               # 27/27 passing
cargo test --lib api_proxy::                   # 4/4 passing
```

## Compatibility

Old prod relays (pre-rc.2) and new prod relays (rc.2) compute different socket paths. After upgrading, the legacy socket file at the old path is orphaned; the relay's existing `cleanup_stale_unix_socket` removes it on next bind, and `$TMPDIR` reapers sweep it otherwise. `ENDARA_API_SOCKET` remains the escape hatch for any test or external integration that needs to pin a specific path.

## Out of scope

- Any UI / `packages/desktop/src/` (Svelte) change.
- Monorepo or relay changes.
- Other socket-path consumers — `resolve_api_socket_path` is the only path-resolution helper in the desktop crate.

**Do NOT merge** until the matching relay PR (#59) is ready — the verifier wave will diff the two implementations to confirm they match before either merges.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author.