### PR TITLE
chore(deps): bump @tauri-apps NPM packages to match Rust crate majors/minors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@endara/desktop",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@endara/desktop",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
-        "@tauri-apps/api": "^2",
+        "@tauri-apps/api": "^2.11.0",
         "@tauri-apps/plugin-autostart": "^2.5.1",
-        "@tauri-apps/plugin-dialog": "^2.6.0",
+        "@tauri-apps/plugin-dialog": "^2.7.1",
         "@tauri-apps/plugin-notification": "^2.3.3",
         "@tauri-apps/plugin-opener": "^2",
         "@tauri-apps/plugin-process": "^2.3.1",
@@ -1266,9 +1266,9 @@
       }
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
-      "integrity": "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.0.tgz",
+      "integrity": "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -1502,12 +1502,12 @@
       }
     },
     "node_modules/@tauri-apps/plugin-dialog": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.6.0.tgz",
-      "integrity": "sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz",
+      "integrity": "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@tauri-apps/api": "^2.8.0"
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@tauri-apps/plugin-notification": {

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@tauri-apps/api": "^2",
+    "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-autostart": "^2.5.1",
-    "@tauri-apps/plugin-dialog": "^2.6.0",
+    "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-process": "^2.3.1",


### PR DESCRIPTION
## Summary

Bumps the JS-side `@tauri-apps/*` packages so their majors/minors match the Rust crate versions resolved by `cargo tree` on `main`. This unblocks the desktop release workflow's preflight check, which started failing during the `v0.1.6-rc.2` cycle:

- Failing run: https://github.com/endara-ai/endara-desktop/actions/runs/25807535824

## Version alignment (NPM → Rust crate)

| Package | Before | After (resolved) | Rust crate (`cargo tree`) |
| --- | --- | --- | --- |
| `@tauri-apps/api` | `^2` (2.10.1) | `^2.11.0` (2.11.0) | `tauri` 2.11.1 |
| `@tauri-apps/plugin-dialog` | `^2.6.0` (2.6.0) | `^2.7.1` (2.7.1) | `tauri-plugin-dialog` 2.7.1 |

All other `@tauri-apps/plugin-*` pairs were verified and already match their Rust counterparts (autostart 2.5.1, notification 2.3.3, opener 2.5.3, process 2.3.1, shell 2.3.5, updater 2.10.0), so they are intentionally left alone.

## How it was done

Used the package manager (npm) — no manual edits to `package.json` beyond what `npm install` wrote:

```
npm install @tauri-apps/api@^2.11 @tauri-apps/plugin-dialog@^2.7
```

`npm install` also auto-synced the `version` field in `package-lock.json` from `0.1.5` → `0.1.6` to match the already-bumped `package.json` (a leftover from the prior release-bump PR). That's the only additional change in the lockfile.

## Verification

All local checks pass on this branch:

- `npm run check` → `svelte-check found 0 errors and 0 warnings`
- `npm test` → `Test Files 16 passed (16)` / `Tests 268 passed | 24 skipped`
- `cd src-tauri && cargo fmt --check` → clean
- `cd src-tauri && cargo clippy --all-targets -- -D warnings` → clean
- `cd src-tauri && cargo test --lib` → `30 passed; 0 failed`

## Scope

- Only `package.json` and `package-lock.json` are touched.
- No Rust changes, no version bumps to the base version, no monorepo or relay changes.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author