### PR TITLE
ci(release): pin x86_64-apple-darwin to macos-13 (macos-latest is now arm64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: macos-latest
+          - platform: macos-13
             target: x86_64-apple-darwin
             relay_target: x86_64-apple-darwin
           - platform: macos-latest


### PR DESCRIPTION
GitHub-hosted `macos-latest` flipped to arm64 runners, which broke the intel mac build path on the desktop release workflow the same way it broke the relay side. The `aarch64-apple-darwin` matrix row stays on `macos-latest` (now arm64-native, which is what we want for that target).

**Diff:** single line — `platform: macos-latest` → `platform: macos-13` for the `x86_64-apple-darwin` matrix row only.

**Companion relay PR:** https://github.com/endara-ai/endara-relay/pull/60

**Failing relay run for context:** https://github.com/endara-ai/endara-relay/actions/runs/25837802327

The desktop release workflow downloads the relay sidecar from the matching `endara-ai/endara-relay` GitHub Release, so the desktop side only needs the runner-pin fix; once relay rc.4 publishes successfully, the desktop x86_64 job will pick it up and bundle it.

Do NOT merge yet — coordinated with the relay companion PR.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author