### PR TITLE
ci(release): drop x86_64-apple-darwin (Apple Silicon only for macOS)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,9 +57,6 @@ jobs:
       matrix:
         include:
           - platform: macos-latest
-            target: x86_64-apple-darwin
-            relay_target: x86_64-apple-darwin
-          - platform: macos-latest
             target: aarch64-apple-darwin
             relay_target: aarch64-apple-darwin
           - platform: windows-latest


### PR DESCRIPTION
Stop shipping `x86_64-apple-darwin` builds. Only Apple Silicon for macOS going forward. Linux x86_64 and Windows x86_64 are unaffected.

This sidesteps the broken `rustup-init` toolchain bootstrap on the new arm64 `macos-latest` runners (which burned `v0.1.6-rc.2` and `v0.1.6-rc.3`) without taking on a `macos-13` pin that GitHub will eventually deprecate.

**Diff:** workflow-only — removes the `x86_64-apple-darwin` matrix include block from `.github/workflows/release.yml`. The `aarch64-apple-darwin` row is unchanged.

**Supersedes #77** (the macos-13 pin attempt — closed without merging).

**Companion relay PR:** Wave CI.2.relay (branch `panghy/release-drop-intel-darwin` on `endara-ai/endara-relay`) — opening alongside this one.

No functional change to the app — just one fewer build target.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author