### PR TITLE
ci(release): pin aarch64-apple-darwin to macos-14 (macos-latest broken)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: macos-latest
+          # pinned to macos-14 — macos-latest (macos-15) ships a rustup-init shim that breaks 'cargo build' in tauri-action's bundle path; companion to relay PR for the same fix. See burned tags v0.1.6-rc.{2,3,4}.
+          - platform: macos-14
             target: aarch64-apple-darwin
             relay_target: aarch64-apple-darwin
           - platform: windows-latest


### PR DESCRIPTION
## Summary

Pin the macOS leg of the desktop release matrix from `macos-latest` to `macos-14` so the Tauri build can resolve `cargo` correctly during signing/bundling.

## Why

`macos-latest` recently rolled forward to `macos-15`, which ships a `rustup-init` shim ahead of the toolchain `cargo` on the runner `PATH`. `tauri-action` invokes `cargo build` during its bundle path, and that shim breaks the build with a cargo resolution failure during signing/bundling.

We burned several rcs trying to ship v0.1.6 through `macos-latest`:

- `v0.1.6-rc.2`
- `v0.1.6-rc.3`
- `v0.1.6-rc.4`

All three desktop release runs failed in the same way on the macOS leg. The relay side hit the same class of failure on its own release workflow — see the failing relay run: https://github.com/endara-ai/endara-relay/actions/runs/25841684545

## Fix

Pin the matrix entry for `aarch64-apple-darwin` to `macos-14` (the previous `macos-latest` image, which still has a working stable Rust toolchain on `PATH`). A YAML comment above the matrix entry explains the reasoning and references the burned rc tags.

This is a **temporary pin (Option A)**. Once GitHub's `macos-latest` image stabilizes — or once we drop the rustup-init shim from PATH ourselves in the workflow — we can revert back to `macos-latest`.

## Companion

There is a parallel relay-side change on branch `panghy/release-pin-macos-14` in `endara-ai/endara-relay` that applies the same pin to relay's macOS release leg. Both must land before re-cutting `v0.1.6-rc.5`.

## Scope

- `.github/workflows/release.yml` only — 1 file changed, 2 insertions, 1 deletion.
- No changes to `tauri.conf.json`, `Cargo.toml`, `src-tauri`, or anywhere else.

## Verification

- `git diff --stat` confirms workflow-only diff.
- Real verification happens when REL4 tags `v0.1.6-rc.5` after this and the companion relay PR merge.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author