### PR TITLE
fix: add get_js_execution_mode and harden set_js_execution_mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,8 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          - os: macos-latest
+          # pinned to macos-14 — macos-latest (macos-15) ships a rustup-init shim that breaks 'cargo' (companion to release.yml fix in #79).
+          - os: macos-14
             target: aarch64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,7 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          # pinned to macos-14 — macos-latest (macos-15) ships a rustup-init shim that breaks 'cargo' (companion to release.yml fix in #79).
-          - os: macos-14
+          - os: macos-latest
             target: aarch64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -207,6 +207,22 @@ fn read_update_channel() -> String {
         .unwrap_or_else(|| "stable".to_string())
 }
 
+/// Read `relay.local_js_execution` from `~/.endara/config.toml`.
+/// Returns `false` on any error, missing section, or missing key, mirroring
+/// `read_update_channel` so the UI gets a deterministic default during cold
+/// start (when the config may not yet have a `[relay]` section).
+fn read_js_execution_mode() -> bool {
+    let Ok(parsed) = read_config() else {
+        return false;
+    };
+    parsed
+        .get("relay")
+        .and_then(|v| v.as_table())
+        .and_then(|t| t.get("local_js_execution"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
 /// Holds the relay sidecar child process handle.
 pub struct RelayState {
     child: Arc<Mutex<Option<tauri_plugin_shell::process::CommandChild>>>,
@@ -940,19 +956,42 @@ async fn set_relay_port(port: u16, state: State<'_, RelayState>) -> Result<(), S
     write_config(&table)
 }
 
+/// Get whether local JS execution is enabled in the relay config.
+/// Returns `false` if the config is missing, malformed, or has no `[relay]` section.
+#[tauri::command]
+async fn get_js_execution_mode() -> Result<bool, String> {
+    Ok(read_js_execution_mode())
+}
+
 #[tauri::command]
 async fn set_js_execution_mode(enabled: bool) -> Result<(), String> {
-    let mut table = read_config()?;
+    let mut table = read_config().unwrap_or_else(|_| toml::Table::new());
 
-    // Set local_js_execution in the [relay] section
-    if let Some(relay) = table.get_mut("relay").and_then(|v| v.as_table_mut()) {
-        relay.insert(
-            "local_js_execution".to_string(),
-            toml::Value::Boolean(enabled),
-        );
-    } else {
-        return Err("Missing [relay] section in config".to_string());
-    }
+    // Ensure [relay] section exists. The relay's `RelayConfig` requires
+    // `machine_name`, so populate it from the system hostname when creating
+    // the section from scratch — otherwise the relay's next config reload
+    // would fail to deserialize.
+    let relay = table
+        .entry("relay")
+        .or_insert_with(|| {
+            let mut t = toml::Table::new();
+            let machine_name = hostname::get()
+                .ok()
+                .and_then(|h| h.into_string().ok())
+                .unwrap_or_else(|| "unknown".to_string());
+            t.insert(
+                "machine_name".to_string(),
+                toml::Value::String(machine_name),
+            );
+            toml::Value::Table(t)
+        })
+        .as_table_mut()
+        .ok_or("Invalid [relay] section in config")?;
+
+    relay.insert(
+        "local_js_execution".to_string(),
+        toml::Value::Boolean(enabled),
+    );
 
     write_config(&table)
 }
@@ -1824,6 +1863,7 @@ pub fn run() {
             set_relay_port,
             mgmt_api_request,
             get_mgmt_api_socket_path,
+            get_js_execution_mode,
             set_js_execution_mode,
             get_config_path_display,
             get_buffered_relay_logs,
@@ -2500,5 +2540,229 @@ mod server_type_override_tests {
             .block_on(get_endpoint_config("drive".to_string()))
             .expect("read after clear");
         assert!(cfg.server_type_override.is_none());
+    }
+}
+
+#[cfg(test)]
+mod js_execution_mode_tests {
+    //! Round-trip coverage for `read_js_execution_mode` and
+    //! `set_js_execution_mode`. Each test pins `$HOME` to a fresh
+    //! `tempfile::TempDir` so the Tauri commands write into an isolated
+    //! `~/.endara-dev/config.toml`. Tests are `serial` because env-var
+    //! manipulation is process-global.
+    use super::*;
+    use serial_test::serial;
+    use tempfile::TempDir;
+
+    /// Snapshots `$HOME` on construction and restores it on drop so tests
+    /// cannot leak the override into each other even on panic.
+    struct HomeGuard {
+        prior: Option<String>,
+        _tmp: TempDir,
+    }
+
+    impl HomeGuard {
+        fn new() -> Self {
+            let prior = std::env::var("HOME").ok();
+            let tmp = tempfile::tempdir().expect("create tempdir");
+            std::env::set_var("HOME", tmp.path());
+            Self { prior, _tmp: tmp }
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            match &self.prior {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+    }
+
+    fn rt() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build tokio runtime")
+    }
+
+    fn write_config_str(contents: &str) {
+        let path = config_path().expect("config_path");
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent dir");
+        }
+        std::fs::write(&path, contents).expect("write config.toml");
+    }
+
+    fn read_config_str() -> String {
+        let path = config_path().expect("config_path");
+        std::fs::read_to_string(&path).expect("read config.toml")
+    }
+
+    #[test]
+    #[serial]
+    fn get_js_execution_mode_returns_true_when_set() {
+        let _home = HomeGuard::new();
+        write_config_str("[relay]\nlocal_js_execution = true\nmachine_name = \"x\"\n");
+        assert!(read_js_execution_mode());
+    }
+
+    #[test]
+    #[serial]
+    fn get_js_execution_mode_returns_false_when_unset() {
+        let _home = HomeGuard::new();
+        write_config_str("[relay]\nmachine_name = \"x\"\n");
+        assert!(!read_js_execution_mode());
+    }
+
+    #[test]
+    #[serial]
+    fn get_js_execution_mode_returns_false_when_no_relay_section() {
+        let _home = HomeGuard::new();
+        write_config_str("[desktop]\nupdate_channel = \"stable\"\n");
+        assert!(!read_js_execution_mode());
+    }
+
+    #[test]
+    #[serial]
+    fn get_js_execution_mode_returns_false_when_file_missing() {
+        let _home = HomeGuard::new();
+        // No config.toml written.
+        assert!(!read_js_execution_mode());
+    }
+
+    #[test]
+    #[serial]
+    fn get_js_execution_mode_returns_false_when_file_malformed() {
+        let _home = HomeGuard::new();
+        write_config_str("not valid toml ====\n");
+        assert!(!read_js_execution_mode());
+    }
+
+    #[test]
+    #[serial]
+    fn set_js_execution_mode_roundtrips() {
+        let _home = HomeGuard::new();
+        let rt = rt();
+        write_config_str("[relay]\nmachine_name = \"x\"\n");
+
+        rt.block_on(set_js_execution_mode(true)).expect("set true");
+        assert!(read_js_execution_mode());
+
+        rt.block_on(set_js_execution_mode(false))
+            .expect("set false");
+        assert!(!read_js_execution_mode());
+    }
+
+    #[test]
+    #[serial]
+    fn set_js_execution_mode_creates_missing_relay_section() {
+        let _home = HomeGuard::new();
+        let rt = rt();
+        write_config_str("[desktop]\nupdate_channel = \"stable\"\n");
+
+        rt.block_on(set_js_execution_mode(true))
+            .expect("set_js_execution_mode should succeed");
+
+        let toml_str = read_config_str();
+        let parsed: toml::Table =
+            toml::from_str(&toml_str).expect("re-parse config.toml as toml::Table");
+
+        let relay = parsed
+            .get("relay")
+            .and_then(|v| v.as_table())
+            .expect("[relay] section should exist");
+        assert_eq!(
+            relay.get("local_js_execution").and_then(|v| v.as_bool()),
+            Some(true),
+            "local_js_execution should be true"
+        );
+        let machine_name = relay
+            .get("machine_name")
+            .and_then(|v| v.as_str())
+            .expect("machine_name should be set");
+        assert!(
+            !machine_name.is_empty(),
+            "machine_name should be non-empty, got {machine_name:?}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn set_js_execution_mode_preserves_other_fields() {
+        let _home = HomeGuard::new();
+        let rt = rt();
+        write_config_str(
+            "[desktop]\n\
+             update_channel = \"beta\"\n\
+             \n\
+             [relay]\n\
+             machine_name = \"host\"\n\
+             token_dir = \"/tmp/x\"\n\
+             \n\
+             [[endpoints]]\n\
+             name = \"gmail-acct\"\n\
+             transport = \"stdio\"\n\
+             tool_prefix = \"gmail\"\n\
+             command = \"echo\"\n\
+             args = [\"hi\"]\n",
+        );
+
+        rt.block_on(set_js_execution_mode(true))
+            .expect("set_js_execution_mode should succeed");
+
+        let toml_str = read_config_str();
+        let parsed: toml::Table =
+            toml::from_str(&toml_str).expect("re-parse config.toml as toml::Table");
+
+        let desktop = parsed
+            .get("desktop")
+            .and_then(|v| v.as_table())
+            .expect("[desktop] preserved");
+        assert_eq!(
+            desktop.get("update_channel").and_then(|v| v.as_str()),
+            Some("beta"),
+            "update_channel should be preserved"
+        );
+
+        let relay = parsed
+            .get("relay")
+            .and_then(|v| v.as_table())
+            .expect("[relay] preserved");
+        assert_eq!(
+            relay.get("machine_name").and_then(|v| v.as_str()),
+            Some("host"),
+            "machine_name should be preserved"
+        );
+        assert_eq!(
+            relay.get("token_dir").and_then(|v| v.as_str()),
+            Some("/tmp/x"),
+            "token_dir should be preserved"
+        );
+        assert_eq!(
+            relay.get("local_js_execution").and_then(|v| v.as_bool()),
+            Some(true),
+            "local_js_execution should be set to true"
+        );
+
+        let endpoints = parsed
+            .get("endpoints")
+            .and_then(|v| v.as_array())
+            .expect("[[endpoints]] preserved");
+        assert_eq!(endpoints.len(), 1, "endpoint count should be unchanged");
+        let ep = endpoints[0].as_table().expect("endpoint is a table");
+        assert_eq!(ep.get("name").and_then(|v| v.as_str()), Some("gmail-acct"));
+        assert_eq!(ep.get("transport").and_then(|v| v.as_str()), Some("stdio"));
+        assert_eq!(
+            ep.get("tool_prefix").and_then(|v| v.as_str()),
+            Some("gmail")
+        );
+        assert_eq!(ep.get("command").and_then(|v| v.as_str()), Some("echo"));
+        let args = ep
+            .get("args")
+            .and_then(|v| v.as_array())
+            .expect("args preserved");
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0].as_str(), Some("hi"));
     }
 }


### PR DESCRIPTION
## Summary

Adds a Tauri command + read helper for the JS execution mode and hardens the writer so it works on cold-start configs that don't yet have a `[relay]` section.

### Changes in `src-tauri/src/lib.rs`

1. **`read_js_execution_mode() -> bool`** — private helper that reads `~/.endara/config.toml` and returns `relay.local_js_execution`, defaulting to `false` on any error or missing key. Mirrors `read_update_channel`.
2. **`#[tauri::command] async fn get_js_execution_mode() -> Result<bool, String>`** — registered in `invoke_handler!` next to `set_js_execution_mode`.
3. **`set_js_execution_mode` hardened** — now creates the `[relay]` section if missing (mirrors `set_update_channel`'s `entry().or_insert_with()` pattern). When creating the table from scratch it populates `machine_name` from the system hostname (via the already-present `hostname` crate) with an `"unknown"` fallback, so the relay's `RelayConfig` deserialization keeps working on its next reload. Previously it errored with `"Missing [relay] section in config"` on any config without a `[relay]` table.

### Tests

New `js_execution_mode_tests` module with 8 unit tests, all using the existing `HomeGuard` (tempdir + `$HOME` override) + `serial_test` pattern from `server_type_override_tests`:

- `get_js_execution_mode_returns_true_when_set`
- `get_js_execution_mode_returns_false_when_unset`
- `get_js_execution_mode_returns_false_when_no_relay_section`
- `get_js_execution_mode_returns_false_when_file_missing`
- `get_js_execution_mode_returns_false_when_file_malformed`
- `set_js_execution_mode_roundtrips`
- `set_js_execution_mode_creates_missing_relay_section`
- `set_js_execution_mode_preserves_other_fields`

### Verification

```
cd packages/desktop/src-tauri
cargo fmt --check  # passes
cargo build        # passes
cargo test         # 38 passed; 0 failed (8 new)
```

### Out of scope (deliberately)

- No UI changes (`packages/desktop/src/**` untouched) — that's a follow-up task.
- No relay changes (`packages/relay` untouched).

### Notes / deviations

- The task note's reference to using `ENDARA_DATA_DIR` to point at a tempdir is slightly inaccurate against the current code: `data_dir()` only treats `ENDARA_DATA_DIR` as a dev-mode flag, not a path override (the actual base dir is always `dirs::home_dir().join(".endara-dev")` in dev mode). The new tests therefore use the existing `HomeGuard` pattern (override `$HOME` to a `tempfile::TempDir`) used by `server_type_override_tests` — same isolation guarantees, same `serial_test` discipline.
- The `hostname` crate was already in `Cargo.toml` and used elsewhere in `lib.rs`, so no new dependency was added.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author