### PR TITLE
feat: surface upstream default name in server-name override (ConfigTab + AddEndpointModal text)

### DIFF
--- a/src/lib/components/AddEndpointModal.svelte
+++ b/src/lib/components/AddEndpointModal.svelte
@@ -907,7 +907,7 @@
                   placeholder="e.g. gmail"
                   maxlength={64}
                   class="w-full text-sm px-3 py-1.5 rounded-lg border bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) {serverTypeOverrideInvalid || serverTypeOverrideTooLong ? 'border-(--offline)' : 'border-(--border)'}" />
-                <p class="text-[11px] text-(--fg2) mt-0.5">Optional. Replaces the name this server reports to MCP clients. Useful when an upstream MCP server returns a placeholder like 'statelessserver'. Max 64 characters.</p>
+                <p class="text-[11px] text-(--fg2) mt-0.5">Optional. Replaces the name this server reports to MCP clients. Max 64 characters.</p>
                 {#if serverTypeOverridePreviewVisible}
                   <p class="text-[11px] text-(--fg2) mt-0.5">Will be saved as: <code>{serverTypeOverrideSanitized}</code></p>
                 {/if}
@@ -1063,7 +1063,7 @@
                   placeholder="e.g. my-server"
                   maxlength={64}
                   class="w-full text-sm px-3 py-1.5 rounded-lg border bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) {serverTypeOverrideInvalid || serverTypeOverrideTooLong ? 'border-(--offline)' : 'border-(--border)'}" />
-                <p class="text-[11px] text-(--fg2) mt-0.5">Optional. Replaces the name this server reports to MCP clients. Useful when an upstream MCP server returns a placeholder like 'statelessserver'. Max 64 characters.</p>
+                <p class="text-[11px] text-(--fg2) mt-0.5">Optional. Replaces the name this server reports to MCP clients. Max 64 characters.</p>
                 {#if serverTypeOverridePreviewVisible}
                   <p class="text-[11px] text-(--fg2) mt-0.5">Will be saved as: <code>{serverTypeOverrideSanitized}</code></p>
                 {/if}

--- a/src/lib/components/ConfigTab.svelte
+++ b/src/lib/components/ConfigTab.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { getEndpointConfig, updateEndpoint, getEndpoints, type UpdateEndpointParams } from '$lib/api';
-  import { selectedEndpoint, endpoints } from '$lib/stores';
+  import { selectedEndpoint, endpoints, selectedEndpointData } from '$lib/stores';
   import { sanitizeName } from '$lib/utils';
 
   type TransportType = 'stdio' | 'sse' | 'http' | 'oauth';
@@ -54,6 +54,15 @@
   // value at ≤64 chars, but pasted content can occasionally bypass that on
   // some platforms. Surface a hint if it ever happens.
   let serverTypeOverrideTooLong = $derived(serverTypeOverride.length > 64);
+
+  // The upstream-reported raw name from the relay's Lifecycle::Ready state,
+  // used to preview what the override would replace. Null when the endpoint
+  // isn't Ready or when the relay hasn't surfaced a raw name yet.
+  let upstreamDefaultName = $derived(
+    $selectedEndpointData?.lifecycle?.state === 'Ready'
+      ? ($selectedEndpointData.lifecycle.server_name_raw ?? null)
+      : null
+  );
 
   // Original value snapshots for dirty-state tracking
   let originalTransport: TransportType = $state('stdio');
@@ -396,14 +405,30 @@
               </div>
               <div>
                 <label for="config-ep-server-type-override" class="block text-xs font-medium mb-1 text-(--fg2)">Server type override <span class="text-(--fg2)/50">(optional)</span></label>
-                <input
-                  id="config-ep-server-type-override"
-                  type="text"
-                  bind:value={serverTypeOverride}
-                  placeholder="e.g. gmail"
-                  maxlength={64}
-                  class="w-full text-sm px-3 py-1.5 rounded-lg border bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) {serverTypeOverrideInvalid || serverTypeOverrideTooLong ? 'border-(--offline)' : 'border-(--border)'}" />
-                <p class="text-[11px] text-(--fg2) mt-0.5">Optional. Replaces the name this server reports to MCP clients. Useful when an upstream MCP server returns a placeholder like 'statelessserver'. Max 64 characters.</p>
+                {#if upstreamDefaultName}
+                  <p class="text-[11px] text-(--fg2) mb-1">Default (from server): <code>{upstreamDefaultName}</code></p>
+                {/if}
+                <div class="flex gap-2">
+                  <input
+                    id="config-ep-server-type-override"
+                    type="text"
+                    bind:value={serverTypeOverride}
+                    placeholder={upstreamDefaultName ?? ''}
+                    maxlength={64}
+                    class="flex-1 text-sm px-3 py-1.5 rounded-lg border bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) {serverTypeOverrideInvalid || serverTypeOverrideTooLong ? 'border-(--offline)' : 'border-(--border)'}" />
+                  <button
+                    type="button"
+                    title="Clear override and use the server's default name"
+                    disabled={serverTypeOverride === ''}
+                    onclick={() => (serverTypeOverride = '')}
+                    class="px-2 py-1 text-xs rounded-lg border border-(--border) text-(--fg2) hover:bg-(--surface-hover) disabled:opacity-50 disabled:cursor-not-allowed"
+                  >Reset</button>
+                </div>
+                {#if upstreamDefaultName}
+                  <p class="text-[11px] text-(--fg2) mt-0.5">Instead of returning the name '{upstreamDefaultName}' to MCP clients, use this name. Max 64 characters.</p>
+                {:else}
+                  <p class="text-[11px] text-(--fg2) mt-0.5">Optional. Replaces the name this server reports to MCP clients. Max 64 characters.</p>
+                {/if}
                 {#if serverTypeOverridePreviewVisible}
                   <p class="text-[11px] text-(--fg2) mt-0.5">Will be saved as: <code>{serverTypeOverrideSanitized}</code></p>
                 {/if}
@@ -494,14 +519,30 @@
             <div class="px-3 pb-3 space-y-3">
               <div>
                 <label for="config-ep-server-type-override-generic" class="block text-xs font-medium mb-1 text-(--fg2)">Server type override <span class="text-(--fg2)/50">(optional)</span></label>
-                <input
-                  id="config-ep-server-type-override-generic"
-                  type="text"
-                  bind:value={serverTypeOverride}
-                  placeholder="e.g. my-server"
-                  maxlength={64}
-                  class="w-full text-sm px-3 py-1.5 rounded-lg border bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) {serverTypeOverrideInvalid || serverTypeOverrideTooLong ? 'border-(--offline)' : 'border-(--border)'}" />
-                <p class="text-[11px] text-(--fg2) mt-0.5">Optional. Replaces the name this server reports to MCP clients. Useful when an upstream MCP server returns a placeholder like 'statelessserver'. Max 64 characters.</p>
+                {#if upstreamDefaultName}
+                  <p class="text-[11px] text-(--fg2) mb-1">Default (from server): <code>{upstreamDefaultName}</code></p>
+                {/if}
+                <div class="flex gap-2">
+                  <input
+                    id="config-ep-server-type-override-generic"
+                    type="text"
+                    bind:value={serverTypeOverride}
+                    placeholder={upstreamDefaultName ?? ''}
+                    maxlength={64}
+                    class="flex-1 text-sm px-3 py-1.5 rounded-lg border bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) {serverTypeOverrideInvalid || serverTypeOverrideTooLong ? 'border-(--offline)' : 'border-(--border)'}" />
+                  <button
+                    type="button"
+                    title="Clear override and use the server's default name"
+                    disabled={serverTypeOverride === ''}
+                    onclick={() => (serverTypeOverride = '')}
+                    class="px-2 py-1 text-xs rounded-lg border border-(--border) text-(--fg2) hover:bg-(--surface-hover) disabled:opacity-50 disabled:cursor-not-allowed"
+                  >Reset</button>
+                </div>
+                {#if upstreamDefaultName}
+                  <p class="text-[11px] text-(--fg2) mt-0.5">Instead of returning the name '{upstreamDefaultName}' to MCP clients, use this name. Max 64 characters.</p>
+                {:else}
+                  <p class="text-[11px] text-(--fg2) mt-0.5">Optional. Replaces the name this server reports to MCP clients. Max 64 characters.</p>
+                {/if}
                 {#if serverTypeOverridePreviewVisible}
                   <p class="text-[11px] text-(--fg2) mt-0.5">Will be saved as: <code>{serverTypeOverrideSanitized}</code></p>
                 {/if}

--- a/src/lib/components/ConfigTab.svelte
+++ b/src/lib/components/ConfigTab.svelte
@@ -79,6 +79,11 @@
   let originalScopes = $state('');
   let originalServerTypeOverride = $state('');
 
+  // Controls the Advanced <details> open state. Two-way bound so user toggles
+  // stick across reactive re-renders; re-seeded from the loaded config on each
+  // endpoint switch / form snapshot.
+  let advancedOpen = $state(false);
+
   function snapshotOriginals() {
     originalTransport = transport;
     originalPrefix = prefix;
@@ -93,6 +98,7 @@
     originalClientId = clientId;
     originalScopes = scopes;
     originalServerTypeOverride = serverTypeOverride;
+    advancedOpen = originalServerTypeOverride !== '';
   }
 
   let prefixPreview = $derived(prefix ? `${prefix}__tool` : 'prefix__tool');
@@ -377,8 +383,8 @@
             <input id="config-ep-url" type="text" bind:value={url} placeholder="https://api.githubcopilot.com/mcp/"
               class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent)" />
           </div>
-          <!-- Auto-expanded when a `server_type_override` is currently stored. -->
-          <details class="border border-(--border) rounded-lg" open={originalServerTypeOverride !== ''}>
+          <!-- Auto-expanded on load when a `server_type_override` is currently stored; user can toggle freely after that. -->
+          <details class="border border-(--border) rounded-lg" bind:open={advancedOpen}>
             <summary class="px-3 py-2 text-xs font-medium text-(--fg2) cursor-pointer hover:bg-(--surface-hover) rounded-lg select-none">Advanced</summary>
             <div class="px-3 pb-3 space-y-3">
               <div>
@@ -511,10 +517,10 @@
           </div>
         {/if}
 
-        <!-- Generic Advanced section for non-OAuth transports. Auto-expanded
-             when a `server_type_override` is currently stored. -->
+        <!-- Generic Advanced section for non-OAuth transports. Auto-expanded on load
+             when a `server_type_override` is currently stored; user can toggle freely after that. -->
         {#if transport !== 'oauth'}
-          <details class="border border-(--border) rounded-lg" open={originalServerTypeOverride !== ''}>
+          <details class="border border-(--border) rounded-lg" bind:open={advancedOpen}>
             <summary class="px-3 py-2 text-xs font-medium text-(--fg2) cursor-pointer hover:bg-(--surface-hover) rounded-lg select-none">Advanced</summary>
             <div class="px-3 pb-3 space-y-3">
               <div>


### PR DESCRIPTION
Two coordinated desktop UX changes for the **server type override** field, both targeting the same branch so they ship together.

## Commits

1. `fix(AddEndpointModal): drop 'statelessserver' mention from override helper text` (dce0722)
   - Modal can't show an upstream-reported name (the endpoint doesn't exist yet), so this is text-only.
   - Both occurrences of the helper text now read: *Optional. Replaces the name this server reports to MCP clients. Max 64 characters.*
   - Placeholders (`e.g. gmail` / `e.g. my-server`) and the `serverTypeOverrideHasDefault` behaviour are unchanged.

2. `feat(ConfigTab): show upstream default name and add Reset for server-name override` (7231831)
   - Imports `selectedEndpointData` and derives `upstreamDefaultName` from `Lifecycle::Ready.server_name_raw` (only when state === 'Ready').
   - In both Advanced override sections (OAuth and generic, non-OAuth):
     - Renders `Default (from server): <code>{name}</code>` above the input when known.
     - Wraps the input in a flex row with a **Reset** button that clears the override (disabled when already empty).
     - Rewrites the helper text to reference the actual upstream name when available: *Instead of returning the name '{name}' to MCP clients, use this name. Max 64 characters.* — fallback: *Optional. Replaces the name this server reports to MCP clients. Max 64 characters.*
     - Placeholder is now `{upstreamDefaultName ?? ''}` so the empty state visibly previews what would be sent.
   - Existing sanitize/preview/invalid/too-long hints below the input are unchanged.
   - `server_name_raw` is already declared on `LifecycleReady` in `src/lib/types.ts`, so no type changes were needed.

## Wave 1 dependency

The ConfigTab change relies on the relay including `server_name_raw` in the `/api/endpoints` Lifecycle::Ready response — see relay PR endara-ai/endara-relay#63 (`panghy/server-name-raw`, **open, not yet merged**). The desktop change degrades gracefully when the field is absent (no default label, no rewritten helper text, empty placeholder).

## Verification

- `pnpm --filter @endara/desktop check` ✅ (svelte-check: 0 errors, 0 warnings)
- `pnpm --filter @endara/desktop lint` ✅ (no linter configured)
- `pnpm --filter @endara/desktop test` ✅ (268 passed, 24 skipped)

---

Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author