### PR TITLE
fix(settings): read js execution mode from tauri to fix cold-start race

### DIFF
--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -2,8 +2,9 @@
   import { theme, jsExecutionMode, relayPort, relayConnected, relaySidecarStatus, relaySidecarError, updateStatus, updateVersion, updateError, updateChannel, lastCheckedChannel } from '$lib/stores';
   import type { Theme, RelayStatus } from '$lib/types';
   import { invoke } from '@tauri-apps/api/core';
-  import { getStatus, getConfig, reloadConfig } from '$lib/api';
+  import { getStatus } from '$lib/api';
   import { canRetryRelay, restartRelay } from '$lib/relaySidecarUi';
+  import { fetchJsExecutionMode, toggleJsExecutionMode } from '$lib/jsExecutionModeUi';
   import { checkAndAutoDownload, restartApp, getUpdateChannel, setUpdateChannel } from '$lib/updater';
   import { onMount, onDestroy } from 'svelte';
   import { toast } from 'svelte-sonner';
@@ -126,19 +127,6 @@
     return `${h}h ${m}m`;
   }
 
-  async function toggleJsExecutionMode() {
-    const newValue = !$jsExecutionMode;
-    jsExecutionMode.set(newValue);
-    try {
-      await invoke('set_js_execution_mode', { enabled: newValue });
-      await reloadConfig();
-    } catch (e) {
-      // Revert on failure
-      jsExecutionMode.set(!newValue);
-      console.error('Failed to set JS execution mode:', e);
-    }
-  }
-
   async function toggleAutoStart() {
     const newValue = !autoStartEnabled;
     autoStartEnabled = newValue;
@@ -155,18 +143,6 @@
       autoStartEnabled = await invoke<boolean>('get_autostart');
     } catch (e) {
       console.error('Failed to get autostart:', e);
-    }
-  }
-
-  async function fetchJsExecutionMode() {
-    try {
-      const config = await getConfig();
-      const relay = config.relay as Record<string, unknown> | undefined;
-      if (relay && typeof relay.local_js_execution === 'boolean') {
-        jsExecutionMode.set(relay.local_js_execution);
-      }
-    } catch {
-      // Relay may not be running yet; leave store at default
     }
   }
 

--- a/src/lib/components/Settings.test.ts
+++ b/src/lib/components/Settings.test.ts
@@ -1,6 +1,18 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+import { invoke } from '@tauri-apps/api/core';
 
 import { canRetryRelay, restartRelay } from '$lib/relaySidecarUi';
+
+// Mock the relay API surface so we can assert the read path doesn't touch
+// `getConfig` and that the write path still calls `reloadConfig`.
+const getConfigMock = vi.fn();
+const reloadConfigMock = vi.fn();
+vi.mock('$lib/api', () => ({
+  getConfig: getConfigMock,
+  reloadConfig: reloadConfigMock,
+  getStatus: vi.fn(),
+}));
 
 describe('Settings relay retry behavior', () => {
   it('shows the retry button when the sidecar failed', () => {
@@ -24,11 +36,113 @@ describe('Settings relay retry behavior', () => {
   });
 
   it('invokes restart_relay when retry is triggered', async () => {
-    const invoke = vi.fn().mockResolvedValue(undefined);
+    const invokeFn = vi.fn().mockResolvedValue(undefined);
 
-    await restartRelay(invoke);
+    await restartRelay(invokeFn);
 
-    expect(invoke).toHaveBeenCalledWith('restart_relay');
+    expect(invokeFn).toHaveBeenCalledWith('restart_relay');
+  });
+});
+
+describe('Settings JS execution mode helpers', () => {
+  const invokeMock = invoke as unknown as ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    invokeMock.mockReset();
+    getConfigMock.mockReset();
+    reloadConfigMock.mockReset();
+    // Reset the shared store to its default before each test so order
+    // doesn't matter.
+    const { jsExecutionMode } = await import('$lib/stores');
+    jsExecutionMode.set(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetchJsExecutionMode updates the store from the Tauri command (true)', async () => {
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'get_js_execution_mode') return Promise.resolve(true);
+      return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
+    });
+    const { fetchJsExecutionMode } = await import('$lib/jsExecutionModeUi');
+    const { jsExecutionMode } = await import('$lib/stores');
+
+    await fetchJsExecutionMode();
+
+    expect(invokeMock).toHaveBeenCalledWith('get_js_execution_mode');
+    expect(get(jsExecutionMode)).toBe(true);
+  });
+
+  it('fetchJsExecutionMode is resilient to a failing relay path (regression for cold-start race)', async () => {
+    // The original bug: a slow/unavailable relay made the read path throw
+    // and the toggle stuck at the default. Now the Tauri command is the
+    // source of truth, and getConfig/reloadConfig rejecting must not stop
+    // the store from picking up the on-disk value.
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'get_js_execution_mode') return Promise.resolve(true);
+      return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
+    });
+    getConfigMock.mockRejectedValue(new Error('relay socket not ready'));
+    reloadConfigMock.mockRejectedValue(new Error('relay socket not ready'));
+    const { fetchJsExecutionMode } = await import('$lib/jsExecutionModeUi');
+    const { jsExecutionMode } = await import('$lib/stores');
+
+    await expect(fetchJsExecutionMode()).resolves.toBeUndefined();
+    expect(get(jsExecutionMode)).toBe(true);
+  });
+
+  it('fetchJsExecutionMode does NOT call getConfig (relay is no longer in the read path)', async () => {
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'get_js_execution_mode') return Promise.resolve(false);
+      return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
+    });
+    const { fetchJsExecutionMode } = await import('$lib/jsExecutionModeUi');
+
+    await fetchJsExecutionMode();
+
+    expect(getConfigMock).not.toHaveBeenCalled();
+  });
+
+  it('toggleJsExecutionMode calls set_js_execution_mode then reloadConfig, in order', async () => {
+    const callOrder: string[] = [];
+    invokeMock.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
+      if (cmd === 'set_js_execution_mode') {
+        callOrder.push(`set:${args?.enabled}`);
+        return Promise.resolve(undefined);
+      }
+      return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
+    });
+    reloadConfigMock.mockImplementation(() => {
+      callOrder.push('reload');
+      return Promise.resolve();
+    });
+    const { toggleJsExecutionMode } = await import('$lib/jsExecutionModeUi');
+    const { jsExecutionMode } = await import('$lib/stores');
+    jsExecutionMode.set(false);
+
+    await toggleJsExecutionMode();
+
+    expect(invokeMock).toHaveBeenCalledWith('set_js_execution_mode', { enabled: true });
+    expect(reloadConfigMock).toHaveBeenCalledTimes(1);
+    expect(callOrder).toEqual(['set:true', 'reload']);
+    expect(get(jsExecutionMode)).toBe(true);
+  });
+
+  it('toggleJsExecutionMode reverts the store when set_js_execution_mode rejects', async () => {
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'set_js_execution_mode') return Promise.reject(new Error('write failed'));
+      return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
+    });
+    const { toggleJsExecutionMode } = await import('$lib/jsExecutionModeUi');
+    const { jsExecutionMode } = await import('$lib/stores');
+    jsExecutionMode.set(false);
+
+    await toggleJsExecutionMode();
+
+    expect(get(jsExecutionMode)).toBe(false);
+    expect(reloadConfigMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/lib/jsExecutionModeUi.ts
+++ b/src/lib/jsExecutionModeUi.ts
@@ -1,0 +1,39 @@
+import { invoke } from '@tauri-apps/api/core';
+import { get } from 'svelte/store';
+import { jsExecutionMode } from './stores';
+import { reloadConfig } from './api';
+
+// Read the JS execution mode from the Tauri backend, which reads
+// `~/.endara/config.toml` directly. The relay is intentionally NOT in the
+// read path: a cold-started UI used to call `getConfig` against the relay
+// while the relay socket was still coming up, race-losing and leaving the
+// toggle stuck at the default `false` even when the on-disk config had it
+// enabled.
+export async function fetchJsExecutionMode(): Promise<void> {
+  try {
+    const enabled = await invoke<boolean>('get_js_execution_mode');
+    jsExecutionMode.set(enabled);
+  } catch (e) {
+    // Swallow and leave the store at its current value; matches the prior
+    // "default-and-move-on" behavior so a transient failure never throws
+    // during Settings mount.
+    console.error('Failed to get JS execution mode:', e);
+  }
+}
+
+// Toggle JS execution mode: write through Tauri (which updates
+// `~/.endara/config.toml`), then ask the running relay to re-read its
+// config so the live sidecar picks up the new value without a restart.
+// Optimistically flips the store first and reverts on failure.
+export async function toggleJsExecutionMode(): Promise<void> {
+  const newValue = !get(jsExecutionMode);
+  jsExecutionMode.set(newValue);
+  try {
+    await invoke('set_js_execution_mode', { enabled: newValue });
+    await reloadConfig();
+  } catch (e) {
+    jsExecutionMode.set(!newValue);
+    console.error('Failed to set JS execution mode:', e);
+  }
+}
+


### PR DESCRIPTION
## What

This is the **UI half** of the JS execution mode cold-start fix paired with [#80](https://github.com/endara-ai/endara-desktop/pull/80) (commit `211d2ad`, which added the `get_js_execution_mode` Tauri command that reads `~/.endara/config.toml` directly).

The Settings toggle used to read its initial state by calling `getConfig()` against the relay's management API. On cold start the relay socket isn't always ready yet, so the read would silently reject and the toggle would stick at the default **`false`** — even when the on-disk config had `local_js_execution = true`. Restarting the app once the relay was up appeared to "fix" the toggle, which obscured the actual race.

## Symptom

1. Set `local_js_execution = true` in `~/.endara/config.toml`.
2. Cold-start the app.
3. Open Settings before the relay sidecar is ready.
4. **Before:** toggle shows OFF (wrong).
5. **After:** toggle shows ON immediately, sourced from `config.toml` via the Tauri command.

## Changes

- **New `src/lib/jsExecutionModeUi.ts`** — extracts `fetchJsExecutionMode` and `toggleJsExecutionMode` into a small helper module, mirroring the existing `relaySidecarUi.ts` pattern. This is required to unit-test the logic without mounting Svelte (the vitest env is `node` and we don't have a Svelte test renderer wired up).
- **`fetchJsExecutionMode`** now invokes `get_js_execution_mode` and writes the boolean to the `jsExecutionMode` store. The relay is no longer in the read path.
- **`toggleJsExecutionMode`** is unchanged in semantics: it still invokes `set_js_execution_mode` and then `reloadConfig()` so the live sidecar picks up the new value without a restart. Only the read path changes.
- **`Settings.svelte`** drops the now-unused `getConfig` / `reloadConfig` imports and the inline function bodies, and imports both helpers instead.

## Tests (all green locally)

New Vitest coverage in `src/lib/components/Settings.test.ts`:

1. `fetchJsExecutionMode` updates the store from the Tauri command.
2. `fetchJsExecutionMode` is resilient when `getConfig` / `reloadConfig` reject — this is the regression test for the cold-start race.
3. `fetchJsExecutionMode` does **not** call `getConfig` (locks in that the relay is no longer in the read path).
4. `toggleJsExecutionMode` calls `set_js_execution_mode` then `reloadConfig`, in order.
5. `toggleJsExecutionMode` reverts the optimistic store update when `set_js_execution_mode` rejects.

Existing `stores.test.ts` default-value test for `jsExecutionMode` still passes.

## Verification

```
cd packages/desktop && npm run check && npm run lint && npm test
```

- `npm run check` → svelte-check found 0 errors and 0 warnings
- `npm run lint` → no linter configured
- `npm test` → 273 passed | 24 skipped (16 files)

## Out of scope

- `src-tauri/` (handled in #80).
- Relay-side changes.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author