### PR TITLE
ci(release): clear rustup-init shim before cargo build on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,13 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Clear rustup-init shim (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          sudo rm -f /usr/local/bin/cargo /usr/local/bin/rustc /usr/local/bin/rustup
+          which cargo
+          cargo --version
+
       - uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           workspaces: './src-tauri -> target'


### PR DESCRIPTION
## Why

The macOS GitHub runner image regressed: `/usr/local/bin/cargo` now resolves to a `rustup-init` shim that intercepts `cargo build` invocations inside `tauri-action`, breaking the Apple Silicon DMG build. Same root cause as the sibling relay-side failure — see the failing relay release run: https://github.com/endara-ai/endara-relay/actions/runs/25864172650.

## What

Add a macOS-gated step in the `publish` job, after `dtolnay/rust-toolchain` installs the real toolchain and before the rust cache / tauri build, that removes the shimmed binaries from `/usr/local/bin` so the `~/.cargo/bin` Rust toolchain is the only one on `PATH`:

```yaml
- name: Clear rustup-init shim (macOS)
  if: runner.os == 'macOS'
  run: |
    sudo rm -f /usr/local/bin/cargo /usr/local/bin/rustc /usr/local/bin/rustup
    which cargo
    cargo --version
```

One removal at the top of the macOS job is enough — all subsequent cargo invocations (including those inside `tauri-action`) inherit the fixed `PATH`.

## Scope

- Only `.github/workflows/release.yml` is touched.
- No version, tag, or pin changes.
- Linux and Windows runners are unaffected.

## Sibling fix

Sibling fix on `endara-relay` coming in parallel (will be linked here once filed).

Do not merge yet — keep alongside the relay PR.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author