### PR TITLE
ci(release): unpin macos-14 now that rustup shim is cleared explicitly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # pinned to macos-14 — macos-latest (macos-15) ships a rustup-init shim that breaks 'cargo build' in tauri-action's bundle path; companion to relay PR for the same fix. See burned tags v0.1.6-rc.{2,3,4}.
-          - platform: macos-14
+          # macos-latest (macos-15) ships a rustup-init shim that breaks 'cargo build' in tauri-action's bundle path; the 'Clear rustup-init shim (macOS)' step below sudo-removes it after dtolnay/rust-toolchain installs, so we can stay on macos-latest. See burned tags v0.1.6-rc.{2,3,4}.
+          - platform: macos-latest
             target: aarch64-apple-darwin
             relay_target: aarch64-apple-darwin
           - platform: windows-latest


### PR DESCRIPTION
## Why

A temporary pin to `macos-14` was added to work around the rustup-init shim regression on `macos-latest` (where `/usr/local/bin/cargo` was a shim that intercepted `cargo build` inside `tauri-action`'s bundle path).

[PR #83](https://github.com/endara-ai/endara-desktop/pull/83) added a dedicated `Clear rustup-init shim (macOS)` step that `sudo`-removes `/usr/local/bin/{cargo,rustc,rustup}` right after `dtolnay/rust-toolchain` installs. That is the durable fix, so the runner pin is now redundant.

## What

- `.github/workflows/release.yml`: change the macOS matrix entry's `platform` from `macos-14` back to `macos-latest`.
- Update the explanatory comment to point at the `Clear rustup-init shim (macOS)` step as the durable fix.

No other lines changed. The `Clear rustup-init shim (macOS)` step is untouched.

## Scope

- Only `.github/workflows/release.yml` is modified.
- No version, tag, or other workflow changes.
- Linux and Windows runners are unaffected.

## Sibling fix

Sibling fix on `endara-relay` coming in parallel (will be linked here once filed).

Do not merge yet — keep alongside the relay PR.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author