### PR TITLE
chore: bump version to 0.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endara/desktop",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "description": "Endara Desktop — Tauri + Svelte tray app for relay management",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1114,7 +1114,7 @@ dependencies = [
 
 [[package]]
 name = "endara-desktop"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "dirs 5.0.1",
  "hostname",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endara-desktop"
-version = "0.1.6"
+version = "0.1.7"
 description = "Endara Desktop — relay management tray app"
 authors = ["Endara"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Endara Desktop",
   "mainBinaryName": "Endara Desktop",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "identifier": "ai.endara.desktop",
   "build": {
     "beforeDevCommand": "ENDARA_DEV_PORT=9500 bash scripts/kill-relay.sh; npm run dev",


### PR DESCRIPTION
Bumps the committed base version to `0.1.7` in lockstep across all four version fields per AGENTS.md § "Release versioning" and Scenario 3 (post-stable-release base bump).

## Changes
- `package.json` → `0.1.7`
- `src-tauri/Cargo.toml` → `0.1.7`
- `src-tauri/tauri.conf.json` → `0.1.7`
- `src-tauri/Cargo.lock` → regenerated via `cargo check`

## Verification
- `grep '^version' src-tauri/Cargo.toml` → `version = "0.1.7"`
- `jq -r '.version' package.json src-tauri/tauri.conf.json` → `0.1.7` ×2
- `cargo fmt --check` clean in `src-tauri/`

The `-rc.N` suffix continues to come from the release tag at build time; the committed version stays clean.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author