### PR TITLE
feat(detail-panel): move Re-authorize into the error bar, hide Refresh Now when auth required

### DIFF
--- a/src/lib/components/AuthTab.svelte
+++ b/src/lib/components/AuthTab.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
   import type { OAuthStatus, OAuthStatusValue } from '$lib/types';
   import { selectedEndpoint, oauthStatuses } from '$lib/stores';
-  import { getOAuthStatus, refreshOAuth, startOAuth } from '$lib/api';
+  import { getOAuthStatus, refreshOAuth } from '$lib/api';
   import { toast } from 'svelte-sonner';
-  import { openUrl } from '@tauri-apps/plugin-opener';
-  import { canReauthorize as canReauthorizeStatus, reauthorize } from '$lib/oauth/actions';
 
   let status = $state<OAuthStatus | null>(null);
   let loading = $state(true);
@@ -87,25 +85,7 @@
     actionInProgress = false;
   }
 
-  async function handleReauthorize() {
-    const name = $selectedEndpoint;
-    if (!name || actionInProgress) return;
-    actionInProgress = true;
-    try {
-      await reauthorize(name, {
-        startOAuth,
-        openUrl,
-        onSuccess: toast.success,
-        onError: toast.error,
-      });
-    } catch {
-      toast.error('Failed to start OAuth flow');
-    }
-    actionInProgress = false;
-  }
-
-  let canRefresh = $derived(status !== null && status.has_refresh_token && ['authenticated', 'auth_required'].includes(status.status));
-  let canReauthorize = $derived(status !== null && canReauthorizeStatus(status.status));
+  let canRefresh = $derived(status !== null && status.has_refresh_token && ['authenticated'].includes(status.status));
 </script>
 
 <div class="h-full overflow-y-auto p-4 space-y-4">
@@ -166,24 +146,15 @@
     </div>
 
     <!-- Actions -->
-    <div class="flex gap-2">
-      {#if canRefresh}
+    {#if canRefresh}
+      <div class="flex gap-2">
         <button
           class="btn-sec"
           onclick={handleRefresh}
           disabled={actionInProgress}
         >Refresh Now</button>
-      {/if}
-      {#if canReauthorize}
-        <button
-          class="btn-pri"
-          onclick={handleReauthorize}
-          disabled={actionInProgress}
-          title="Open the browser to sign in again"
-          aria-label="Re-authorize"
-        >Re-authorize</button>
-      {/if}
-    </div>
+      </div>
+    {/if}
   {/if}
 </div>
 

--- a/src/lib/components/AuthTab.test.ts
+++ b/src/lib/components/AuthTab.test.ts
@@ -21,6 +21,32 @@ function formatCountdown(seconds: number | null): string {
   return m > 0 ? `${m}m ${s}s` : `${s}s`;
 }
 
+// Pure mirror of the `canRefresh` derivation in AuthTab.svelte. Kept in sync
+// with the component so we can unit-test which OAuth statuses surface the
+// "Refresh Now" button. `auth_required` is intentionally excluded — once the
+// token is expired the user must re-authorize, not silently refresh.
+type OAuthStatusValue =
+  | 'authenticated'
+  | 'needs_login'
+  | 'refreshing'
+  | 'auth_required'
+  | 'disconnected'
+  | 'connection_failed';
+
+interface MinimalOAuthStatus {
+  status: OAuthStatusValue;
+  has_refresh_token: boolean;
+}
+
+function canRefresh(status: MinimalOAuthStatus | null): boolean {
+  return (
+    status !== null &&
+    status.has_refresh_token &&
+    (['authenticated'] as OAuthStatusValue[]).includes(status.status)
+  );
+}
+
+
 describe('formatTime', () => {
   it('returns "—" for null', () => {
     expect(formatTime(null)).toBe('—');
@@ -82,6 +108,35 @@ describe('formatCountdown', () => {
   it('formats 3661 seconds as "1h 1m"', () => {
     // 3661 seconds = 61 minutes 1 second → 1h 1m
     expect(formatCountdown(3661)).toBe('1h 1m');
+  });
+});
+
+describe('canRefresh', () => {
+  it('returns true when authenticated and a refresh token is present', () => {
+    expect(canRefresh({ status: 'authenticated', has_refresh_token: true })).toBe(true);
+  });
+
+  it('returns false when authenticated but no refresh token is present', () => {
+    expect(canRefresh({ status: 'authenticated', has_refresh_token: false })).toBe(false);
+  });
+
+  // Regression guard: prior to moving Re-authorize into the error bar,
+  // `auth_required` qualified for Refresh Now. After the change, an expired
+  // token should hide Refresh Now so the user re-authorizes instead.
+  it('returns false for auth_required (regression guard)', () => {
+    expect(canRefresh({ status: 'auth_required', has_refresh_token: true })).toBe(false);
+  });
+
+  it('returns false for needs_login', () => {
+    expect(canRefresh({ status: 'needs_login', has_refresh_token: true })).toBe(false);
+  });
+
+  it('returns false for disconnected', () => {
+    expect(canRefresh({ status: 'disconnected', has_refresh_token: true })).toBe(false);
+  });
+
+  it('returns false when status is null', () => {
+    expect(canRefresh(null)).toBe(false);
   });
 });
 

--- a/src/lib/components/DetailPanel.svelte
+++ b/src/lib/components/DetailPanel.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
-  import { selectedEndpointData, activeTab, selectedEndpoint, endpoints } from '$lib/stores';
+  import { selectedEndpointData, activeTab, selectedEndpoint, endpoints, oauthStatuses } from '$lib/stores';
   import { requestNavigation } from '$lib/stores/unsavedChangesGuard';
-  import { restartEndpoint, refreshEndpoint, removeEndpoint, getEndpoints, disableEndpoint, enableEndpoint } from '$lib/api';
+  import { restartEndpoint, refreshEndpoint, removeEndpoint, getEndpoints, disableEndpoint, enableEndpoint, startOAuth } from '$lib/api';
+  import { openUrl } from '@tauri-apps/plugin-opener';
+  import { reauthorize } from '$lib/oauth/actions';
   import { toast } from 'svelte-sonner';
   import ToolsTab from './ToolsTab.svelte';
   import LogsTab from './LogsTab.svelte';
@@ -11,11 +13,26 @@
   import EndpointIcon from './EndpointIcon.svelte';
   import TransportBadge from './TransportBadge.svelte';
   import AuthTab from './AuthTab.svelte';
-  import { shouldShowRestartButton, shouldShowRefreshButton, visibleTabs } from './detail-panel-helpers';
+  import {
+    shouldShowRestartButton,
+    shouldShowRefreshButton,
+    shouldShowReauthorizeButton,
+    visibleTabs,
+  } from './detail-panel-helpers';
 
   let showRestartConfirm = $state(false);
   let showDeleteConfirm = $state(false);
   let toggling = $state(false);
+  let reauthInProgress = $state(false);
+
+  let oauthStatus = $derived(
+    $selectedEndpointData ? $oauthStatuses.get($selectedEndpointData.name)?.status ?? null : null
+  );
+  let showReauthorize = $derived(
+    $selectedEndpointData
+      ? shouldShowReauthorizeButton($selectedEndpointData.transport, oauthStatus)
+      : false
+  );
 
   let tabs = $derived(
     $selectedEndpointData
@@ -102,6 +119,23 @@
     }
     showDeleteConfirm = false;
   }
+
+  async function handleReauthorize() {
+    const name = $selectedEndpoint;
+    if (!name || reauthInProgress) return;
+    reauthInProgress = true;
+    try {
+      await reauthorize(name, {
+        startOAuth,
+        openUrl,
+        onSuccess: toast.success,
+        onError: toast.error,
+      });
+    } catch {
+      toast.error('Failed to start OAuth flow');
+    }
+    reauthInProgress = false;
+  }
 </script>
 
 <div class="flex-1 h-full flex flex-col bg-(--surface) min-w-0">
@@ -147,14 +181,28 @@
       </div>
     </div>
 
-    {#if ep.error}
+    {#if ep.error || showReauthorize}
       <div class="px-5 py-3 border-b" style="background: color-mix(in oklab, var(--offline) 12%, transparent); border-bottom-color: color-mix(in oklab, var(--offline) 30%, transparent);">
         <div class="flex items-start gap-2">
           <span class="flex-shrink-0 text-(--offline)">⚠</span>
-          <div>
-            <div class="text-sm font-medium text-(--offline)">Initialization Error</div>
-            <div class="text-xs text-(--offline) mt-0.5 whitespace-pre-wrap break-all max-h-[5lh] overflow-y-auto opacity-90">{ep.error}</div>
+          <div class="min-w-0">
+            {#if ep.error}
+              <div class="text-sm font-medium text-(--offline)">Initialization Error</div>
+              <div class="text-xs text-(--offline) mt-0.5 whitespace-pre-wrap break-all max-h-[5lh] overflow-y-auto opacity-90">{ep.error}</div>
+            {:else}
+              <div class="text-sm font-medium text-(--offline)">Authorization required</div>
+              <div class="text-xs text-(--offline) mt-0.5 opacity-90">Sign in again to reconnect this server.</div>
+            {/if}
           </div>
+          {#if showReauthorize}
+            <button
+              class="btn-pri btn-sm ml-auto flex-shrink-0 self-start"
+              onclick={handleReauthorize}
+              disabled={reauthInProgress}
+              title="Open the browser to sign in again"
+              aria-label="Re-authorize"
+            >Re-authorize</button>
+          {/if}
         </div>
       </div>
     {/if}

--- a/src/lib/components/detail-panel-helpers.test.ts
+++ b/src/lib/components/detail-panel-helpers.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
 import detailPanelSource from './DetailPanel.svelte?raw';
+import type { OAuthStatusValue } from '$lib/types';
 import {
   shouldShowRestartButton,
   shouldShowRefreshButton,
+  shouldShowReauthorizeButton,
   visibleTabs,
   type EndpointTransport,
 } from './detail-panel-helpers';
@@ -225,5 +227,53 @@ describe('DetailPanel endpoint toggle (a11y)', () => {
   it('binds aria-checked to the endpoint enabled state (!ep.disabled)', () => {
     expect(toggleBlock, 'expected to find the endpoint toggle button').not.toBeNull();
     expect(toggleBlock![0]).toMatch(/aria-checked=\{!ep\.disabled\}/);
+  });
+});
+
+describe('shouldShowReauthorizeButton', () => {
+  const reauthStatuses: OAuthStatusValue[] = ['disconnected', 'auth_required', 'needs_login'];
+  const nonReauthStatuses: OAuthStatusValue[] = ['authenticated', 'refreshing', 'connection_failed'];
+
+  for (const s of reauthStatuses) {
+    it(`returns true for oauth + "${s}"`, () => {
+      expect(shouldShowReauthorizeButton('oauth', s)).toBe(true);
+    });
+  }
+  for (const s of nonReauthStatuses) {
+    it(`returns false for oauth + "${s}"`, () => {
+      expect(shouldShowReauthorizeButton('oauth', s)).toBe(false);
+    });
+  }
+  it('returns false when oauthStatus is null', () => {
+    expect(shouldShowReauthorizeButton('oauth', null)).toBe(false);
+  });
+  it('returns false when oauthStatus is undefined', () => {
+    expect(shouldShowReauthorizeButton('oauth', undefined)).toBe(false);
+  });
+  for (const t of ['stdio', 'sse', 'http'] as const) {
+    it(`returns false for non-oauth transport "${t}" even when auth_required`, () => {
+      expect(shouldShowReauthorizeButton(t, 'auth_required')).toBe(false);
+    });
+  }
+});
+
+// ── Re-authorize button source-inspection (mirrors the toggle a11y pattern) ──
+//
+// The Re-authorize button lives inside the red error bar in DetailPanel.svelte
+// and must (a) be rendered only when `showReauthorize` is true and (b) be
+// right-aligned via `ml-auto` so it sits opposite the message column.
+describe('DetailPanel re-authorize button', () => {
+  const reauthBlock = detailPanelSource.match(
+    /\{#if showReauthorize\}[\s\S]*?<button[^>]*aria-label="Re-authorize"[\s\S]*?<\/button>[\s\S]*?\{\/if\}/,
+  );
+
+  it('renders the Re-authorize button under a showReauthorize guard', () => {
+    expect(reauthBlock, 'expected to find the Re-authorize {#if showReauthorize} block').not.toBeNull();
+    expect(reauthBlock![0]).toContain('>Re-authorize<');
+  });
+
+  it('right-aligns the Re-authorize button using ml-auto', () => {
+    expect(reauthBlock, 'expected to find the Re-authorize {#if showReauthorize} block').not.toBeNull();
+    expect(reauthBlock![0]).toContain('ml-auto');
   });
 });

--- a/src/lib/components/detail-panel-helpers.ts
+++ b/src/lib/components/detail-panel-helpers.ts
@@ -1,6 +1,21 @@
-import type { Endpoint } from '$lib/types';
+import type { Endpoint, OAuthStatusValue } from '$lib/types';
 
 export type EndpointTransport = Endpoint['transport'];
+
+const REAUTH_NEEDED_STATUSES: ReadonlyArray<OAuthStatusValue> = [
+  'disconnected',
+  'auth_required',
+  'needs_login',
+];
+
+export function shouldShowReauthorizeButton(
+  transport: EndpointTransport,
+  oauthStatus: OAuthStatusValue | null | undefined,
+): boolean {
+  if (transport !== 'oauth') return false;
+  if (!oauthStatus) return false;
+  return REAUTH_NEEDED_STATUSES.includes(oauthStatus);
+}
 
 export type DetailTabId = 'tools' | 'logs' | 'config' | 'auth';
 


### PR DESCRIPTION
## Summary

Moves the **Re-authorize** button out of the Auth tab and into the red Initialization Error bar at the top of the Detail panel, and hides **Refresh Now** in the Auth tab when the token has expired (`auth_required`).

When an OAuth endpoint is in `disconnected | auth_required | needs_login` state:
- The red error bar renders even if `ep.error` is empty, with a fallback message **"Authorization required — Sign in again to reconnect this server."**
- A right-aligned **Re-authorize** button (`ml-auto`) sits opposite the message column.
- The Auth tab no longer shows the Re-authorize button.
- The Auth tab hides Refresh Now once the token is expired — silently refreshing an `auth_required` token isn't useful; the user needs to re-authorize.

## Changes

- `src/lib/components/detail-panel-helpers.ts` — new pure helper `shouldShowReauthorizeButton(transport, oauthStatus)`.
- `src/lib/components/DetailPanel.svelte` — derives `oauthStatus` from the global `oauthStatuses` store, expands the `{#if ep.error}` guard to `{#if ep.error || showReauthorize}`, renders the Re-authorize button inside the bar with `ml-auto`, and adds a `handleReauthorize` action that delegates to the existing `reauthorize()` helper.
- `src/lib/components/AuthTab.svelte` — removes the Re-authorize button, the `canReauthorize` derivation, the `handleReauthorize` function, and the now-unused `openUrl` / `startOAuth` / `reauthorize` / `canReauthorize` imports. Drops `auth_required` from the `canRefresh` eligible statuses and wraps the actions row in `{#if canRefresh}` so the container doesn't render empty.
- `src/lib/components/detail-panel-helpers.test.ts` — unit tests for `shouldShowReauthorizeButton` across all transports and statuses, plus a source-inspection test that the DetailPanel Re-authorize button is rendered under `{#if showReauthorize}` and uses `ml-auto`.
- `src/lib/components/AuthTab.test.ts` — pure-helper test block for `canRefresh` (mirrors the component derivation), with an explicit regression guard that `auth_required` no longer qualifies.

## Verification

From `packages/desktop`:
```
npm run check  # svelte-check: 0 errors, 0 warnings
npm run lint   # (no linter configured)
npm test       # vitest: 379 passed, 24 skipped, 20 files
```


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author