### PR TITLE
feat(logs): add ParsedLogLine parser module

### DIFF
--- a/src/lib/logParser.test.ts
+++ b/src/lib/logParser.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { parseLogLine, extractTimestamp } from '$lib/logParser';
+
+describe('parseLogLine', () => {
+  it('extracts endpoint name from endpoint{endpoint=github} span', () => {
+    const parsed = parseLogLine('info', 'endpoint{endpoint=github}: Initialize handshake complete');
+    expect(parsed.endpoint).toBe('github');
+    expect(parsed.message).toBe('Initialize handshake complete');
+    expect(parsed.level).toBe('info');
+  });
+
+  it('extracts multiple span fields (endpoint, transport, server_type)', () => {
+    const parsed = parseLogLine(
+      'info',
+      'endpoint{endpoint=github transport=stdio server_type=github}: Initialize handshake complete'
+    );
+    expect(parsed.endpoint).toBe('github');
+    expect(parsed.transport).toBe('stdio');
+    expect(parsed.serverType).toBe('github');
+    expect(parsed.message).toBe('Initialize handshake complete');
+  });
+
+  it('extracts inline fields (tool, status, duration_ms) and request span', () => {
+    const parsed = parseLogLine(
+      'info',
+      'request{method=tools/call id=42} endpoint{endpoint=github}: Tool call completed tool=get_file_contents status=ok duration_ms=312'
+    );
+    expect(parsed.endpoint).toBe('github');
+    expect(parsed.method).toBe('tools/call');
+    expect(parsed.requestId).toBe('42');
+    expect(parsed.tool).toBe('get_file_contents');
+    expect(parsed.status).toBe('ok');
+    expect(parsed.durationMs).toBe(312);
+    expect(parsed.message).toBe('Tool call completed');
+  });
+
+  it('handles lines with no span context (relay-level events)', () => {
+    const parsed = parseLogLine('info', 'Relay listening on 127.0.0.1:47107');
+    expect(parsed.endpoint).toBeUndefined();
+    expect(parsed.transport).toBeUndefined();
+    expect(parsed.method).toBeUndefined();
+    expect(parsed.message).toBe('Relay listening on 127.0.0.1:47107');
+    expect(parsed.raw).toBe('Relay listening on 127.0.0.1:47107');
+  });
+
+  it('extracts ISO timestamp from message prefix', () => {
+    const parsed = parseLogLine(
+      'info',
+      '2026-05-20T10:32:05.123Z endpoint{endpoint=github}: Initialize handshake complete'
+    );
+    expect(parsed.timestamp.toISOString()).toBe('2026-05-20T10:32:05.123Z');
+    expect(parsed.endpoint).toBe('github');
+    expect(parsed.message).toBe('Initialize handshake complete');
+  });
+
+  it('falls back to client-side timestamp when no timestamp in message', () => {
+    const before = Date.now();
+    const parsed = parseLogLine('info', 'endpoint{endpoint=github}: Initialize handshake complete');
+    const after = Date.now();
+    const t = parsed.timestamp.getTime();
+    expect(t).toBeGreaterThanOrEqual(before);
+    expect(t).toBeLessThanOrEqual(after);
+  });
+
+  it('normalizes unknown levels to info and lowercases known ones', () => {
+    expect(parseLogLine('ERROR', 'boom').level).toBe('error');
+    expect(parseLogLine('Warn', 'careful').level).toBe('warn');
+    expect(parseLogLine('TRACE', 'noisy').level).toBe('trace');
+    expect(parseLogLine('whatever', 'fallback').level).toBe('info');
+  });
+
+  describe('isToolCall detection', () => {
+    it('flags completed tool calls when tool field is present', () => {
+      const parsed = parseLogLine(
+        'info',
+        'endpoint{endpoint=github}: Tool call completed tool=get_file_contents status=ok duration_ms=312'
+      );
+      expect(parsed.isToolCall).toBe(true);
+      expect(parsed.tool).toBe('get_file_contents');
+    });
+
+    it('flags failed tool calls when tool field is present', () => {
+      const parsed = parseLogLine(
+        'warn',
+        'endpoint{endpoint=slack}: Tool call failed tool=send_message status=error duration_ms=1204'
+      );
+      expect(parsed.isToolCall).toBe(true);
+      expect(parsed.tool).toBe('send_message');
+      expect(parsed.status).toBe('error');
+      expect(parsed.durationMs).toBe(1204);
+    });
+
+    it('flags rows that carry status + duration_ms even without "Tool call" phrasing', () => {
+      const parsed = parseLogLine(
+        'info',
+        'endpoint{endpoint=github}: handled status=ok duration_ms=42'
+      );
+      expect(parsed.isToolCall).toBe(true);
+      expect(parsed.status).toBe('ok');
+      expect(parsed.durationMs).toBe(42);
+    });
+
+    it('does not flag plain informational lines as tool calls', () => {
+      const parsed = parseLogLine('info', 'endpoint{endpoint=github}: Initialize handshake complete');
+      expect(parsed.isToolCall).toBe(false);
+    });
+  });
+});
+
+describe('extractTimestamp', () => {
+  it('parses an ISO timestamp prefix and returns the rest of the message', () => {
+    const { timestamp, rest } = extractTimestamp(
+      '2026-05-20T10:32:05.123Z endpoint{endpoint=github}: hello'
+    );
+    expect(timestamp.toISOString()).toBe('2026-05-20T10:32:05.123Z');
+    expect(rest).toBe('endpoint{endpoint=github}: hello');
+  });
+
+  it('falls back to the current time when no timestamp prefix is present', () => {
+    const before = Date.now();
+    const { timestamp, rest } = extractTimestamp('endpoint{endpoint=github}: hello');
+    const after = Date.now();
+    expect(timestamp.getTime()).toBeGreaterThanOrEqual(before);
+    expect(timestamp.getTime()).toBeLessThanOrEqual(after);
+    expect(rest).toBe('endpoint{endpoint=github}: hello');
+  });
+});

--- a/src/lib/logParser.ts
+++ b/src/lib/logParser.ts
@@ -1,0 +1,104 @@
+// Parser for the relay's compact tracing log format. The relay (PR #67) emits
+// lines like:
+//
+//   2026-05-20T10:32:05.123Z endpoint{endpoint=github transport=stdio}: Tool call completed tool=foo status=ok duration_ms=312
+//
+// The Tauri host already splits level from the message, so this parser
+// operates on the level + message pair and extracts the relay timestamp,
+// span context (endpoint / request) and inline key=value fields.
+
+export type LogLevel = 'error' | 'warn' | 'info' | 'debug' | 'trace';
+
+export interface ParsedLogLine {
+  timestamp: Date;
+  level: LogLevel;
+  endpoint?: string;
+  transport?: string;
+  serverType?: string;
+  method?: string;
+  requestId?: string;
+  tool?: string;
+  status?: string;
+  durationMs?: number;
+  message: string;
+  raw: string;
+  isToolCall: boolean;
+}
+
+const SPAN_RE = /(\w+)\{([^}]+)\}/g;
+const FIELD_RE = /(\w+)=([^\s,}]+|"[^"]*")/g;
+const TIMESTAMP_RE = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z?)\s+/;
+
+export function extractTimestamp(message: string): { timestamp: Date; rest: string } {
+  const match = message.match(TIMESTAMP_RE);
+  if (match) {
+    return { timestamp: new Date(match[1]), rest: message.slice(match[0].length) };
+  }
+  return { timestamp: new Date(), rest: message };
+}
+
+function normalizeLevel(level: string): LogLevel {
+  const l = level.toLowerCase();
+  if (l === 'error' || l === 'warn' || l === 'info' || l === 'debug' || l === 'trace') {
+    return l;
+  }
+  return 'info';
+}
+
+export function parseLogLine(level: string, message: string): ParsedLogLine {
+  const { timestamp, rest } = extractTimestamp(message);
+
+  const spans: Record<string, Record<string, string>> = {};
+  const fields: Record<string, string> = {};
+
+  let cleanMessage = rest;
+  for (const match of rest.matchAll(SPAN_RE)) {
+    const [full, spanName, spanFields] = match;
+    spans[spanName] = {};
+    for (const fm of spanFields.matchAll(FIELD_RE)) {
+      spans[spanName][fm[1]] = fm[2].replace(/^"|"$/g, '');
+    }
+    cleanMessage = cleanMessage.replace(full, '');
+  }
+  // After span removal we may be left with leading whitespace and a stray
+  // ": " separator that preceded the message text. Collapse both.
+  cleanMessage = cleanMessage.replace(/^\s+/, '').replace(/^:\s*/, '').trim();
+
+  const msgParts = cleanMessage.length > 0 ? cleanMessage.split(/\s+/) : [];
+  const messageParts: string[] = [];
+  for (const part of msgParts) {
+    const fieldMatch = part.match(/^(\w+)=(.+)$/);
+    if (fieldMatch) {
+      fields[fieldMatch[1]] = fieldMatch[2].replace(/^"|"$/g, '');
+    } else {
+      messageParts.push(part);
+    }
+  }
+
+  const cleanedMessage = messageParts.join(' ').trim();
+  const tool = fields.tool;
+  const status = fields.status;
+  const durationMs = fields.duration_ms !== undefined ? parseInt(fields.duration_ms, 10) : undefined;
+
+  const isToolCall =
+    (tool !== undefined &&
+      (cleanedMessage.includes('Tool call completed') ||
+        cleanedMessage.includes('Tool call failed'))) ||
+    (status !== undefined && durationMs !== undefined && !Number.isNaN(durationMs));
+
+  return {
+    timestamp,
+    level: normalizeLevel(level),
+    endpoint: spans.endpoint?.endpoint,
+    transport: spans.endpoint?.transport,
+    serverType: spans.endpoint?.server_type,
+    method: spans.request?.method,
+    requestId: spans.request?.id,
+    tool,
+    status,
+    durationMs: durationMs !== undefined && !Number.isNaN(durationMs) ? durationMs : undefined,
+    message: cleanedMessage,
+    raw: message,
+    isToolCall,
+  };
+}


### PR DESCRIPTION
## Summary

Slice A.1 of the desktop log display overhaul (spec §2.1 / §2.6 / §5 tests #1–#6). This PR adds the pure parser foundation everything else builds on. No store, listener, or UI changes — those land in Slice A.2 so the type swap happens in one atomic UI change.

## What changed

- New `src/lib/logParser.ts` exporting:
  - `LogLevel` type — `'error' | 'warn' | 'info' | 'debug' | 'trace'`.
  - `ParsedLogLine` interface with `timestamp`, `level`, `endpoint`, `transport`, `serverType`, `method`, `requestId`, `tool`, `status`, `durationMs`, `message`, `raw`, `isToolCall`.
  - `parseLogLine(level, message)` — extracts the relay timestamp, span context (`endpoint{…}` / `request{…}`) and inline `key=value` fields (`tool`, `status`, `duration_ms`) from the relay's compact tracing format.
  - `extractTimestamp(message)` — pulls an ISO timestamp prefix off the message, falling back to client time when absent.
- `isToolCall` is set when `tool` is defined alongside a `"Tool call completed"` / `"Tool call failed"` message **or** when `status` and `durationMs` are both populated — Slice C can consume the parser output directly without re-deriving.
- New `src/lib/logParser.test.ts` — Vitest coverage for spec test rows #1–#6 plus four `isToolCall` cases (completed, failed, status+duration-only, plain info line as negative) and a level-normalization sanity check, 13 tests total.

## Out of scope (intentional)

Per the slice plan, this PR does **not** touch `stores.ts`, `logListener.ts`, `types.ts`, or any Svelte component. Those move over to `ParsedLogLine` in Slice A.2.

## Verification

```
cd packages/desktop
pnpm install
pnpm test src/lib/logParser.test.ts
```

```
 Test Files  1 passed (1)
      Tests  13 passed (13)
```
