### PR TITLE
feat(logs): structured RelayLogs rows + filter bar

### DIFF
--- a/src/lib/components/LogFilterBar.svelte
+++ b/src/lib/components/LogFilterBar.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+  import type { LogLevel, ParsedLogLine } from '$lib/logParser';
+
+  // Level toggles render in this fixed display order so the bar layout
+  // doesn't reshuffle as logs arrive.
+  const LEVEL_ORDER: LogLevel[] = ['error', 'warn', 'info', 'debug', 'trace'];
+
+  type Props = {
+    lines: ParsedLogLine[];
+    filteredCount: number;
+    activeLevels: Set<LogLevel>;
+    selectedEndpoints: Set<string>;
+    searchText: string;
+    onclear: () => void;
+  };
+
+  let {
+    lines,
+    filteredCount,
+    activeLevels = $bindable(),
+    selectedEndpoints = $bindable(),
+    searchText = $bindable(),
+    onclear,
+  }: Props = $props();
+
+  // Search input is bound locally and the debounced value is published into
+  // the bindable `searchText` prop. 150ms matches the engineering spec.
+  let searchInput = $state(searchText);
+  let endpointMenuOpen = $state(false);
+
+  let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+  $effect(() => {
+    const value = searchInput;
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      searchText = value;
+    }, 150);
+    return () => {
+      if (debounceTimer) clearTimeout(debounceTimer);
+    };
+  });
+
+  const levelCounts = $derived.by(() => {
+    const counts: Record<LogLevel, number> = { error: 0, warn: 0, info: 0, debug: 0, trace: 0 };
+    for (const line of lines) counts[line.level]++;
+    return counts;
+  });
+
+  const allEndpoints = $derived.by(() => {
+    const set = new Set<string>();
+    for (const line of lines) if (line.endpoint) set.add(line.endpoint);
+    return Array.from(set).sort();
+  });
+
+  function toggleLevel(level: LogLevel) {
+    const next = new Set(activeLevels);
+    if (next.has(level)) next.delete(level);
+    else next.add(level);
+    activeLevels = next;
+  }
+
+  function toggleEndpoint(name: string) {
+    const next = new Set(selectedEndpoints);
+    if (next.has(name)) next.delete(name);
+    else next.add(name);
+    selectedEndpoints = next;
+  }
+
+  function selectAllEndpoints() {
+    selectedEndpoints = new Set();
+  }
+
+  function levelPillClass(level: LogLevel, active: boolean): string {
+    if (!active) return 'border-(--border) text-(--fg3) bg-transparent';
+    switch (level) {
+      case 'error': return 'border-(--offline) bg-(--offline)/10 text-(--offline)';
+      case 'warn': return 'border-(--degraded) bg-(--degraded)/10 text-(--degraded)';
+      case 'info': return 'border-(--border-strong) text-(--fg2)';
+      case 'debug':
+      case 'trace': return 'border-(--border) text-(--fg3)';
+    }
+  }
+</script>
+
+<div class="px-3 py-2 border-b border-(--border) bg-(--hd-bg) flex flex-col gap-2">
+  <div class="flex items-center gap-2 flex-wrap">
+    {#each LEVEL_ORDER as level (level)}
+      <button
+        type="button"
+        class="pill border transition-colors {levelPillClass(level, activeLevels.has(level))}"
+        aria-pressed={activeLevels.has(level)}
+        onclick={() => toggleLevel(level)}
+      >
+        {level.toUpperCase()} ({levelCounts[level]})
+      </button>
+    {/each}
+
+    <div class="ml-auto relative">
+      <button
+        type="button"
+        class="btn-sec btn-sm"
+        aria-haspopup="listbox"
+        aria-expanded={endpointMenuOpen}
+        onclick={() => (endpointMenuOpen = !endpointMenuOpen)}
+      >
+        Endpoint: {selectedEndpoints.size === 0
+          ? 'All'
+          : selectedEndpoints.size === 1
+            ? Array.from(selectedEndpoints)[0]
+            : `${selectedEndpoints.size} selected`} ▾
+      </button>
+      {#if endpointMenuOpen}
+        <ul
+          role="listbox"
+          aria-multiselectable="true"
+          class="absolute right-0 mt-1 z-10 min-w-[12rem] max-h-64 overflow-y-auto rounded-md border border-(--border) bg-(--surface) shadow-lg text-sm"
+        >
+          <li>
+            <button type="button" class="w-full text-left px-3 py-1.5 hover:bg-(--surface-hover)" onclick={selectAllEndpoints}>
+              {selectedEndpoints.size === 0 ? '✓ ' : '  '}All
+            </button>
+          </li>
+          {#each allEndpoints as ep (ep)}
+            <li>
+              <button type="button" class="w-full text-left px-3 py-1.5 hover:bg-(--surface-hover) font-mono" onclick={() => toggleEndpoint(ep)}>
+                {selectedEndpoints.has(ep) ? '✓ ' : '  '}{ep}
+              </button>
+            </li>
+          {:else}
+            <li class="px-3 py-1.5 text-(--fg3) italic">No endpoints yet</li>
+          {/each}
+        </ul>
+      {/if}
+    </div>
+  </div>
+
+  <div class="flex items-center gap-2">
+    <div class="relative flex-1">
+      <svg class="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-(--fg3)" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <circle cx="11" cy="11" r="8" />
+        <path d="M21 21l-4.3-4.3" stroke-linecap="round" />
+      </svg>
+      <input
+        type="text"
+        placeholder="Search logs…"
+        bind:value={searchInput}
+        class="w-full pl-7 pr-2 py-[5px] text-[13px] rounded-lg border border-(--border) bg-(--surface) text-(--fg1) focus:outline-none focus:border-(--accent) focus:shadow-[0_0_0_3px_var(--accent-tint)] transition-shadow"
+      />
+    </div>
+    <span class="text-xs text-(--fg3) whitespace-nowrap">{filteredCount} / {lines.length} lines</span>
+    <button type="button" class="btn-sec btn-sm" onclick={onclear}>Clear</button>
+  </div>
+</div>

--- a/src/lib/components/LogFilterBar.test.ts
+++ b/src/lib/components/LogFilterBar.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import { parseLogLine } from '$lib/logParser';
+import type { LogLevel, ParsedLogLine } from '$lib/logParser';
+
+// Pure mirror of the filter combine logic in `LogFilterBar.svelte` +
+// `RelayLogs.svelte`. Kept in sync with the components so we can unit-test
+// the AND-combine semantics without spinning up a Svelte runtime (the desktop
+// test env is Node, not jsdom). Engineering spec §2.2 + tests #7–#10.
+
+interface LogFilterState {
+  activeLevels: Set<LogLevel>;
+  searchText: string;
+  selectedEndpoints: Set<string>; // empty = "All"
+}
+
+function applyLogFilters(lines: ParsedLogLine[], state: LogFilterState): ParsedLogLine[] {
+  const q = state.searchText.trim().toLowerCase();
+  const hasEndpointFilter = state.selectedEndpoints.size > 0;
+  return lines.filter((line) => {
+    if (!state.activeLevels.has(line.level)) return false;
+    if (hasEndpointFilter) {
+      if (!line.endpoint || !state.selectedEndpoints.has(line.endpoint)) return false;
+    }
+    if (q.length > 0 && !line.raw.toLowerCase().includes(q)) return false;
+    return true;
+  });
+}
+
+const ALL_LEVELS: Set<LogLevel> = new Set(['error', 'warn', 'info', 'debug', 'trace']);
+
+function makeSampleLines(): ParsedLogLine[] {
+  return [
+    parseLogLine('info', 'endpoint{endpoint=github}: Initialize handshake complete'),
+    parseLogLine('warn', 'endpoint{endpoint=slack}: Connection lost, reconnecting...'),
+    parseLogLine('error', 'endpoint{endpoint=postgres}: MCP server exited exit_code=1'),
+    parseLogLine(
+      'info',
+      'endpoint{endpoint=github}: Tool call completed tool=get_file_contents status=ok duration_ms=312'
+    ),
+    parseLogLine('debug', 'endpoint{endpoint=gmail}: Polling for messages'),
+    parseLogLine('info', 'Relay listening on 127.0.0.1:47107'),
+  ];
+}
+
+describe('applyLogFilters', () => {
+  // #7 — Level filter toggles correctly include/exclude log lines
+  it('includes a level only when it is in the active set', () => {
+    const lines = makeSampleLines();
+    const onlyErrors = applyLogFilters(lines, {
+      activeLevels: new Set<LogLevel>(['error']),
+      searchText: '',
+      selectedEndpoints: new Set(),
+    });
+    expect(onlyErrors).toHaveLength(1);
+    expect(onlyErrors[0].level).toBe('error');
+
+    const errorAndWarn = applyLogFilters(lines, {
+      activeLevels: new Set<LogLevel>(['error', 'warn']),
+      searchText: '',
+      selectedEndpoints: new Set(),
+    });
+    expect(errorAndWarn.map((l) => l.level).sort()).toEqual(['error', 'warn']);
+
+    const none = applyLogFilters(lines, {
+      activeLevels: new Set<LogLevel>(),
+      searchText: '',
+      selectedEndpoints: new Set(),
+    });
+    expect(none).toHaveLength(0);
+  });
+
+  // #8 — Text search filters lines by case-insensitive substring match
+  it('filters lines by case-insensitive substring search against raw', () => {
+    const lines = makeSampleLines();
+    const githubLines = applyLogFilters(lines, {
+      activeLevels: ALL_LEVELS,
+      searchText: 'GITHUB',
+      selectedEndpoints: new Set(),
+    });
+    expect(githubLines).toHaveLength(2);
+    expect(githubLines.every((l) => l.endpoint === 'github')).toBe(true);
+
+    const toolLines = applyLogFilters(lines, {
+      activeLevels: ALL_LEVELS,
+      searchText: 'tool call',
+      selectedEndpoints: new Set(),
+    });
+    expect(toolLines).toHaveLength(1);
+    expect(toolLines[0].tool).toBe('get_file_contents');
+
+    const trimmed = applyLogFilters(lines, {
+      activeLevels: ALL_LEVELS,
+      searchText: '   ',
+      selectedEndpoints: new Set(),
+    });
+    expect(trimmed).toHaveLength(lines.length);
+  });
+
+  // #9 — Endpoint filter shows only lines matching selected endpoint(s)
+  it('restricts to the selected endpoints (empty set = All)', () => {
+    const lines = makeSampleLines();
+    const justGithub = applyLogFilters(lines, {
+      activeLevels: ALL_LEVELS,
+      searchText: '',
+      selectedEndpoints: new Set(['github']),
+    });
+    expect(justGithub).toHaveLength(2);
+    expect(justGithub.every((l) => l.endpoint === 'github')).toBe(true);
+
+    const githubOrSlack = applyLogFilters(lines, {
+      activeLevels: ALL_LEVELS,
+      searchText: '',
+      selectedEndpoints: new Set(['github', 'slack']),
+    });
+    expect(githubOrSlack.map((l) => l.endpoint).sort()).toEqual(['github', 'github', 'slack']);
+
+    // Relay-level events (no endpoint) are excluded when an endpoint filter
+    // is active — the "Relay listening on …" line is filtered out.
+    const noRelayLevel = githubOrSlack.find((l) => l.endpoint === undefined);
+    expect(noRelayLevel).toBeUndefined();
+
+    // Empty selectedEndpoints means "All" — the relay-level line is kept.
+    const all = applyLogFilters(lines, {
+      activeLevels: ALL_LEVELS,
+      searchText: '',
+      selectedEndpoints: new Set(),
+    });
+    expect(all).toHaveLength(lines.length);
+  });
+
+  // #10 — Combined filters (level + text + endpoint) apply with AND logic
+  it('combines level, search, and endpoint filters with AND semantics', () => {
+    const lines = makeSampleLines();
+    const result = applyLogFilters(lines, {
+      activeLevels: new Set<LogLevel>(['info']),
+      searchText: 'tool',
+      selectedEndpoints: new Set(['github']),
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].endpoint).toBe('github');
+    expect(result[0].level).toBe('info');
+    expect(result[0].tool).toBe('get_file_contents');
+
+    const noMatch = applyLogFilters(lines, {
+      activeLevels: new Set<LogLevel>(['error']),
+      searchText: 'tool',
+      selectedEndpoints: new Set(['github']),
+    });
+    expect(noMatch).toHaveLength(0);
+  });
+});

--- a/src/lib/components/RelayLogs.svelte
+++ b/src/lib/components/RelayLogs.svelte
@@ -1,12 +1,40 @@
 <script lang="ts">
   import { tick } from 'svelte';
   import { relayLogLines, activeTopLevelTab } from '$lib/stores';
-  import type { RelayLogLine } from '$lib/stores';
+  import type { LogLevel, ParsedLogLine } from '$lib/logParser';
   import { isAtBottom } from '$lib/scrollUtils';
+  import LogFilterBar from './LogFilterBar.svelte';
 
   let scrollContainer: HTMLDivElement | undefined = $state();
   let autoScroll = $state(true);
   let isTabSwitching = $state(false);
+
+  // Filter state — local, not persisted (engineering spec §2.2).
+  let activeLevels = $state<Set<LogLevel>>(new Set(['error', 'warn', 'info', 'debug', 'trace']));
+  let selectedEndpoints = $state<Set<string>>(new Set());
+  let searchText = $state('');
+
+  // Hover tooltip clock — ticks every second only while this tab is visible
+  // so we don't keep firing $effect updates in the background (spec §2.6).
+  let now = $state(Date.now());
+  $effect(() => {
+    if ($activeTopLevelTab !== 'relay-logs') return;
+    const id = setInterval(() => (now = Date.now()), 1000);
+    return () => clearInterval(id);
+  });
+
+  const filteredLines = $derived.by(() => {
+    const q = searchText.trim().toLowerCase();
+    const hasEndpointFilter = selectedEndpoints.size > 0;
+    return $relayLogLines.filter((line) => {
+      if (!activeLevels.has(line.level)) return false;
+      if (hasEndpointFilter) {
+        if (!line.endpoint || !selectedEndpoints.has(line.endpoint)) return false;
+      }
+      if (q.length > 0 && !line.raw.toLowerCase().includes(q)) return false;
+      return true;
+    });
+  });
 
   function handleScroll() {
     if (!scrollContainer || isTabSwitching) return;
@@ -16,7 +44,7 @@
 
   async function scrollToBottom() {
     if (!autoScroll) return;
-    await tick(); // wait for Svelte to flush DOM updates
+    await tick();
     requestAnimationFrame(() => {
       if (scrollContainer && autoScroll) {
         scrollContainer.scrollTop = scrollContainer.scrollHeight;
@@ -39,21 +67,50 @@
     relayLogLines.set([]);
   }
 
-  function levelColor(level: string): string {
+  function formatHMS(d: Date): string {
+    return d.toLocaleTimeString(undefined, { hour12: false });
+  }
+
+  function formatRelative(d: Date, nowMs: number): string {
+    const diff = Math.max(0, Math.floor((nowMs - d.getTime()) / 1000));
+    if (diff < 60) return `${diff}s ago`;
+    if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+    return `${Math.floor(diff / 3600)}h ago`;
+  }
+
+  function levelPillClass(level: LogLevel): string {
     switch (level) {
-      case 'error': return 'text-(--offline)';
-      case 'warn': return 'text-(--degraded)';
-      default: return 'text-(--fg1)';
+      case 'error': return 'bg-(--offline)/10 text-(--offline)';
+      case 'warn': return 'bg-(--degraded)/10 text-(--degraded)';
+      case 'info': return 'text-(--fg2)';
+      case 'debug':
+      case 'trace': return 'text-(--fg3)';
     }
   }
 
-  // Auto-scroll when new lines arrive
+  // Split the message around the search term so the matching substring can be
+  // highlighted in the rendered row (case-insensitive, first occurrence only).
+  function highlightSegments(text: string, query: string): Array<{ text: string; match: boolean }> {
+    if (!query) return [{ text, match: false }];
+    const lower = text.toLowerCase();
+    const q = query.toLowerCase();
+    const idx = lower.indexOf(q);
+    if (idx === -1) return [{ text, match: false }];
+    return [
+      { text: text.slice(0, idx), match: false },
+      { text: text.slice(idx, idx + q.length), match: true },
+      { text: text.slice(idx + q.length), match: false },
+    ];
+  }
+
+  // Auto-scroll when new lines arrive (subscribe to filtered list so toggling
+  // a level back on also pins us to bottom).
   $effect(() => {
-    $relayLogLines;  // subscribe to log changes
+    filteredLines;
     scrollToBottom();
   });
 
-  // Force scroll when switching back to relay-logs tab
+  // Force scroll when switching back to the relay-logs tab.
   $effect(() => {
     const tab = $activeTopLevelTab;
     if (tab === 'relay-logs' && autoScroll && scrollContainer) {
@@ -72,41 +129,56 @@
       };
     }
   });
+
+  const trimmedSearch = $derived(searchText.trim());
 </script>
 
 <div class="h-full flex flex-col">
-  <div class="px-4 py-2 border-b border-(--border) flex items-center justify-between bg-(--hd-bg)">
-    <span class="text-xs text-(--fg3)">{$relayLogLines.length} lines</span>
-    <div class="flex items-center gap-1.5">
-      {#if !autoScroll}
-        <button
-          class="btn-sec btn-sm"
-          onclick={goToEnd}
-        >Go to end</button>
-      {/if}
-      <button
-        class="btn-sec btn-sm"
-        onclick={clearLogs}
-      >Clear</button>
-    </div>
+  <LogFilterBar
+    lines={$relayLogLines}
+    filteredCount={filteredLines.length}
+    bind:activeLevels
+    bind:selectedEndpoints
+    bind:searchText
+    onclear={clearLogs}
+  />
+  <div class="px-4 py-1 border-b border-(--border) bg-(--hd-bg) flex items-center justify-end">
+    {#if !autoScroll}
+      <button class="btn-sec btn-sm" onclick={goToEnd}>Go to end</button>
+    {/if}
   </div>
   <div
     bind:this={scrollContainer}
     onscroll={handleScroll}
-    class="flex-1 overflow-y-auto p-4 t-mono-log bg-(--surface-sunken)"
+    class="flex-1 overflow-y-auto t-mono-log bg-(--surface-sunken)"
   >
     {#if $relayLogLines.length === 0}
       <div class="text-(--fg3) text-center py-6">
         No relay logs yet. Logs will appear here when the relay sidecar produces output.
       </div>
+    {:else if filteredLines.length === 0}
+      <div class="text-(--fg3) text-center py-6">
+        No lines match the current filters.
+      </div>
     {:else}
-      {#each $relayLogLines as line, i}
-        <div class="hover:bg-(--surface-hover) px-1 rounded whitespace-pre-wrap break-all {levelColor(line.level)}">
-          <span class="text-(--fg3) select-none">{line.timestamp}</span>
-          {' '}{line.message}
+      {#each filteredLines as line (line)}
+        {@const segs = highlightSegments(line.message || line.raw, trimmedSearch)}
+        <div class="grid grid-cols-[auto_4rem_8rem_1fr] gap-3 px-3 py-0.5 hover:bg-(--surface-hover) items-baseline">
+          <span
+            class="text-(--fg3) select-none tabular-nums"
+            title={`${line.timestamp.toISOString()} · ${formatRelative(line.timestamp, now)}`}
+          >{formatHMS(line.timestamp)}</span>
+          <span class="pill {levelPillClass(line.level)}">{line.level.toUpperCase()}</span>
+          <span class="truncate text-(--fg2)" title={line.endpoint ?? ''}>
+            {line.endpoint ?? '──'}
+          </span>
+          <span class="whitespace-pre-wrap break-all">
+            {#each segs as seg}
+              {#if seg.match}<mark class="bg-(--accent)/20 text-(--fg1)">{seg.text}</mark>{:else}{seg.text}{/if}
+            {/each}
+          </span>
         </div>
       {/each}
     {/if}
   </div>
 </div>
-

--- a/src/lib/logListener.test.ts
+++ b/src/lib/logListener.test.ts
@@ -64,7 +64,7 @@ describe('logListener', () => {
       expect(get(relaySidecarError)).toBe('startup crash');
     });
 
-    it('adds log entries to relayLogLines store on relay-log event', async () => {
+    it('parses relay-log events into ParsedLogLine entries on the store', async () => {
       const mockListen = vi.mocked(listen);
       let relayLogCallback: ((event: { payload: { level: string; message: string } }) => void) | undefined;
 
@@ -80,12 +80,45 @@ describe('logListener', () => {
       await initRelayLogListener();
 
       expect(relayLogCallback).toBeDefined();
-      relayLogCallback!({ payload: { level: 'info', message: 'test message' } });
+      relayLogCallback!({
+        payload: {
+          level: 'info',
+          message:
+            '2026-05-20T10:32:05.123Z endpoint{endpoint=github transport=stdio}: Initialize handshake complete',
+        },
+      });
 
       const lines = get(relayLogLines);
       expect(lines).toHaveLength(1);
-      expect(lines[0].message).toBe('test message');
       expect(lines[0].level).toBe('info');
+      expect(lines[0].endpoint).toBe('github');
+      expect(lines[0].transport).toBe('stdio');
+      expect(lines[0].message).toBe('Initialize handshake complete');
+      expect(lines[0].raw).toContain('endpoint{endpoint=github');
+      expect(lines[0].timestamp.toISOString()).toBe('2026-05-20T10:32:05.123Z');
+    });
+
+    it('replays buffered relay logs through parseLogLine on init', async () => {
+      const mockListen = vi.mocked(listen);
+      mockListen.mockResolvedValue(vi.fn());
+      vi.mocked(invoke).mockImplementation((cmd: string) => {
+        if (cmd === 'get_buffered_relay_logs') {
+          return Promise.resolve([
+            { level: 'warn', message: 'endpoint{endpoint=slack}: Connection lost, reconnecting...' },
+          ]);
+        }
+        return Promise.resolve({ status: 'unknown', error: null });
+      });
+
+      const { initRelayLogListener } = await import('./logListener');
+      const { relayLogLines } = await import('./stores');
+      await initRelayLogListener();
+
+      const lines = get(relayLogLines);
+      expect(lines).toHaveLength(1);
+      expect(lines[0].level).toBe('warn');
+      expect(lines[0].endpoint).toBe('slack');
+      expect(lines[0].message).toBe('Connection lost, reconnecting...');
     });
 
     it('registers relay-health listener without error', async () => {

--- a/src/lib/logListener.ts
+++ b/src/lib/logListener.ts
@@ -1,7 +1,8 @@
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { relayLogLines, relaySidecarStatus, relaySidecarError } from './stores';
-import type { RelayLogLine, RelaySidecarStatusType } from './stores';
+import type { RelaySidecarStatusType } from './stores';
+import { parseLogLine } from './logParser';
 
 let initialized = false;
 
@@ -25,11 +26,7 @@ export async function initRelayLogListener() {
 
   const listenerRegistrations = [
     listen<{ level: string; message: string }>('relay-log', (event) => {
-    const line: RelayLogLine = {
-      timestamp: new Date().toLocaleTimeString(),
-      level: (event.payload.level as RelayLogLine['level']) || 'info',
-      message: event.payload.message,
-    };
+    const line = parseLogLine(event.payload.level || 'info', event.payload.message);
     relayLogLines.update((lines) => {
       const updated = [...lines, line];
       return updated.length > 5000 ? updated.slice(-5000) : updated;
@@ -58,11 +55,7 @@ export async function initRelayLogListener() {
   try {
     const buffered = await invoke<Array<{ level: string; message: string }>>('get_buffered_relay_logs');
     if (buffered && buffered.length > 0) {
-      const lines: RelayLogLine[] = buffered.map(entry => ({
-        timestamp: new Date().toLocaleTimeString(),
-        level: (entry.level as RelayLogLine['level']) || 'info',
-        message: entry.message,
-      }));
+      const lines = buffered.map((entry) => parseLogLine(entry.level || 'info', entry.message));
       relayLogLines.update(existing => {
         const merged = [...lines, ...existing];
         return merged.length > 5000 ? merged.slice(-5000) : merged;

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -1,5 +1,6 @@
 import { writable, derived } from 'svelte/store';
 import type { Endpoint, Theme, OAuthStatus } from './types';
+import type { ParsedLogLine } from './logParser';
 
 export const endpoints = writable<Endpoint[]>([]);
 export const selectedEndpoint = writable<string | null>(null);
@@ -55,13 +56,7 @@ export const activeTab = writable<'tools' | 'logs' | 'config' | 'auth'>('tools')
 export const oauthStatuses = writable<Map<string, OAuthStatus>>(new Map());
 export const activeTopLevelTab = writable<'servers' | 'unified-catalog' | 'relay-logs' | 'settings'>('servers');
 
-export interface RelayLogLine {
-  timestamp: string;
-  level: 'info' | 'warn' | 'error';
-  message: string;
-}
-
-export const relayLogLines = writable<RelayLogLine[]>([]);
+export const relayLogLines = writable<ParsedLogLine[]>([]);
 export const miniPlayerMode = writable<boolean>(false);
 
 export const relayConnected = writable<boolean>(false);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -131,3 +131,7 @@ export interface OAuthSetupStatusResponse {
 
 export type Theme = 'light' | 'dark' | 'system';
 
+// Re-export the parsed relay log type so components can import it from
+// `$lib/types` alongside the rest of the desktop type surface.
+export type { ParsedLogLine, LogLevel } from './logParser';
+


### PR DESCRIPTION
Slice A.2 of the desktop log overhaul. Builds on the `ParsedLogLine` parser from #90.

## What changed
- **`stores.ts` + `types.ts`** — drop the legacy `RelayLogLine` interface; `relayLogLines` is now `ParsedLogLine[]`. `types.ts` re-exports `ParsedLogLine` / `LogLevel` so components can pull them from `$lib/types`.
- **`logListener.ts`** — call `parseLogLine(level, message)` for both the live `relay-log` Tauri event and the `get_buffered_relay_logs` replay. Drop the `new Date().toLocaleTimeString()` fallback — the parser handles timestamp extraction.
- **`logListener.test.ts`** — assertions updated to the parsed shape, with a new test covering the `get_buffered_relay_logs` replay path.
- **`RelayLogs.svelte`** — full rewrite of the row rendering: a 4-column grid (timestamp / level pill / endpoint / message), `HH:MM:SS` monospaced dimmed timestamps with hover tooltip carrying the full ISO + a relative "Ns ago" that ticks every second only while the Relay Logs tab is visible. Auto-scroll, "Go to end", clear, 5000-line cap, and tab-switching scroll behavior are preserved. Search matches are highlighted inline via `<mark>`.
- **`LogFilterBar.svelte` (new)** — level toggle pills with per-level count badges, debounced (150ms) search input, endpoint multi-select dropdown. State held locally with Svelte runes, not persisted across sessions.
- **`LogFilterBar.test.ts` (new)** — covers the filter combine logic (engineering-spec rows #7–#10): level toggles, case-insensitive substring search against `raw`, endpoint filter, and combined AND semantics.

## Out of scope (deferred to later slices)
- `LogsTab.svelte` rewrite — Slice D.
- Endpoint click-to-filter / cross-link to Servers tab — Slice B.
- Tool-call inline card rendering + "Tool calls only" toggle — Slice C.

## Verification
From `packages/desktop`:
- `pnpm install` — clean
- `pnpm test` — 397 passed, 24 skipped (22 files)
- `pnpm check` — 0 errors, 1 pre-existing unrelated warning (`Cannot find type definition file for 'node'`)
- `pnpm build` — succeeds
- `grep -rn "RelayLogLine" packages/desktop/src` — no hits

## Spec
- Task note: Slice A.2 — Wire parser into store/listener + rewrite RelayLogs with filter bar
- Engineering spec §2.1 (structured rendering), §2.2 (filter bar), §2.6 (timestamp display)
- Tests cover spec rows #7, #8, #9, #10
