### PR TITLE
feat(logs): endpoint column polish (click-to-filter + color stripe + cross-link)

### DIFF
--- a/src/lib/components/RelayLogs.svelte
+++ b/src/lib/components/RelayLogs.svelte
@@ -3,11 +3,21 @@
   import { relayLogLines, activeTopLevelTab } from '$lib/stores';
   import type { LogLevel, ParsedLogLine } from '$lib/logParser';
   import { isAtBottom } from '$lib/scrollUtils';
+  import { endpointStripeStyle } from '$lib/endpointColor';
   import LogFilterBar from './LogFilterBar.svelte';
+  import { toggleEndpointFilter } from './relay-logs-helpers';
+
+  type Props = {
+    ongotoendpoint?: (name: string) => void;
+  };
+  let { ongotoendpoint }: Props = $props();
 
   let scrollContainer: HTMLDivElement | undefined = $state();
   let autoScroll = $state(true);
   let isTabSwitching = $state(false);
+
+  // Right-click "Go to endpoint" context menu state. `null` = no menu open.
+  let contextMenu = $state<{ x: number; y: number; endpoint: string } | null>(null);
 
   // Filter state — local, not persisted (engineering spec §2.2).
   let activeLevels = $state<Set<LogLevel>>(new Set(['error', 'warn', 'info', 'debug', 'trace']));
@@ -131,6 +141,39 @@
   });
 
   const trimmedSearch = $derived(searchText.trim());
+
+  function onEndpointClick(name: string) {
+    selectedEndpoints = toggleEndpointFilter(selectedEndpoints, name);
+  }
+
+  function onEndpointContextMenu(event: MouseEvent, name: string) {
+    event.preventDefault();
+    contextMenu = { x: event.clientX, y: event.clientY, endpoint: name };
+  }
+
+  function closeContextMenu() {
+    contextMenu = null;
+  }
+
+  function onGoToEndpoint(name: string) {
+    closeContextMenu();
+    ongotoendpoint?.(name);
+  }
+
+  // Close the context menu on any outside click or Escape.
+  $effect(() => {
+    if (!contextMenu) return;
+    const onDown = () => closeContextMenu();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeContextMenu();
+    };
+    window.addEventListener('mousedown', onDown);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('mousedown', onDown);
+      window.removeEventListener('keydown', onKey);
+    };
+  });
 </script>
 
 <div class="h-full flex flex-col">
@@ -163,15 +206,28 @@
     {:else}
       {#each filteredLines as line (line)}
         {@const segs = highlightSegments(line.message || line.raw, trimmedSearch)}
-        <div class="grid grid-cols-[auto_4rem_8rem_1fr] gap-3 px-3 py-0.5 hover:bg-(--surface-hover) items-baseline">
+        {@const isActive = !!line.endpoint && selectedEndpoints.size === 1 && selectedEndpoints.has(line.endpoint)}
+        <div
+          class="grid grid-cols-[auto_4rem_8rem_1fr] gap-3 pl-2 pr-3 py-0.5 hover:bg-(--surface-hover) items-baseline"
+          style={endpointStripeStyle(line.endpoint)}
+        >
           <span
             class="text-(--fg3) select-none tabular-nums"
             title={`${line.timestamp.toISOString()} · ${formatRelative(line.timestamp, now)}`}
           >{formatHMS(line.timestamp)}</span>
           <span class="pill {levelPillClass(line.level)}">{line.level.toUpperCase()}</span>
-          <span class="truncate text-(--fg2)" title={line.endpoint ?? ''}>
-            {line.endpoint ?? '──'}
-          </span>
+          {#if line.endpoint}
+            <button
+              type="button"
+              class="truncate text-left text-(--fg2) hover:text-(--accent) hover:underline cursor-pointer {isActive ? 'text-(--accent) font-medium' : ''}"
+              title={`${line.endpoint} — click to filter, right-click for actions`}
+              aria-pressed={isActive}
+              onclick={() => onEndpointClick(line.endpoint!)}
+              oncontextmenu={(e) => onEndpointContextMenu(e, line.endpoint!)}
+            >{line.endpoint}</button>
+          {:else}
+            <span class="truncate text-(--fg3)" title="Relay-level event">──</span>
+          {/if}
           <span class="whitespace-pre-wrap break-all">
             {#each segs as seg}
               {#if seg.match}<mark class="bg-(--accent)/20 text-(--fg1)">{seg.text}</mark>{:else}{seg.text}{/if}
@@ -181,4 +237,24 @@
       {/each}
     {/if}
   </div>
+
+  {#if contextMenu}
+    <ul
+      role="menu"
+      class="fixed z-20 min-w-[10rem] rounded-md border border-(--border) bg-(--surface) shadow-lg text-sm py-1"
+      style:left="{contextMenu.x}px"
+      style:top="{contextMenu.y}px"
+    >
+      <li role="none">
+        <button
+          type="button"
+          role="menuitem"
+          class="w-full text-left px-3 py-1.5 hover:bg-(--surface-hover)"
+          onclick={() => onGoToEndpoint(contextMenu!.endpoint)}
+        >
+          Go to endpoint
+        </button>
+      </li>
+    </ul>
+  {/if}
 </div>

--- a/src/lib/components/RelayLogs.test.ts
+++ b/src/lib/components/RelayLogs.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+
+import { selectedEndpoint, activeTopLevelTab } from '$lib/stores';
+import { applyGoToEndpoint, toggleEndpointFilter } from './relay-logs-helpers';
+
+// Engineering spec §5 — Slice B test rows #11 (click-to-filter) and #13
+// (cross-link to Servers tab). Exercised against the pure helpers extracted
+// from `RelayLogs.svelte` so they can run in the Node test env.
+
+describe('toggleEndpointFilter (test #11 — click-to-filter)', () => {
+  it('activates the endpoint filter when the row is currently "All"', () => {
+    const next = toggleEndpointFilter(new Set(), 'github');
+    expect(next).toEqual(new Set(['github']));
+  });
+
+  it('clears back to "All" when the only active filter is the clicked endpoint', () => {
+    const next = toggleEndpointFilter(new Set(['github']), 'github');
+    expect(next.size).toBe(0);
+  });
+
+  it('replaces a different active filter with the clicked endpoint', () => {
+    const next = toggleEndpointFilter(new Set(['slack']), 'github');
+    expect(next).toEqual(new Set(['github']));
+  });
+
+  it('replaces a multi-endpoint filter with just the clicked endpoint', () => {
+    const next = toggleEndpointFilter(new Set(['slack', 'gmail']), 'github');
+    expect(next).toEqual(new Set(['github']));
+  });
+
+  it('returns a fresh Set so reactive consumers see a new reference', () => {
+    const current = new Set(['slack']);
+    const next = toggleEndpointFilter(current, 'github');
+    expect(next).not.toBe(current);
+    expect(current).toEqual(new Set(['slack']));
+  });
+});
+
+describe('applyGoToEndpoint (test #13 — cross-link to Servers tab)', () => {
+  beforeEach(() => {
+    selectedEndpoint.set(null);
+    activeTopLevelTab.set('relay-logs');
+  });
+
+  it('selects the endpoint and switches to the Servers tab', () => {
+    applyGoToEndpoint('github');
+    expect(get(selectedEndpoint)).toBe('github');
+    expect(get(activeTopLevelTab)).toBe('servers');
+  });
+
+  it('overwrites a previously selected endpoint', () => {
+    selectedEndpoint.set('slack');
+    applyGoToEndpoint('github');
+    expect(get(selectedEndpoint)).toBe('github');
+    expect(get(activeTopLevelTab)).toBe('servers');
+  });
+
+  it('still switches to Servers when the tab was already active', () => {
+    activeTopLevelTab.set('servers');
+    applyGoToEndpoint('postgres');
+    expect(get(activeTopLevelTab)).toBe('servers');
+    expect(get(selectedEndpoint)).toBe('postgres');
+  });
+});

--- a/src/lib/components/relay-logs-helpers.ts
+++ b/src/lib/components/relay-logs-helpers.ts
@@ -1,0 +1,36 @@
+import { activeTopLevelTab, selectedEndpoint } from '$lib/stores';
+
+/**
+ * Helpers for the relay log view endpoint affordances (Slice B,
+ * engineering spec §2.4). Extracted as pure functions so they can be unit
+ * tested in the Node test env without spinning up a Svelte runtime.
+ */
+
+/**
+ * Click-to-filter toggle for the endpoint column.
+ *
+ * Behaviour (spec §2.4):
+ *  - If the filter is already exactly `{name}` → clear back to "All" (empty).
+ *  - Otherwise → replace whatever's selected with just `{name}`.
+ *
+ * Always returns a fresh Set so reactive consumers see a new reference.
+ */
+export function toggleEndpointFilter(
+  current: ReadonlySet<string>,
+  name: string,
+): Set<string> {
+  if (current.size === 1 && current.has(name)) return new Set();
+  return new Set([name]);
+}
+
+/**
+ * Cross-link side effect for the right-click "Go to endpoint" menu item.
+ *
+ * Sets the global stores so the Servers tab opens with that endpoint
+ * selected. The `+page.svelte` handler wraps this in `requestNavigation`
+ * so the shared unsaved-changes guard runs first.
+ */
+export function applyGoToEndpoint(name: string): void {
+  selectedEndpoint.set(name);
+  activeTopLevelTab.set('servers');
+}

--- a/src/lib/endpointColor.test.ts
+++ b/src/lib/endpointColor.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { endpointHue, endpointStripeStyle } from './endpointColor';
+
+// Engineering spec §5 row #12 — endpoint color stripe is consistent for the
+// same endpoint name across renders.
+describe('endpointHue', () => {
+  it('is deterministic for the same input', () => {
+    expect(endpointHue('github')).toBe(endpointHue('github'));
+    expect(endpointHue('postgres')).toBe(endpointHue('postgres'));
+    expect(endpointHue('a-very-long-endpoint-name-with-dashes')).toBe(
+      endpointHue('a-very-long-endpoint-name-with-dashes'),
+    );
+  });
+
+  it('returns a value in [0, 360)', () => {
+    for (const name of ['github', 'slack', 'gmail', 'postgres', '', 'x']) {
+      const hue = endpointHue(name);
+      expect(hue).toBeGreaterThanOrEqual(0);
+      expect(hue).toBeLessThan(360);
+      expect(Number.isInteger(hue)).toBe(true);
+    }
+  });
+
+  it('produces different hues for typical distinct endpoint names', () => {
+    // Not a strict requirement of FNV-1a, but a sanity check that we aren't
+    // collapsing common names to the same hue.
+    const names = ['github', 'slack', 'gmail', 'postgres', 'notion'];
+    const hues = new Set(names.map(endpointHue));
+    expect(hues.size).toBeGreaterThan(1);
+  });
+});
+
+describe('endpointStripeStyle', () => {
+  it('returns a transparent stripe when name is missing', () => {
+    expect(endpointStripeStyle(undefined)).toBe('border-left: 2px solid transparent;');
+    expect(endpointStripeStyle(null)).toBe('border-left: 2px solid transparent;');
+    expect(endpointStripeStyle('')).toBe('border-left: 2px solid transparent;');
+  });
+
+  it('renders a 2px hsl stripe using the endpoint hue', () => {
+    const style = endpointStripeStyle('github');
+    expect(style).toBe(`border-left: 2px solid hsl(${endpointHue('github')}, 65%, 55%);`);
+  });
+
+  it('is stable across calls (same name → same style string)', () => {
+    expect(endpointStripeStyle('github')).toBe(endpointStripeStyle('github'));
+    expect(endpointStripeStyle('postgres')).toBe(endpointStripeStyle('postgres'));
+  });
+});

--- a/src/lib/endpointColor.ts
+++ b/src/lib/endpointColor.ts
@@ -1,0 +1,40 @@
+/**
+ * Deterministic endpoint → color helpers used by the relay log view (Slice B,
+ * engineering spec §2.4). Same endpoint name always yields the same hue so the
+ * 2px left stripe on a log row is stable across page reloads, app restarts,
+ * and component re-renders — no random per-session colors.
+ *
+ * Pure helpers, no DOM access. Tested in `endpointColor.test.ts`.
+ */
+
+const FNV_OFFSET_32 = 0x811c9dc5;
+const FNV_PRIME_32 = 0x01000193;
+
+/** FNV-1a 32-bit hash. Pure, branch-free, stable across runs. */
+function fnv1a(input: string): number {
+  let h = FNV_OFFSET_32;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, FNV_PRIME_32);
+  }
+  return h >>> 0;
+}
+
+/**
+ * Map an endpoint name to a hue in [0, 360). Deterministic — `endpointHue(x)`
+ * always returns the same value for the same `x`.
+ */
+export function endpointHue(name: string): number {
+  return fnv1a(name) % 360;
+}
+
+/**
+ * Inline CSS for the 2px left stripe on a log row. Returns a transparent
+ * stripe when the row has no endpoint context (relay-level events) so the
+ * grid layout stays aligned across rows.
+ */
+export function endpointStripeStyle(name: string | null | undefined): string {
+  if (!name) return 'border-left: 2px solid transparent;';
+  const hue = endpointHue(name);
+  return `border-left: 2px solid hsl(${hue}, 65%, 55%);`;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -17,6 +17,7 @@
   } from '$lib/stores/unsavedChangesGuard';
   import { getEndpoints, getOAuthStatus } from '$lib/api';
   import { initRelayLogListener } from '$lib/logListener';
+  import { applyGoToEndpoint } from '$lib/components/relay-logs-helpers';
   import { getActiveTopLevelTab, getVisibleTopLevelTabs, shouldShowRelayStartupFailure, shouldSkipEndpointPolling } from '$lib/relaySidecarUi';
   import { invoke } from '@tauri-apps/api/core';
   import { get } from 'svelte/store';
@@ -159,6 +160,10 @@
     });
   }
 
+  function handleGoToEndpoint(name: string) {
+    requestNavigation(() => applyGoToEndpoint(name));
+  }
+
   async function handleRetryRelay() {
     if (retryingRelay) return;
 
@@ -288,7 +293,7 @@
         <UnifiedCatalog />
       </div>
       <div class="h-full" style:display={$activeTopLevelTab === 'relay-logs' ? 'block' : 'none'}>
-        <RelayLogs />
+        <RelayLogs ongotoendpoint={handleGoToEndpoint} />
       </div>
       <div class="h-full" style:display={$activeTopLevelTab === 'settings' ? 'block' : 'none'}>
         <Settings />


### PR DESCRIPTION
Slice B of the desktop log overhaul (engineering spec §2.4). Builds on the
structured 4-column rows shipped in Slices A.1 + A.2 (#90, #91).

## Changes

- **Click-to-filter**: the endpoint name in each log row is now a button.
  Left-click toggles the endpoint filter to that endpoint, or clears back
  to "All" if it was already the only active filter. Active row is
  highlighted in the accent color.
- **2px left color stripe**: each row gets a stable left border whose hue
  comes from a deterministic FNV-1a hash of the endpoint name
  (`src/lib/endpointColor.ts`). Same name → same hue across reloads /
  app restarts. Relay-level events (no endpoint) get a transparent
  stripe so the column grid stays aligned.
- **Right-click "Go to endpoint"**: opens a single-item context menu;
  selecting it dispatches a callback that the page component handles by
  switching to the Servers tab and selecting that endpoint (routed
  through the existing `requestNavigation` unsaved-changes guard).

## Tests

Engineering spec §5 Slice B rows:

- `#11` — click-to-filter toggle behaviour (`RelayLogs.test.ts`).
- `#12` — endpoint color stripe stability (`endpointColor.test.ts`).
- `#13` — cross-link to Servers tab (`RelayLogs.test.ts`).

All run in the existing Node test env via pure helpers
(`src/lib/components/relay-logs-helpers.ts`).

## Verification

```
cd packages/desktop
pnpm install
pnpm test    # 411 passed
pnpm check   # 0 errors
pnpm build   # ok
```

## Out of scope

- Tool-call row UI is Slice C.
- `LogsTab` changes are Slice D.
