### PR TITLE
feat(logs): tool-call event highlighting

### DIFF
--- a/src/lib/components/LogFilterBar.svelte
+++ b/src/lib/components/LogFilterBar.svelte
@@ -11,6 +11,7 @@
     activeLevels: Set<LogLevel>;
     selectedEndpoints: Set<string>;
     searchText: string;
+    toolCallsOnly: boolean;
     onclear: () => void;
   };
 
@@ -20,6 +21,7 @@
     activeLevels = $bindable(),
     selectedEndpoints = $bindable(),
     searchText = $bindable(),
+    toolCallsOnly = $bindable(),
     onclear,
   }: Props = $props();
 
@@ -50,6 +52,12 @@
     const set = new Set<string>();
     for (const line of lines) if (line.endpoint) set.add(line.endpoint);
     return Array.from(set).sort();
+  });
+
+  const toolCallCount = $derived.by(() => {
+    let n = 0;
+    for (const line of lines) if (line.isToolCall) n++;
+    return n;
   });
 
   function toggleLevel(level: LogLevel) {
@@ -94,6 +102,18 @@
         {level.toUpperCase()} ({levelCounts[level]})
       </button>
     {/each}
+
+    <button
+      type="button"
+      class="pill border transition-colors {toolCallsOnly
+        ? 'border-(--accent) bg-(--accent)/10 text-(--accent)'
+        : 'border-(--border) text-(--fg3) bg-transparent'}"
+      aria-pressed={toolCallsOnly}
+      title="Show only tool-call events"
+      onclick={() => (toolCallsOnly = !toolCallsOnly)}
+    >
+      ⚡ Tool calls only ({toolCallCount})
+    </button>
 
     <div class="ml-auto relative">
       <button

--- a/src/lib/components/LogFilterBar.test.ts
+++ b/src/lib/components/LogFilterBar.test.ts
@@ -11,13 +11,16 @@ interface LogFilterState {
   activeLevels: Set<LogLevel>;
   searchText: string;
   selectedEndpoints: Set<string>; // empty = "All"
+  toolCallsOnly?: boolean;
 }
 
 function applyLogFilters(lines: ParsedLogLine[], state: LogFilterState): ParsedLogLine[] {
   const q = state.searchText.trim().toLowerCase();
   const hasEndpointFilter = state.selectedEndpoints.size > 0;
+  const toolCallsOnly = state.toolCallsOnly === true;
   return lines.filter((line) => {
     if (!state.activeLevels.has(line.level)) return false;
+    if (toolCallsOnly && !line.isToolCall) return false;
     if (hasEndpointFilter) {
       if (!line.endpoint || !state.selectedEndpoints.has(line.endpoint)) return false;
     }
@@ -147,5 +150,49 @@ describe('applyLogFilters', () => {
       selectedEndpoints: new Set(['github']),
     });
     expect(noMatch).toHaveLength(0);
+  });
+
+  // #16 — "Tool calls only" filter shows only isToolCall === true lines, and
+  // AND-combines with the existing level / search / endpoint filters.
+  it('"Tool calls only" toggle restricts to isToolCall lines and AND-combines', () => {
+    const lines = makeSampleLines();
+
+    // toolCallsOnly = false (default) keeps every line that the level filter allows.
+    const allWhenOff = applyLogFilters(lines, {
+      activeLevels: ALL_LEVELS,
+      searchText: '',
+      selectedEndpoints: new Set(),
+      toolCallsOnly: false,
+    });
+    expect(allWhenOff).toHaveLength(lines.length);
+
+    // toolCallsOnly = true keeps only the single Tool-call completed line.
+    const onlyToolCalls = applyLogFilters(lines, {
+      activeLevels: ALL_LEVELS,
+      searchText: '',
+      selectedEndpoints: new Set(),
+      toolCallsOnly: true,
+    });
+    expect(onlyToolCalls).toHaveLength(1);
+    expect(onlyToolCalls[0].isToolCall).toBe(true);
+    expect(onlyToolCalls[0].tool).toBe('get_file_contents');
+
+    // AND-combine with level/endpoint: turning off INFO drops the only tool call.
+    const noInfoToolCalls = applyLogFilters(lines, {
+      activeLevels: new Set<LogLevel>(['error', 'warn', 'debug', 'trace']),
+      searchText: '',
+      selectedEndpoints: new Set(),
+      toolCallsOnly: true,
+    });
+    expect(noInfoToolCalls).toHaveLength(0);
+
+    // AND-combine with endpoint: restricting to slack drops the github tool call.
+    const slackToolCalls = applyLogFilters(lines, {
+      activeLevels: ALL_LEVELS,
+      searchText: '',
+      selectedEndpoints: new Set(['slack']),
+      toolCallsOnly: true,
+    });
+    expect(slackToolCalls).toHaveLength(0);
   });
 });

--- a/src/lib/components/RelayLogs.svelte
+++ b/src/lib/components/RelayLogs.svelte
@@ -5,6 +5,7 @@
   import { isAtBottom } from '$lib/scrollUtils';
   import { endpointStripeStyle } from '$lib/endpointColor';
   import LogFilterBar from './LogFilterBar.svelte';
+  import ToolCallRow from './ToolCallRow.svelte';
   import { toggleEndpointFilter } from './relay-logs-helpers';
 
   type Props = {
@@ -23,6 +24,7 @@
   let activeLevels = $state<Set<LogLevel>>(new Set(['error', 'warn', 'info', 'debug', 'trace']));
   let selectedEndpoints = $state<Set<string>>(new Set());
   let searchText = $state('');
+  let toolCallsOnly = $state(false);
 
   // Hover tooltip clock — ticks every second only while this tab is visible
   // so we don't keep firing $effect updates in the background (spec §2.6).
@@ -38,6 +40,7 @@
     const hasEndpointFilter = selectedEndpoints.size > 0;
     return $relayLogLines.filter((line) => {
       if (!activeLevels.has(line.level)) return false;
+      if (toolCallsOnly && !line.isToolCall) return false;
       if (hasEndpointFilter) {
         if (!line.endpoint || !selectedEndpoints.has(line.endpoint)) return false;
       }
@@ -183,6 +186,7 @@
     bind:activeLevels
     bind:selectedEndpoints
     bind:searchText
+    bind:toolCallsOnly
     onclear={clearLogs}
   />
   <div class="px-4 py-1 border-b border-(--border) bg-(--hd-bg) flex items-center justify-end">
@@ -228,11 +232,15 @@
           {:else}
             <span class="truncate text-(--fg3)" title="Relay-level event">──</span>
           {/if}
-          <span class="whitespace-pre-wrap break-all">
-            {#each segs as seg}
-              {#if seg.match}<mark class="bg-(--accent)/20 text-(--fg1)">{seg.text}</mark>{:else}{seg.text}{/if}
-            {/each}
-          </span>
+          {#if line.isToolCall}
+            <ToolCallRow {line} />
+          {:else}
+            <span class="whitespace-pre-wrap break-all">
+              {#each segs as seg}
+                {#if seg.match}<mark class="bg-(--accent)/20 text-(--fg1)">{seg.text}</mark>{:else}{seg.text}{/if}
+              {/each}
+            </span>
+          {/if}
         </div>
       {/each}
     {/if}

--- a/src/lib/components/ToolCallRow.svelte
+++ b/src/lib/components/ToolCallRow.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import type { ParsedLogLine } from '$lib/logParser';
+  import {
+    durationColorClass,
+    statusIcon,
+    statusIconClass,
+    toolCallErrorSuffix,
+    formatDurationMs,
+  } from './tool-call-row-helpers';
+
+  type Props = {
+    line: ParsedLogLine;
+  };
+  let { line }: Props = $props();
+
+  const durationClass = $derived(durationColorClass(line.durationMs));
+  const durationLabel = $derived(formatDurationMs(line.durationMs));
+  const icon = $derived(statusIcon(line.status));
+  const iconClass = $derived(statusIconClass(line.status));
+  const errSuffix = $derived(toolCallErrorSuffix(line));
+</script>
+
+<span class="inline-flex items-baseline gap-2 min-w-0 w-full" data-testid="tool-call-row">
+  <span class="select-none" aria-hidden="true">⚡</span>
+  <span class="font-mono font-semibold text-(--fg1) truncate" data-testid="tool-name">
+    {line.tool ?? ''}
+  </span>
+  {#if durationLabel}
+    <span
+      class="ml-auto tabular-nums {durationClass}"
+      data-testid="tool-duration"
+      data-duration-bucket={(line.durationMs ?? 0) < 200
+        ? 'normal'
+        : (line.durationMs ?? 0) <= 1000
+          ? 'degraded'
+          : 'offline'}
+    >{durationLabel}</span>
+  {/if}
+  <span class={iconClass} data-testid="tool-status" aria-label={line.status === 'ok' ? 'ok' : 'error'}>
+    {icon}
+  </span>
+  {#if errSuffix}
+    <span
+      class="text-(--fg3) truncate"
+      data-testid="tool-error-suffix"
+      title={line.raw}
+    >{errSuffix}</span>
+  {/if}
+</span>

--- a/src/lib/components/ToolCallRow.test.ts
+++ b/src/lib/components/ToolCallRow.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+
+import { parseLogLine } from '$lib/logParser';
+import type { ParsedLogLine } from '$lib/logParser';
+import {
+  durationColorClass,
+  statusIcon,
+  statusIconClass,
+  toolCallErrorSuffix,
+  formatDurationMs,
+  ERROR_SUFFIX_MAX_LEN,
+} from './tool-call-row-helpers';
+
+// Engineering spec §5 — Slice C test rows #14–#17. The test env is Node
+// (vitest.config.ts), so we exercise the pure helpers extracted from
+// `ToolCallRow.svelte` rather than mounting the Svelte component — same
+// pattern used elsewhere in this folder (LogFilterBar.test.ts,
+// relay-logs-helpers.ts, etc).
+
+function toolCallLine(opts: {
+  tool: string;
+  status: 'ok' | 'error';
+  durationMs: number;
+  errorText?: string;
+}): ParsedLogLine {
+  const verb = opts.status === 'ok' ? 'completed' : 'failed';
+  const trailer = opts.errorText ? ' ' + opts.errorText : '';
+  return parseLogLine(
+    opts.status === 'ok' ? 'info' : 'warn',
+    `endpoint{endpoint=github}: Tool call ${verb} tool=${opts.tool} status=${opts.status} duration_ms=${opts.durationMs}${trailer}`
+  );
+}
+
+// #14 — Tool-call events render with tool name, duration badge, and status icon.
+describe('ToolCallRow — fields (test #14)', () => {
+  it('exposes tool name, duration label, and status icon for a successful call', () => {
+    const line = toolCallLine({ tool: 'get_file_contents', status: 'ok', durationMs: 312 });
+    expect(line.isToolCall).toBe(true);
+    expect(line.tool).toBe('get_file_contents');
+    expect(formatDurationMs(line.durationMs)).toBe('312ms');
+    expect(statusIcon(line.status)).toBe('✓');
+  });
+
+  it('exposes tool name, duration label, and status icon for a failed call', () => {
+    const line = toolCallLine({
+      tool: 'send_message',
+      status: 'error',
+      durationMs: 1204,
+      errorText: 'timeout',
+    });
+    expect(line.isToolCall).toBe(true);
+    expect(line.tool).toBe('send_message');
+    expect(formatDurationMs(line.durationMs)).toBe('1204ms');
+    expect(statusIcon(line.status)).toBe('✗');
+  });
+
+  it('returns an empty duration label when duration is missing', () => {
+    expect(formatDurationMs(undefined)).toBe('');
+    expect(formatDurationMs(Number.NaN)).toBe('');
+  });
+});
+
+// #15 — Duration badge color: <200ms = normal, 200-1000ms = yellow, >1000ms = red.
+describe('ToolCallRow — duration thresholds (test #15)', () => {
+  it('treats sub-200ms calls as normal', () => {
+    expect(durationColorClass(0)).toBe('text-(--fg2)');
+    expect(durationColorClass(50)).toBe('text-(--fg2)');
+    expect(durationColorClass(199)).toBe('text-(--fg2)');
+  });
+
+  it('treats 200–1000ms calls as degraded (yellow)', () => {
+    expect(durationColorClass(200)).toBe('text-(--degraded)');
+    expect(durationColorClass(500)).toBe('text-(--degraded)');
+    expect(durationColorClass(1000)).toBe('text-(--degraded)');
+  });
+
+  it('treats >1000ms calls as offline (red)', () => {
+    expect(durationColorClass(1001)).toBe('text-(--offline)');
+    expect(durationColorClass(5000)).toBe('text-(--offline)');
+  });
+
+  it('falls back to normal when duration is missing', () => {
+    expect(durationColorClass(undefined)).toBe('text-(--fg2)');
+    expect(durationColorClass(Number.NaN)).toBe('text-(--fg2)');
+  });
+});
+
+// #16 — covered alongside the rest of LogFilterBar.test.ts; here we only
+// double-check the status-icon color mapping that the spec calls out.
+describe('ToolCallRow — status icon color', () => {
+  it('shows ✓ in the healthy color for ok', () => {
+    expect(statusIcon('ok')).toBe('✓');
+    expect(statusIconClass('ok')).toBe('text-(--healthy)');
+  });
+
+  it('shows ✗ in the offline color for any non-ok status', () => {
+    expect(statusIcon('error')).toBe('✗');
+    expect(statusIconClass('error')).toBe('text-(--offline)');
+    expect(statusIcon('timeout')).toBe('✗');
+    expect(statusIconClass('timeout')).toBe('text-(--offline)');
+  });
+});
+
+// #17 — Error tool calls show truncated error message.
+describe('ToolCallRow — error suffix (test #17)', () => {
+  it('returns null for a successful call', () => {
+    const line = toolCallLine({ tool: 'foo', status: 'ok', durationMs: 50 });
+    expect(toolCallErrorSuffix(line)).toBeNull();
+  });
+
+  it('returns the error text after stripping the "Tool call failed" prefix', () => {
+    const line = toolCallLine({
+      tool: 'send_message',
+      status: 'error',
+      durationMs: 1204,
+      errorText: 'connection refused',
+    });
+    expect(toolCallErrorSuffix(line)).toBe('connection refused');
+  });
+
+  it('returns null when the failed line has no extra error text', () => {
+    const line = toolCallLine({ tool: 'send_message', status: 'error', durationMs: 1204 });
+    expect(toolCallErrorSuffix(line)).toBeNull();
+  });
+
+  it('truncates very long error messages with an ellipsis', () => {
+    const errorText = 'x'.repeat(ERROR_SUFFIX_MAX_LEN + 50);
+    const line = toolCallLine({
+      tool: 'send_message',
+      status: 'error',
+      durationMs: 500,
+      errorText,
+    });
+    const suffix = toolCallErrorSuffix(line);
+    expect(suffix).not.toBeNull();
+    expect(suffix!.length).toBe(ERROR_SUFFIX_MAX_LEN);
+    expect(suffix!.endsWith('…')).toBe(true);
+  });
+});

--- a/src/lib/components/tool-call-row-helpers.ts
+++ b/src/lib/components/tool-call-row-helpers.ts
@@ -1,0 +1,47 @@
+import type { ParsedLogLine } from '$lib/logParser';
+
+// Pure helpers extracted from `ToolCallRow.svelte` so the duration-threshold
+// colors, status icon mapping, and error-suffix truncation can be unit-tested
+// without spinning up a Svelte runtime (the desktop test env is Node, not
+// jsdom). Engineering spec §2.5 + tests #14–#17.
+
+// Threshold buckets from spec §2.5:
+//   <200ms = normal, 200–1000ms = degraded, >1000ms = offline.
+export function durationColorClass(durationMs: number | undefined): string {
+  if (durationMs === undefined || Number.isNaN(durationMs)) return 'text-(--fg2)';
+  if (durationMs < 200) return 'text-(--fg2)';
+  if (durationMs <= 1000) return 'text-(--degraded)';
+  return 'text-(--offline)';
+}
+
+export function statusIcon(status: string | undefined): '✓' | '✗' {
+  return status === 'ok' ? '✓' : '✗';
+}
+
+export function statusIconClass(status: string | undefined): string {
+  return status === 'ok' ? 'text-(--healthy)' : 'text-(--offline)';
+}
+
+// Max characters we surface in the inline error suffix. Anything longer is
+// truncated with an ellipsis — the full message is still available via the
+// row's hover tooltip on `raw`.
+export const ERROR_SUFFIX_MAX_LEN = 80;
+
+// Derive the truncated error message shown after the ✗ icon on failed tool
+// calls. The parser strips `key=value` pairs out of the message text, so on
+// a `Tool call failed tool=foo status=error duration_ms=42 connection refused`
+// line `line.message` ends up as "Tool call failed connection refused"; we
+// trim the "Tool call failed/completed" prefix and return what remains.
+// Returns null when the call succeeded or there is no extra text to show.
+export function toolCallErrorSuffix(line: ParsedLogLine): string | null {
+  if (!line.status || line.status === 'ok') return null;
+  const rest = line.message.replace(/^Tool call (failed|completed)\s*/i, '').trim();
+  if (rest.length === 0) return null;
+  if (rest.length <= ERROR_SUFFIX_MAX_LEN) return rest;
+  return rest.slice(0, ERROR_SUFFIX_MAX_LEN - 1) + '…';
+}
+
+export function formatDurationMs(durationMs: number | undefined): string {
+  if (durationMs === undefined || Number.isNaN(durationMs)) return '';
+  return `${durationMs}ms`;
+}


### PR DESCRIPTION
Slice C of the desktop log overhaul (engineering spec §2.5, tests #14–#17). Builds on Waves 1 + 2 already on `main`.

## What's in this PR

- **NEW** `src/lib/components/ToolCallRow.svelte` — compact inline card for tool-call events:
  - ⚡ icon + monospaced bold tool name
  - Right-aligned duration badge, color-coded via the spec's thresholds: `<200ms` → `text-(--fg2)`, `200–1000ms` → `text-(--degraded)`, `>1000ms` → `text-(--offline)`
  - ✓ / ✗ status icon (`text-(--healthy)` / `text-(--offline)`)
  - Truncated error suffix on failure (80-char cap with ellipsis)
- **NEW** `src/lib/components/tool-call-row-helpers.ts` — pure helpers extracted so the duration thresholds, status mapping, and error-suffix truncation are unit-testable in the Node vitest env (matches the existing `relay-logs-helpers.ts` pattern).
- **NEW** `src/lib/components/ToolCallRow.test.ts` — engineering spec tests #14 (renders fields), #15 (duration thresholds), #17 (error suffix).
- **MOD** `src/lib/components/RelayLogs.svelte` — when `line.isToolCall`, render `<ToolCallRow {line} />` in the message column instead of the plain message text. Timestamp/level/endpoint columns untouched. New `toolCallsOnly` state AND-combined into the `$derived` filter.
- **MOD** `src/lib/components/LogFilterBar.svelte` — adds a "⚡ Tool calls only (N)" pill toggle with bindable `toolCallsOnly` prop and a live tool-call count.
- **MOD** `src/lib/components/LogFilterBar.test.ts` — adds the test #16 assertion (`toolCallsOnly` filter restricts to `isToolCall` lines and AND-combines with level / endpoint).

No parser changes — `isToolCall` is already set by `logParser.ts` from Slice A.1. No `LogsTab.svelte` changes (that's Slice D).

## Verification

```
cd packages/desktop
pnpm install && pnpm test && pnpm check && pnpm build
```

All green:
- `pnpm test` → 425 passed, 24 skipped (25 files)
- `pnpm check` → 0 errors, 1 pre-existing node-typedef warning
- `pnpm build` → success
