### PR TITLE
feat(sidecar): emit endpoint on relay-log events

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1126,6 +1126,7 @@ dependencies = [
  "objc2",
  "objc2-app-kit",
  "objc2-web-kit",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,6 +34,7 @@ urlencoding = "2.1.3"
 hyper = { version = "1", features = ["client", "http1"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 http-body-util = "0.1"
+regex = "1.12.3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.4"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3299,3 +3299,71 @@ mod js_execution_mode_tests {
         assert_eq!(args[0].as_str(), Some("hi"));
     }
 }
+
+#[cfg(test)]
+mod parse_endpoint_from_span_tests {
+    //! Coverage for [`parse_endpoint_from_span`] — the helper that lifts the
+    //! endpoint name out of the relay's compact-format tracing span so each
+    //! `relay-log` Tauri event carries an authoritative `endpoint` field.
+    //!
+    //! Corresponds to engineering spec §5 test rows #18 (endpoint present in
+    //! span) and #19 (relay-level event with no span yields `None`).
+
+    use super::*;
+
+    #[test]
+    fn endpoint_present_in_span_returns_some() {
+        // Spec §5 test #18 — typical tool-call event with span context.
+        let line = "2026-05-20T10:00:00.000Z  INFO endpoint{endpoint=github transport=stdio}: Tool call completed";
+        assert_eq!(
+            parse_endpoint_from_span(line),
+            Some("github".to_string()),
+            "endpoint name should be extracted from endpoint{{endpoint=NAME ...}} span"
+        );
+    }
+
+    #[test]
+    fn no_span_returns_none() {
+        // Spec §5 test #19 — relay-level event with no endpoint span.
+        let line = "2026-05-20T10:00:00.000Z  INFO Relay listening on 127.0.0.1:47107";
+        assert_eq!(
+            parse_endpoint_from_span(line),
+            None,
+            "lines without an endpoint{{...}} span must yield None"
+        );
+    }
+
+    #[test]
+    fn nested_request_and_endpoint_spans_still_extract_endpoint() {
+        // Compact format with multiple span scopes (request{...} endpoint{...}).
+        let line = "2026-05-20T10:00:00.000Z  INFO request{method=tools/call id=42} endpoint{endpoint=gmail transport=stdio}: handled";
+        assert_eq!(parse_endpoint_from_span(line), Some("gmail".to_string()),);
+    }
+
+    #[test]
+    fn quoted_endpoint_name_is_unquoted() {
+        // The relay does not quote endpoint names today, but if it ever did
+        // (e.g. names with spaces), the leading/trailing `"` should be trimmed
+        // to keep the parsed value usable as a key.
+        let line = "endpoint{endpoint=\"slack-prod\" transport=http}: connected";
+        assert_eq!(
+            parse_endpoint_from_span(line),
+            Some("slack-prod".to_string()),
+        );
+    }
+
+    #[test]
+    fn empty_endpoint_field_returns_none() {
+        // Defensive: a malformed `endpoint{endpoint=}` should not produce an
+        // empty-string endpoint that the front-end might display as a row.
+        let line = "endpoint{endpoint= transport=stdio}: weird";
+        assert_eq!(parse_endpoint_from_span(line), None);
+    }
+
+    #[test]
+    fn endpoint_at_end_of_span_closing_brace() {
+        // Endpoint field with no trailing space — terminator is the `}`.
+        let line = "endpoint{endpoint=postgres}: ready";
+        assert_eq!(parse_endpoint_from_span(line), Some("postgres".to_string()),);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -246,6 +246,28 @@ fn strip_ansi(s: &str) -> String {
     result
 }
 
+/// Extract the endpoint name from the relay's compact-format tracing span
+/// (e.g. `endpoint{endpoint=github transport=stdio}: Initialize handshake ...`).
+///
+/// Returns `Some("github")` when the span is present and `None` for
+/// relay-level events that have no `endpoint{...}` span. The match mirrors the
+/// front-end `SPAN_RE` parser: the field value runs from after the `=` up to
+/// the next space or closing brace and is not unquoted (the relay never quotes
+/// the endpoint name in compact format), but a leading `"` is trimmed so a
+/// hypothetical `endpoint{endpoint="my name"}` still yields a plausible token.
+fn parse_endpoint_from_span(line: &str) -> Option<String> {
+    use std::sync::OnceLock;
+    static RE: OnceLock<regex::Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        regex::Regex::new(r"endpoint\{endpoint=([^ }]+)")
+            .expect("parse_endpoint_from_span regex is valid")
+    });
+    re.captures(line)
+        .and_then(|c| c.get(1))
+        .map(|m| m.as_str().trim_matches('"').to_string())
+        .filter(|s| !s.is_empty())
+}
+
 /// Return the path to config.toml in the appropriate data directory
 /// (`~/.endara-dev/config.toml` in dev mode, `~/.endara/config.toml` in production).
 fn config_path() -> Result<std::path::PathBuf, String> {
@@ -376,6 +398,14 @@ pub struct RelayStatusInfo {
 pub struct RelayLogPayload {
     pub level: String,
     pub message: String,
+    /// Endpoint name extracted from the compact-format tracing span
+    /// (`endpoint{endpoint=NAME ...}`), or `None` for relay-level events with
+    /// no span context. Populated by [`parse_endpoint_from_span`] during
+    /// stdout/stderr capture so downstream consumers (live `relay-log` events
+    /// and the buffered-logs fetch) see the same authoritative value.
+    /// Serialized as JSON `null` (not omitted) when absent so the desktop
+    /// front-end can rely on the field being present on every event.
+    pub endpoint: Option<String>,
 }
 
 #[derive(Serialize, Clone)]
@@ -883,6 +913,7 @@ async fn spawn_relay(
             match event {
                 CommandEvent::Stdout(line) => {
                     let text = strip_ansi(&String::from_utf8_lossy(&line));
+                    let endpoint = parse_endpoint_from_span(&text);
                     // Detect successful startup from stdout
                     if text.contains("MCP server running") {
                         emit_sidecar_status(&app_handle, "running", None).await;
@@ -892,6 +923,7 @@ async fn spawn_relay(
                         buf.push(RelayLogPayload {
                             level: "info".to_string(),
                             message: text.clone(),
+                            endpoint: endpoint.clone(),
                         });
                         let len = buf.len();
                         if len > 5000 {
@@ -903,6 +935,7 @@ async fn spawn_relay(
                         RelayLogPayload {
                             level: "info".to_string(),
                             message: text,
+                            endpoint,
                         },
                     );
                 }
@@ -915,6 +948,7 @@ async fn spawn_relay(
                     } else {
                         "info"
                     };
+                    let endpoint = parse_endpoint_from_span(&text);
                     // Detect successful startup from stderr (tracing outputs to stderr)
                     if text.contains("MCP server running") {
                         emit_sidecar_status(&app_handle, "running", None).await;
@@ -924,6 +958,7 @@ async fn spawn_relay(
                         buf.push(RelayLogPayload {
                             level: level.to_string(),
                             message: text.clone(),
+                            endpoint: endpoint.clone(),
                         });
                         let len = buf.len();
                         if len > 5000 {
@@ -935,6 +970,7 @@ async fn spawn_relay(
                         RelayLogPayload {
                             level: level.to_string(),
                             message: text.clone(),
+                            endpoint,
                         },
                     );
                     // Emit relay-health event for ERROR lines


### PR DESCRIPTION
Slice D.1 of the desktop log overhaul — the only Rust-side change in this
overhaul. Extends the `relay-log` Tauri event payload with an
authoritative `endpoint: Option<String>` field lifted from the relay's
compact-format tracing span (`endpoint{endpoint=NAME ...}`).

## Changes

- **`RelayLogPayload`** gains `endpoint: Option<String>`. Serialized as
  JSON `null` (not omitted) when absent so the desktop front-end can
  rely on the field being present on every event.
- **`parse_endpoint_from_span(line: &str) -> Option<String>`** new helper.
  Uses a lazily-initialized `regex::Regex` with the pattern
  `endpoint\{endpoint=([^ }]+)` — the same shape the desktop front-end
  parser's `SPAN_RE` extracts. Trims a leading `"` so a hypothetical
  quoted name still yields a usable token; returns `None` for empty
  matches.
- **Sidecar capture loop** invokes the helper on both stdout and stderr
  branches AND when pushing into the `log_buffer` used by
  `get_buffered_relay_logs`, so live `relay-log` events and the
  buffered-logs fetch see the same value.
- **`regex = "1.12.3"`** added to `src-tauri/Cargo.toml` via `cargo add`.

## Tests

New `parse_endpoint_from_span_tests` module covers spec §5 rows:

- **#18** — endpoint present in span returns `Some("github")`.
- **#19** — relay-level event with no span returns `None`.

Plus edge cases: nested `request{}/endpoint{}` spans, quoted endpoint
names, malformed empty endpoint fields, and endpoint values terminated
by the span's closing brace.

## Backward compatibility

The payload change is additive — older TypeScript code consuming
`relay-log` events ignores unknown fields, so the desktop UI continues
to work until Slice D.2 lands the front-end consumer.

## Scope

- Only `packages/desktop/src-tauri/` (Rust). The TypeScript side that
  consumes the new field is Slice D.2.
- No changes to `packages/relay` (the Rust submodule is untouched per
  the overall plan).

## Verification

```
cd src-tauri
cargo fmt --check
cargo clippy --all-targets -- -D warnings
cargo test
```

All 50 unit tests pass locally, including the 6 new ones.
