### PR TITLE
feat(logs): live-streaming per-endpoint Logs tab + shared LogRow

### DIFF
--- a/src/lib/components/LogRow.svelte
+++ b/src/lib/components/LogRow.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+  import type { LogLevel, ParsedLogLine } from '$lib/logParser';
+  import { endpointStripeStyle } from '$lib/endpointColor';
+  import ToolCallRow from './ToolCallRow.svelte';
+
+  // Pure presentation row shared by RelayLogs.svelte and LogsTab.svelte
+  // (engineering spec §2.3 — extract once both consumers exist). Visual
+  // output must stay byte-identical to the inlined row that previously
+  // lived in RelayLogs.svelte.
+
+  type Props = {
+    line: ParsedLogLine;
+    /** When set, the endpoint button reflects "this row is the active filter". */
+    isActiveEndpoint?: boolean;
+    /** Search query for substring highlighting inside the message column. */
+    searchQuery?: string;
+    /** Tick value (ms) for the hover tooltip's "Ns ago" relative time. */
+    nowMs?: number;
+    /** Click handler for the endpoint name. Omit to render a non-interactive label. */
+    onEndpointClick?: (name: string) => void;
+    /** Right-click handler for the endpoint name (context menu). */
+    onEndpointContextMenu?: (event: MouseEvent, name: string) => void;
+  };
+
+  let {
+    line,
+    isActiveEndpoint = false,
+    searchQuery = '',
+    nowMs,
+    onEndpointClick,
+    onEndpointContextMenu,
+  }: Props = $props();
+
+  const trimmedQuery = $derived(searchQuery.trim());
+
+  function formatHMS(d: Date): string {
+    return d.toLocaleTimeString(undefined, { hour12: false });
+  }
+
+  function formatRelative(d: Date, ms: number): string {
+    const diff = Math.max(0, Math.floor((ms - d.getTime()) / 1000));
+    if (diff < 60) return `${diff}s ago`;
+    if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+    return `${Math.floor(diff / 3600)}h ago`;
+  }
+
+  function levelPillClass(level: LogLevel): string {
+    switch (level) {
+      case 'error': return 'bg-(--offline)/10 text-(--offline)';
+      case 'warn': return 'bg-(--degraded)/10 text-(--degraded)';
+      case 'info': return 'text-(--fg2)';
+      case 'debug':
+      case 'trace': return 'text-(--fg3)';
+    }
+  }
+
+  // Split the message around the search term so the matching substring can be
+  // highlighted in the rendered row (case-insensitive, first occurrence only).
+  function highlightSegments(text: string, query: string): Array<{ text: string; match: boolean }> {
+    if (!query) return [{ text, match: false }];
+    const lower = text.toLowerCase();
+    const q = query.toLowerCase();
+    const idx = lower.indexOf(q);
+    if (idx === -1) return [{ text, match: false }];
+    return [
+      { text: text.slice(0, idx), match: false },
+      { text: text.slice(idx, idx + q.length), match: true },
+      { text: text.slice(idx + q.length), match: false },
+    ];
+  }
+
+  const segments = $derived(highlightSegments(line.message || line.raw, trimmedQuery));
+  const timestampTitle = $derived(
+    nowMs !== undefined
+      ? `${line.timestamp.toISOString()} · ${formatRelative(line.timestamp, nowMs)}`
+      : line.timestamp.toISOString(),
+  );
+</script>
+
+<div
+  class="grid grid-cols-[auto_4rem_8rem_1fr] gap-3 pl-2 pr-3 py-0.5 hover:bg-(--surface-hover) items-baseline"
+  style={endpointStripeStyle(line.endpoint)}
+  data-testid="log-row"
+>
+  <span
+    class="text-(--fg3) select-none tabular-nums"
+    title={timestampTitle}
+  >{formatHMS(line.timestamp)}</span>
+  <span class="pill {levelPillClass(line.level)}">{line.level.toUpperCase()}</span>
+  {#if line.endpoint}
+    {#if onEndpointClick || onEndpointContextMenu}
+      <button
+        type="button"
+        class="truncate text-left text-(--fg2) hover:text-(--accent) hover:underline cursor-pointer {isActiveEndpoint ? 'text-(--accent) font-medium' : ''}"
+        title={`${line.endpoint} — click to filter, right-click for actions`}
+        aria-pressed={isActiveEndpoint}
+        onclick={() => onEndpointClick?.(line.endpoint!)}
+        oncontextmenu={(e) => onEndpointContextMenu?.(e, line.endpoint!)}
+      >{line.endpoint}</button>
+    {:else}
+      <span class="truncate text-(--fg2)" title={line.endpoint}>{line.endpoint}</span>
+    {/if}
+  {:else}
+    <span class="truncate text-(--fg3)" title="Relay-level event">──</span>
+  {/if}
+  {#if line.isToolCall}
+    <ToolCallRow {line} />
+  {:else}
+    <span class="whitespace-pre-wrap break-all">
+      {#each segments as seg}
+        {#if seg.match}<mark class="bg-(--accent)/20 text-(--fg1)">{seg.text}</mark>{:else}{seg.text}{/if}
+      {/each}
+    </span>
+  {/if}
+</div>

--- a/src/lib/components/LogsTab.svelte
+++ b/src/lib/components/LogsTab.svelte
@@ -1,19 +1,54 @@
 <script lang="ts">
-  import { selectedEndpoint } from '$lib/stores';
+  import { tick } from 'svelte';
+  import { selectedEndpoint, relayLogLines, activeTab } from '$lib/stores';
   import { getEndpointLogs } from '$lib/api';
+  import { isAtBottom } from '$lib/scrollUtils';
+  import type { ParsedLogLine } from '$lib/logParser';
+  import LogRow from './LogRow.svelte';
+  import {
+    parseHistoricalSeed,
+    mergeDeduped,
+    filterLinesForEndpoint,
+  } from './logs-tab-helpers';
 
+  // Live-streaming per-endpoint log view (engineering spec §2.3, Slice D.2).
+  // Seeds with a one-shot fetch of the relay's in-memory ring for pre-mount
+  // history, then appends every matching `relay-log` event in real time.
+  // Display = historical ++ live, deduped by `raw` so an overlap doesn't
+  // double up.
 
-  let lines: string[] = $state([]);
+  let historical: ParsedLogLine[] = $state([]);
   let loading = $state(true);
   let scrollContainer: HTMLDivElement | undefined = $state();
+  let autoScroll = $state(true);
+  let isTabSwitching = $state(false);
+  let now = $state(Date.now());
 
+  // Hover-tooltip clock — same pattern as RelayLogs.svelte; only ticks while
+  // this tab is the active detail-panel tab to avoid background work.
+  $effect(() => {
+    if ($activeTab !== 'logs') return;
+    const id = setInterval(() => (now = Date.now()), 1000);
+    return () => clearInterval(id);
+  });
+
+  // (Re)seed historical lines whenever the selected endpoint changes. The
+  // dependency on `$selectedEndpoint` is what re-runs this effect.
   $effect(() => {
     const name = $selectedEndpoint;
-    if (!name) return;
+    if (!name) {
+      historical = [];
+      loading = false;
+      return;
+    }
     loading = true;
     getEndpointLogs(name)
-      .then((data) => { lines = data.lines; })
-      .catch(() => { lines = []; })
+      .then((data) => {
+        historical = parseHistoricalSeed(data.lines ?? [], name);
+      })
+      .catch(() => {
+        historical = [];
+      })
       .finally(() => {
         loading = false;
         requestAnimationFrame(() => {
@@ -23,30 +58,107 @@
         });
       });
   });
+
+  const liveLines = $derived.by(() => {
+    const name = $selectedEndpoint;
+    if (!name) return [] as ParsedLogLine[];
+    return filterLinesForEndpoint($relayLogLines, name);
+  });
+
+  const displayLines = $derived(mergeDeduped(historical, liveLines));
+
+  function handleScroll() {
+    if (!scrollContainer || isTabSwitching) return;
+    const { scrollTop, scrollHeight, clientHeight } = scrollContainer;
+    autoScroll = isAtBottom(scrollTop, scrollHeight, clientHeight);
+  }
+
+  async function scrollToBottom() {
+    if (!autoScroll) return;
+    await tick();
+    requestAnimationFrame(() => {
+      if (scrollContainer && autoScroll) {
+        scrollContainer.scrollTop = scrollContainer.scrollHeight;
+      }
+    });
+  }
+
+  function goToEnd() {
+    autoScroll = true;
+    tick().then(() => {
+      requestAnimationFrame(() => {
+        if (scrollContainer) {
+          scrollContainer.scrollTop = scrollContainer.scrollHeight;
+        }
+      });
+    });
+  }
+
+  // Clear empties the historical seed; live events keep streaming in for as
+  // long as this endpoint stays selected (matches the spec wording — the
+  // live filter "keeps appending").
+  function clearLogs() {
+    historical = [];
+  }
+
+  // Auto-scroll when new lines arrive.
+  $effect(() => {
+    displayLines;
+    scrollToBottom();
+  });
+
+  // Force scroll when the user re-opens the Logs tab.
+  $effect(() => {
+    const tab = $activeTab;
+    if (tab === 'logs' && autoScroll && scrollContainer) {
+      isTabSwitching = true;
+      const timer = setTimeout(() => {
+        if (scrollContainer) {
+          scrollContainer.scrollTop = scrollContainer.scrollHeight;
+        }
+        requestAnimationFrame(() => {
+          isTabSwitching = false;
+        });
+      }, 50);
+      return () => {
+        clearTimeout(timer);
+        isTabSwitching = false;
+      };
+    }
+  });
 </script>
 
 <div class="h-full flex flex-col">
   <div class="px-4 py-2 border-b border-(--border) flex items-center justify-between bg-(--hd-bg)">
-    <span class="text-xs text-(--fg3)">{lines.length} lines</span>
+    <span class="text-xs text-(--fg3)">{displayLines.length} lines</span>
+    <div class="flex items-center gap-2">
+      {#if !autoScroll}
+        <button class="btn-sec btn-sm" onclick={goToEnd}>Go to end</button>
+      {/if}
+      <button
+        class="btn-sec btn-sm"
+        onclick={clearLogs}
+        disabled={historical.length === 0}
+      >Clear</button>
+    </div>
   </div>
   <div
     bind:this={scrollContainer}
-    class="flex-1 overflow-y-auto p-4 t-mono-log bg-(--surface-sunken)"
+    onscroll={handleScroll}
+    class="flex-1 overflow-y-auto t-mono-log bg-(--surface-sunken)"
   >
     {#if loading}
-      <div class="space-y-1">
+      <div class="space-y-1 p-4">
         {#each [1, 2, 3, 4, 5] as _}
           <div class="h-4 w-3/4 rounded bg-(--surface-hover) animate-pulse"></div>
         {/each}
       </div>
+    {:else if displayLines.length === 0}
+      <div class="text-(--fg3) text-center py-6">No logs available</div>
     {:else}
-      {#each lines as line, i}
-        <div class="hover:bg-(--surface-hover) px-1 rounded whitespace-pre-wrap break-all">{line}</div>
+      {#each displayLines as line (line)}
+        <LogRow {line} nowMs={now} />
       {/each}
-      {#if lines.length === 0}
-        <div class="text-(--fg3) text-center py-6">No logs available</div>
-      {/if}
     {/if}
   </div>
 </div>
-

--- a/src/lib/components/RelayLogs.svelte
+++ b/src/lib/components/RelayLogs.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
   import { tick } from 'svelte';
   import { relayLogLines, activeTopLevelTab } from '$lib/stores';
-  import type { LogLevel, ParsedLogLine } from '$lib/logParser';
+  import type { LogLevel } from '$lib/logParser';
   import { isAtBottom } from '$lib/scrollUtils';
-  import { endpointStripeStyle } from '$lib/endpointColor';
   import LogFilterBar from './LogFilterBar.svelte';
-  import ToolCallRow from './ToolCallRow.svelte';
+  import LogRow from './LogRow.svelte';
   import { toggleEndpointFilter } from './relay-logs-helpers';
 
   type Props = {
@@ -78,42 +77,6 @@
 
   function clearLogs() {
     relayLogLines.set([]);
-  }
-
-  function formatHMS(d: Date): string {
-    return d.toLocaleTimeString(undefined, { hour12: false });
-  }
-
-  function formatRelative(d: Date, nowMs: number): string {
-    const diff = Math.max(0, Math.floor((nowMs - d.getTime()) / 1000));
-    if (diff < 60) return `${diff}s ago`;
-    if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
-    return `${Math.floor(diff / 3600)}h ago`;
-  }
-
-  function levelPillClass(level: LogLevel): string {
-    switch (level) {
-      case 'error': return 'bg-(--offline)/10 text-(--offline)';
-      case 'warn': return 'bg-(--degraded)/10 text-(--degraded)';
-      case 'info': return 'text-(--fg2)';
-      case 'debug':
-      case 'trace': return 'text-(--fg3)';
-    }
-  }
-
-  // Split the message around the search term so the matching substring can be
-  // highlighted in the rendered row (case-insensitive, first occurrence only).
-  function highlightSegments(text: string, query: string): Array<{ text: string; match: boolean }> {
-    if (!query) return [{ text, match: false }];
-    const lower = text.toLowerCase();
-    const q = query.toLowerCase();
-    const idx = lower.indexOf(q);
-    if (idx === -1) return [{ text, match: false }];
-    return [
-      { text: text.slice(0, idx), match: false },
-      { text: text.slice(idx, idx + q.length), match: true },
-      { text: text.slice(idx + q.length), match: false },
-    ];
   }
 
   // Auto-scroll when new lines arrive (subscribe to filtered list so toggling
@@ -209,39 +172,15 @@
       </div>
     {:else}
       {#each filteredLines as line (line)}
-        {@const segs = highlightSegments(line.message || line.raw, trimmedSearch)}
         {@const isActive = !!line.endpoint && selectedEndpoints.size === 1 && selectedEndpoints.has(line.endpoint)}
-        <div
-          class="grid grid-cols-[auto_4rem_8rem_1fr] gap-3 pl-2 pr-3 py-0.5 hover:bg-(--surface-hover) items-baseline"
-          style={endpointStripeStyle(line.endpoint)}
-        >
-          <span
-            class="text-(--fg3) select-none tabular-nums"
-            title={`${line.timestamp.toISOString()} · ${formatRelative(line.timestamp, now)}`}
-          >{formatHMS(line.timestamp)}</span>
-          <span class="pill {levelPillClass(line.level)}">{line.level.toUpperCase()}</span>
-          {#if line.endpoint}
-            <button
-              type="button"
-              class="truncate text-left text-(--fg2) hover:text-(--accent) hover:underline cursor-pointer {isActive ? 'text-(--accent) font-medium' : ''}"
-              title={`${line.endpoint} — click to filter, right-click for actions`}
-              aria-pressed={isActive}
-              onclick={() => onEndpointClick(line.endpoint!)}
-              oncontextmenu={(e) => onEndpointContextMenu(e, line.endpoint!)}
-            >{line.endpoint}</button>
-          {:else}
-            <span class="truncate text-(--fg3)" title="Relay-level event">──</span>
-          {/if}
-          {#if line.isToolCall}
-            <ToolCallRow {line} />
-          {:else}
-            <span class="whitespace-pre-wrap break-all">
-              {#each segs as seg}
-                {#if seg.match}<mark class="bg-(--accent)/20 text-(--fg1)">{seg.text}</mark>{:else}{seg.text}{/if}
-              {/each}
-            </span>
-          {/if}
-        </div>
+        <LogRow
+          {line}
+          isActiveEndpoint={isActive}
+          searchQuery={trimmedSearch}
+          nowMs={now}
+          onEndpointClick={onEndpointClick}
+          onEndpointContextMenu={onEndpointContextMenu}
+        />
       {/each}
     {/if}
   </div>

--- a/src/lib/components/logs-tab-helpers.test.ts
+++ b/src/lib/components/logs-tab-helpers.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+
+import { parseLogLine } from '$lib/logParser';
+import type { ParsedLogLine } from '$lib/logParser';
+import {
+  parseHistoricalSeed,
+  mergeDeduped,
+  filterLinesForEndpoint,
+} from './logs-tab-helpers';
+
+// Engineering spec §5 — Slice D.2 test rows #20, #21, #22, #23. The desktop
+// test env is Node (vitest.config.ts), so we exercise the pure helpers that
+// back `LogsTab.svelte` and assert structural-identity by sharing the same
+// `ParsedLogLine` data path that `LogRow.svelte` consumes in both views —
+// mirrors the relay-logs-helpers / tool-call-row-helpers pattern used by
+// every other component in this folder.
+
+function liveLine(opts: { endpoint: string | undefined; raw: string; level?: string }): ParsedLogLine {
+  const msg = opts.endpoint
+    ? `endpoint{endpoint=${opts.endpoint}}: ${opts.raw}`
+    : opts.raw;
+  return parseLogLine(opts.level ?? 'info', msg);
+}
+
+// #20 — LogsTab shows live-updating lines matching the selected endpoint.
+describe('filterLinesForEndpoint (test #20 — live updates per endpoint)', () => {
+  it('keeps only lines whose endpoint matches the selection', () => {
+    const stream = [
+      liveLine({ endpoint: 'github', raw: 'one' }),
+      liveLine({ endpoint: 'slack', raw: 'two' }),
+      liveLine({ endpoint: 'github', raw: 'three' }),
+      liveLine({ endpoint: undefined, raw: 'relay-level' }),
+    ];
+    const filtered = filterLinesForEndpoint(stream, 'github');
+    expect(filtered.map((l) => l.message)).toEqual(['one', 'three']);
+  });
+
+  it('returns an empty list when no live line matches', () => {
+    const stream = [liveLine({ endpoint: 'slack', raw: 'noise' })];
+    expect(filterLinesForEndpoint(stream, 'github')).toEqual([]);
+  });
+
+  it('reflects new lines appended to the live stream without re-fetching', () => {
+    // The "no re-fetch" semantic in production is enforced by the store
+    // subscription; here we model that by appending to the same array and
+    // re-running the filter — the consumer sees the new line on next tick.
+    const stream: ParsedLogLine[] = [liveLine({ endpoint: 'github', raw: 'first' })];
+    expect(filterLinesForEndpoint(stream, 'github')).toHaveLength(1);
+    stream.push(liveLine({ endpoint: 'github', raw: 'second' }));
+    const next = filterLinesForEndpoint(stream, 'github');
+    expect(next).toHaveLength(2);
+    expect(next[1].message).toBe('second');
+  });
+});
+
+// #21 — LogsTab prepends historical lines from one-shot API fetch.
+describe('parseHistoricalSeed + mergeDeduped (test #21 — historical seed prepended)', () => {
+  it('parses raw historical strings using the endpoint override', () => {
+    const seed = parseHistoricalSeed(
+      ['Initialize handshake complete', 'Tool call completed tool=foo status=ok duration_ms=5'],
+      'github',
+    );
+    expect(seed).toHaveLength(2);
+    expect(seed[0].endpoint).toBe('github');
+    expect(seed[0].message).toBe('Initialize handshake complete');
+    expect(seed[1].endpoint).toBe('github');
+    expect(seed[1].isToolCall).toBe(true);
+  });
+
+  it('puts historical seed before live lines in the merged view', () => {
+    const seed = parseHistoricalSeed(['old-1', 'old-2'], 'github');
+    const live = [liveLine({ endpoint: 'github', raw: 'new-1' })];
+    const merged = mergeDeduped(seed, live);
+    expect(merged.map((l) => l.message)).toEqual(['old-1', 'old-2', 'new-1']);
+  });
+});
+
+// #22 — Dedupe: overlap between historical + live doesn't produce duplicates.
+describe('mergeDeduped (test #22 — dedupe by raw)', () => {
+  it('suppresses live lines that already appear in the historical seed', () => {
+    // The relay's ring buffer may include the same line that the live event
+    // channel re-emits. The historical line keeps its slot at the top and the
+    // duplicate live line is dropped.
+    const sharedRaw = 'endpoint{endpoint=github}: Tool call completed tool=foo status=ok duration_ms=5';
+    const seedLines = parseHistoricalSeed([sharedRaw], 'github');
+    const liveDuplicate = parseLogLine('info', sharedRaw);
+    const liveNew = liveLine({ endpoint: 'github', raw: 'fresh' });
+
+    const merged = mergeDeduped(seedLines, [liveDuplicate, liveNew]);
+
+    expect(merged).toHaveLength(2);
+    expect(merged[0]).toBe(seedLines[0]);
+    expect(merged[1].message).toBe('fresh');
+  });
+
+  it('keeps the first occurrence when the historical seed itself has duplicates', () => {
+    const seed = parseHistoricalSeed(['same', 'same', 'different'], 'github');
+    const merged = mergeDeduped(seed, []);
+    expect(merged.map((l) => l.message)).toEqual(['same', 'different']);
+  });
+
+  it('drops duplicate live lines even when no historical seed exists', () => {
+    const a = liveLine({ endpoint: 'github', raw: 'one' });
+    const b = parseLogLine(a.level, a.raw); // same raw, fresh instance
+    expect(mergeDeduped([], [a, b])).toHaveLength(1);
+  });
+});
+
+// #23 — LogRow renders identically in RelayLogs and LogsTab for the same
+// ParsedLogLine. Both consumers feed `<LogRow line={...} />` with the same
+// `ParsedLogLine` payload, so identity is established by showing that:
+//   (a) the helpers RelayLogs uses to build a row's input (the raw store
+//       value) and the helpers LogsTab uses (parseHistoricalSeed + filter)
+//       produce the same canonical `ParsedLogLine` for a shared raw string;
+//   (b) consequently both views pass an identically-shaped object into the
+//       same `LogRow.svelte` component, which is the only place a row is
+//       rendered after this slice.
+describe('LogRow structural identity across RelayLogs + LogsTab (test #23)', () => {
+  it('feeds the shared LogRow with byte-equivalent ParsedLogLine fields', () => {
+    const raw = 'endpoint{endpoint=github}: Tool call completed tool=get_file_contents status=ok duration_ms=312';
+
+    // RelayLogs path: the line lands in the global store after the listener
+    // calls parseLogLine on the Tauri payload — modeled here directly.
+    const relayLogsLine = parseLogLine('info', raw, { endpointOverride: 'github' });
+
+    // LogsTab path: same raw string surfaces either via the live filter (also
+    // parseLogLine in logListener.ts) or via parseHistoricalSeed.
+    const liveLineForTab = parseLogLine('info', raw, { endpointOverride: 'github' });
+    const seedLineForTab = parseHistoricalSeed([raw], 'github')[0];
+
+    const fields = (l: ParsedLogLine) => ({
+      level: l.level,
+      endpoint: l.endpoint,
+      transport: l.transport,
+      serverType: l.serverType,
+      method: l.method,
+      requestId: l.requestId,
+      tool: l.tool,
+      status: l.status,
+      durationMs: l.durationMs,
+      message: l.message,
+      raw: l.raw,
+      isToolCall: l.isToolCall,
+    });
+
+    expect(fields(liveLineForTab)).toEqual(fields(relayLogsLine));
+    expect(fields(seedLineForTab)).toEqual(fields(relayLogsLine));
+  });
+});

--- a/src/lib/components/logs-tab-helpers.ts
+++ b/src/lib/components/logs-tab-helpers.ts
@@ -1,0 +1,67 @@
+import { parseLogLine, type ParsedLogLine } from '$lib/logParser';
+
+/**
+ * Pure helpers backing `LogsTab.svelte`'s live-streaming view (engineering
+ * spec §2.3 / Slice D.2). Extracted as plain functions so they can be
+ * exercised in the Node test env — the rest of the desktop test suite
+ * follows the same pattern (relay-logs-helpers, tool-call-row-helpers,
+ * sidebar-helpers, ...).
+ */
+
+/**
+ * Parse the historical lines returned by `GET /api/endpoints/{name}/logs`
+ * into `ParsedLogLine` records. The one-shot API hands us raw strings with
+ * no level field, so we default to 'info' and let `parseLogLine` infer the
+ * relay-side level when the message itself includes one. The endpoint name
+ * is supplied as the authoritative override since the historical response
+ * is already scoped to a single endpoint.
+ */
+export function parseHistoricalSeed(
+  rawLines: readonly string[],
+  endpointName: string,
+): ParsedLogLine[] {
+  return rawLines.map((raw) =>
+    parseLogLine('info', raw, { endpointOverride: endpointName }),
+  );
+}
+
+/**
+ * Merge the historical seed with the live-filtered tail, suppressing
+ * duplicate rows that may appear in both lists when the desktop subscribes
+ * to the event stream while the relay's in-memory ring still buffers the
+ * same lines. Dedup key is the original `raw` string — cheap, stable, and
+ * matches the spec's "Set check on raw" semantics.
+ *
+ * The first occurrence wins so the historical lines keep their position at
+ * the top of the merged view.
+ */
+export function mergeDeduped(
+  historical: readonly ParsedLogLine[],
+  live: readonly ParsedLogLine[],
+): ParsedLogLine[] {
+  const seen = new Set<string>();
+  const out: ParsedLogLine[] = [];
+  for (const line of historical) {
+    if (seen.has(line.raw)) continue;
+    seen.add(line.raw);
+    out.push(line);
+  }
+  for (const line of live) {
+    if (seen.has(line.raw)) continue;
+    seen.add(line.raw);
+    out.push(line);
+  }
+  return out;
+}
+
+/**
+ * Filter the global relay log stream down to lines belonging to a specific
+ * endpoint. Defined here (instead of inlined in LogsTab.svelte) so the
+ * live-streaming behaviour can be unit tested without mounting Svelte.
+ */
+export function filterLinesForEndpoint(
+  lines: readonly ParsedLogLine[],
+  endpointName: string,
+): ParsedLogLine[] {
+  return lines.filter((line) => line.endpoint === endpointName);
+}

--- a/src/lib/logListener.ts
+++ b/src/lib/logListener.ts
@@ -25,8 +25,10 @@ export async function initRelayLogListener() {
   initialized = true;
 
   const listenerRegistrations = [
-    listen<{ level: string; message: string }>('relay-log', (event) => {
-    const line = parseLogLine(event.payload.level || 'info', event.payload.message);
+    listen<{ level: string; message: string; endpoint?: string | null }>('relay-log', (event) => {
+    const line = parseLogLine(event.payload.level || 'info', event.payload.message, {
+      endpointOverride: event.payload.endpoint,
+    });
     relayLogLines.update((lines) => {
       const updated = [...lines, line];
       return updated.length > 5000 ? updated.slice(-5000) : updated;
@@ -53,9 +55,11 @@ export async function initRelayLogListener() {
 
   // Replay any buffered logs that arrived before the listener was ready
   try {
-    const buffered = await invoke<Array<{ level: string; message: string }>>('get_buffered_relay_logs');
+    const buffered = await invoke<Array<{ level: string; message: string; endpoint?: string | null }>>('get_buffered_relay_logs');
     if (buffered && buffered.length > 0) {
-      const lines = buffered.map((entry) => parseLogLine(entry.level || 'info', entry.message));
+      const lines = buffered.map((entry) =>
+        parseLogLine(entry.level || 'info', entry.message, { endpointOverride: entry.endpoint }),
+      );
       relayLogLines.update(existing => {
         const merged = [...lines, ...existing];
         return merged.length > 5000 ? merged.slice(-5000) : merged;

--- a/src/lib/logParser.test.ts
+++ b/src/lib/logParser.test.ts
@@ -107,6 +107,42 @@ describe('parseLogLine', () => {
   });
 });
 
+describe('parseLogLine — endpointOverride (Slice D.2)', () => {
+  it('uses the override when provided, ignoring the parsed span value', () => {
+    const parsed = parseLogLine(
+      'info',
+      'endpoint{endpoint=github transport=stdio}: hello',
+      { endpointOverride: 'gmail' },
+    );
+    expect(parsed.endpoint).toBe('gmail');
+    // span-level fields beyond endpoint still come from the regex
+    expect(parsed.transport).toBe('stdio');
+  });
+
+  it('falls back to the parsed value when override is null', () => {
+    const parsed = parseLogLine(
+      'info',
+      'endpoint{endpoint=github}: hello',
+      { endpointOverride: null },
+    );
+    expect(parsed.endpoint).toBe('github');
+  });
+
+  it('falls back to the parsed value when override is undefined', () => {
+    const parsed = parseLogLine(
+      'info',
+      'endpoint{endpoint=github}: hello',
+      { endpointOverride: undefined },
+    );
+    expect(parsed.endpoint).toBe('github');
+  });
+
+  it('supplies the endpoint when the message has no span context', () => {
+    const parsed = parseLogLine('info', 'plain message', { endpointOverride: 'slack' });
+    expect(parsed.endpoint).toBe('slack');
+  });
+});
+
 describe('extractTimestamp', () => {
   it('parses an ISO timestamp prefix and returns the rest of the message', () => {
     const { timestamp, rest } = extractTimestamp(

--- a/src/lib/logParser.ts
+++ b/src/lib/logParser.ts
@@ -45,7 +45,21 @@ function normalizeLevel(level: string): LogLevel {
   return 'info';
 }
 
-export function parseLogLine(level: string, message: string): ParsedLogLine {
+export interface ParseLogLineOptions {
+  /**
+   * Authoritative endpoint name supplied by the Rust sidecar (Slice D). When
+   * non-null/undefined, overrides whatever the regex extracts from the span
+   * context — the Rust side reads the same tracing span and knows the
+   * canonical value even when the formatted message is ambiguous.
+   */
+  endpointOverride?: string | null;
+}
+
+export function parseLogLine(
+  level: string,
+  message: string,
+  options?: ParseLogLineOptions,
+): ParsedLogLine {
   const { timestamp, rest } = extractTimestamp(message);
 
   const spans: Record<string, Record<string, string>> = {};
@@ -86,10 +100,16 @@ export function parseLogLine(level: string, message: string): ParsedLogLine {
         cleanedMessage.includes('Tool call failed'))) ||
     (status !== undefined && durationMs !== undefined && !Number.isNaN(durationMs));
 
+  const parsedEndpoint = spans.endpoint?.endpoint;
+  const endpoint =
+    options?.endpointOverride !== undefined && options.endpointOverride !== null
+      ? options.endpointOverride
+      : parsedEndpoint;
+
   return {
     timestamp,
     level: normalizeLevel(level),
-    endpoint: spans.endpoint?.endpoint,
+    endpoint,
     transport: spans.endpoint?.transport,
     serverType: spans.endpoint?.server_type,
     method: spans.request?.method,


### PR DESCRIPTION
## Summary

Final slice (D.2) of the desktop log overhaul. Converts the per-endpoint **Logs** tab from a one-shot fetch into a live stream filtered out of the global `relayLogLines` store, and extracts a shared `LogRow.svelte` so the two views render byte-identically.

Stacks on top of A.1 (parser), A.2 (store/listener/RelayLogs + filter bar), B (endpoint polish), C (tool-call highlighting), and D.1 (Rust payload extension, `a62d567`).

## Changes

Three scoped commits:

1. **`feat(logs): pass authoritative endpoint from Tauri payload into parseLogLine`** — adds an optional `endpointOverride` to `parseLogLine` and threads the new Rust-side `endpoint` field (D.1) through `logListener.ts` for both the live event handler and the `get_buffered_relay_logs` replay.
2. **`refactor(logs): extract shared LogRow component`** — pulls the row layout (timestamp / level pill / endpoint chip / message-or-`ToolCallRow`) out of `RelayLogs.svelte` into `LogRow.svelte`. Same DOM, same Tailwind classes, same `endpointStripeStyle` — visual-no-op refactor.
3. **`feat(logs): live-streaming LogsTab with historical seed`** — rewrites `LogsTab.svelte`:
   - On mount / `$selectedEndpoint` change, seeds historical lines via `parseHistoricalSeed(getEndpointLogs(...).lines, name)` (uses the new override to tag every line with the right endpoint).
   - `$derived` live view = `relayLogLines` filtered by endpoint, then merged with the seed and **deduped by `raw`** so the relay's in-memory ring overlap with the live event channel doesn't double up.
   - Renders with `<LogRow />` so rows are identical to the global view.
   - Auto-scroll, "Go to end", and Clear (clears the seed only; the live filter keeps appending).

Pure helpers live in `src/lib/components/logs-tab-helpers.ts`, matching the `relay-logs-helpers` / `tool-call-row-helpers` pattern in this folder.

## Tests

- `src/lib/logParser.test.ts` — 4 new cases for `endpointOverride` (override wins, null/undefined fallback, message-with-no-span path).
- `src/lib/components/logs-tab-helpers.test.ts` — covers spec §5 tests **#20** (live filter per endpoint), **#21** (historical seed prepended), **#22** (dedupe by `raw`), and **#23** (structural identity of the `ParsedLogLine` passed into `<LogRow />` across both views).

Full suite: **438 passed / 24 skipped**, `pnpm check` clean (the one pre-existing `Cannot find type definition file for 'node'` warning is unrelated), `pnpm build` green.

Acceptance criterion #11 (no `RelayLogLine` identifier left in `src/`) verified: `grep -rn RelayLogLine src` → no matches.

## Verification

```
cd packages/desktop
pnpm install
pnpm test       # 438 passed
pnpm check      # 0 errors
pnpm build      # ok
```
