### PR TITLE
fix(logs): extract level from line text + distinct per-level colors

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -268,6 +268,42 @@ fn parse_endpoint_from_span(line: &str) -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
+/// Extract the tracing level token from a relay compact-format log line.
+///
+/// The relay's stdout/stderr emits lines whose level token (`ERROR` / `WARN` /
+/// `INFO` / `DEBUG` / `TRACE`) appears as a whole word right after the ISO
+/// timestamp prefix, with one or two spaces of padding (compact format
+/// right-aligns the level). The regex anchors near the start of the line so it
+/// will not return `Some` just because the message body happens to contain the
+/// English word "error".
+///
+/// Returns the lowercased static level string (`"error"` / `"warn"` / `"info"`
+/// / `"debug"` / `"trace"`) when the token is present, or `None` for raw
+/// stdout/stderr lines emitted by adapters without tracing context. Callers
+/// (the stdout/stderr capture branches) supply their own fallback when the
+/// helper returns `None`.
+fn parse_level_from_line(line: &str) -> Option<&'static str> {
+    use std::sync::OnceLock;
+    static RE: OnceLock<regex::Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        // Match a whole-word level token after the ISO timestamp prefix. The
+        // compact format pads the level with one or two spaces, so we allow
+        // any run of whitespace before and after the token.
+        regex::Regex::new(r"^\S+\s+(ERROR|WARN|INFO|DEBUG|TRACE)(?:\s|$)")
+            .expect("parse_level_from_line regex is valid")
+    });
+    re.captures(line)
+        .and_then(|c| c.get(1))
+        .map(|m| match m.as_str() {
+            "ERROR" => "error",
+            "WARN" => "warn",
+            "INFO" => "info",
+            "DEBUG" => "debug",
+            "TRACE" => "trace",
+            _ => unreachable!("regex alternation restricts matches to the five level tokens"),
+        })
+}
+
 /// Return the path to config.toml in the appropriate data directory
 /// (`~/.endara-dev/config.toml` in dev mode, `~/.endara/config.toml` in production).
 fn config_path() -> Result<std::path::PathBuf, String> {
@@ -914,6 +950,7 @@ async fn spawn_relay(
                 CommandEvent::Stdout(line) => {
                     let text = strip_ansi(&String::from_utf8_lossy(&line));
                     let endpoint = parse_endpoint_from_span(&text);
+                    let level = parse_level_from_line(&text).unwrap_or("info");
                     // Detect successful startup from stdout
                     if text.contains("MCP server running") {
                         emit_sidecar_status(&app_handle, "running", None).await;
@@ -921,7 +958,7 @@ async fn spawn_relay(
                     if let Some(state) = app_handle.try_state::<RelayState>() {
                         let mut buf = state.log_buffer.lock().await;
                         buf.push(RelayLogPayload {
-                            level: "info".to_string(),
+                            level: level.to_string(),
                             message: text.clone(),
                             endpoint: endpoint.clone(),
                         });
@@ -933,7 +970,7 @@ async fn spawn_relay(
                     let _ = app_handle.emit(
                         "relay-log",
                         RelayLogPayload {
-                            level: "info".to_string(),
+                            level: level.to_string(),
                             message: text,
                             endpoint,
                         },
@@ -941,13 +978,18 @@ async fn spawn_relay(
                 }
                 CommandEvent::Stderr(line) => {
                     let text = strip_ansi(&String::from_utf8_lossy(&line));
-                    let level = if text.contains("ERROR") || text.contains("error") {
-                        "error"
-                    } else if text.contains("WARN") || text.contains("warn") {
-                        "warn"
-                    } else {
-                        "info"
-                    };
+                    // Prefer the tracing level token at the start of the line;
+                    // fall back to the legacy substring heuristic for raw
+                    // stderr lines that have no tracing prefix.
+                    let level = parse_level_from_line(&text).unwrap_or_else(|| {
+                        if text.contains("ERROR") || text.contains("error") {
+                            "error"
+                        } else if text.contains("WARN") || text.contains("warn") {
+                            "warn"
+                        } else {
+                            "info"
+                        }
+                    });
                     let endpoint = parse_endpoint_from_span(&text);
                     // Detect successful startup from stderr (tracing outputs to stderr)
                     if text.contains("MCP server running") {
@@ -3365,5 +3407,64 @@ mod parse_endpoint_from_span_tests {
         // Endpoint field with no trailing space — terminator is the `}`.
         let line = "endpoint{endpoint=postgres}: ready";
         assert_eq!(parse_endpoint_from_span(line), Some("postgres".to_string()),);
+    }
+}
+
+#[cfg(test)]
+mod parse_level_from_line_tests {
+    //! Coverage for [`parse_level_from_line`] — the helper that lifts the
+    //! tracing level token (ERROR/WARN/INFO/DEBUG/TRACE) out of the relay's
+    //! compact-format log line. Drives the level pill in both the top-level
+    //! Logs view and the per-endpoint LogsTab so DEBUG / WARN / TRACE lines
+    //! no longer fall through to the hardcoded `"info"` default.
+
+    use super::*;
+
+    #[test]
+    fn debug_line_returns_debug() {
+        let line = "2026-05-20T17:54:47.123Z DEBUG endara_relay::registry: Registering adapter";
+        assert_eq!(parse_level_from_line(line), Some("debug"));
+    }
+
+    #[test]
+    fn info_line_with_two_space_padding_returns_info() {
+        // Compact format right-aligns the level — INFO and WARN get an extra
+        // leading space so columns line up with ERROR / DEBUG / TRACE.
+        let line = "2026-05-20T17:54:47.123Z  INFO endpoint{endpoint=foo}: connected";
+        assert_eq!(parse_level_from_line(line), Some("info"));
+    }
+
+    #[test]
+    fn warn_line_returns_warn() {
+        let line = "2026-05-20T17:54:47.123Z  WARN endpoint{endpoint=slack}: reconnecting";
+        assert_eq!(parse_level_from_line(line), Some("warn"));
+    }
+
+    #[test]
+    fn error_line_returns_error() {
+        let line = "2026-05-20T17:54:47.123Z ERROR endpoint{endpoint=postgres}: server exited";
+        assert_eq!(parse_level_from_line(line), Some("error"));
+    }
+
+    #[test]
+    fn trace_line_returns_trace() {
+        let line = "2026-05-20T17:54:47.123Z TRACE endara_relay::core: very noisy";
+        assert_eq!(parse_level_from_line(line), Some("trace"));
+    }
+
+    #[test]
+    fn raw_line_with_no_level_token_returns_none() {
+        let line = "raw stdout from an adapter without tracing context";
+        assert_eq!(parse_level_from_line(line), None);
+    }
+
+    #[test]
+    fn message_body_word_error_does_not_match() {
+        // The helper anchors near the start of the line, so a lowercase
+        // English word "error" inside the message body must not be promoted
+        // to a tracing level. The stderr fallback substring matcher still
+        // handles this case, but the helper itself stays strict.
+        let line = "2026-05-20T17:54:47.123Z something happened: an error occurred mid-body";
+        assert_eq!(parse_level_from_line(line), None);
     }
 }

--- a/src/lib/components/LogFilterBar.svelte
+++ b/src/lib/components/LogFilterBar.svelte
@@ -83,9 +83,9 @@
     switch (level) {
       case 'error': return 'border-(--offline) bg-(--offline)/10 text-(--offline)';
       case 'warn': return 'border-(--degraded) bg-(--degraded)/10 text-(--degraded)';
-      case 'info': return 'border-(--border-strong) text-(--fg2)';
-      case 'debug':
-      case 'trace': return 'border-(--border) text-(--fg3)';
+      case 'info': return 'border-(--healthy) bg-(--healthy)/10 text-(--healthy)';
+      case 'debug': return 'border-(--accent) bg-(--accent)/10 text-(--accent)';
+      case 'trace': return 'border-(--fg3) bg-(--fg3)/15 text-(--fg2)';
     }
   }
 </script>

--- a/src/lib/components/LogRow.svelte
+++ b/src/lib/components/LogRow.svelte
@@ -48,8 +48,8 @@
     switch (level) {
       case 'error': return 'bg-(--offline)/10 text-(--offline)';
       case 'warn': return 'bg-(--degraded)/10 text-(--degraded)';
-      case 'info': return 'text-(--fg2)';
-      case 'debug':
+      case 'info': return 'bg-(--healthy)/10 text-(--healthy)';
+      case 'debug': return 'bg-(--accent)/10 text-(--accent)';
       case 'trace': return 'text-(--fg3)';
     }
   }

--- a/src/lib/logParser.test.ts
+++ b/src/lib/logParser.test.ts
@@ -161,3 +161,73 @@ describe('extractTimestamp', () => {
     expect(rest).toBe('endpoint{endpoint=github}: hello');
   });
 });
+
+describe('parseLogLine — in-text level extraction (hotfix)', () => {
+  it('extracts DEBUG level from the line and strips it from the message', () => {
+    const parsed = parseLogLine(
+      'info',
+      '2026-05-20T17:54:47.123Z DEBUG endara_relay::registry: Registering adapter',
+    );
+    expect(parsed.level).toBe('debug');
+    // The "DEBUG" token is stripped; the module path that follows is left
+    // intact (parsing module paths is out of scope for this hotfix).
+    expect(parsed.message.startsWith('DEBUG')).toBe(false);
+    expect(parsed.message).toBe('endara_relay::registry: Registering adapter');
+  });
+
+  it('extracts INFO level even when the sidecar passed a different default', () => {
+    const parsed = parseLogLine(
+      'info',
+      '2026-05-20T17:54:47.123Z INFO endpoint{endpoint=github transport=stdio}: Initialize handshake complete',
+    );
+    expect(parsed.level).toBe('info');
+    expect(parsed.message.startsWith('INFO')).toBe(false);
+    expect(parsed.endpoint).toBe('github');
+    expect(parsed.message).toBe('Initialize handshake complete');
+  });
+
+  it('extracts WARN level and strips it from the message', () => {
+    const parsed = parseLogLine(
+      'info',
+      '2026-05-20T17:54:47.123Z WARN endpoint{endpoint=slack}: Connection lost, reconnecting',
+    );
+    expect(parsed.level).toBe('warn');
+    expect(parsed.message.startsWith('WARN')).toBe(false);
+    expect(parsed.message).toBe('Connection lost, reconnecting');
+  });
+
+  it('extracts ERROR level and strips it from the message', () => {
+    const parsed = parseLogLine(
+      'info',
+      '2026-05-20T17:54:47.123Z ERROR endpoint{endpoint=postgres}: MCP server exited',
+    );
+    expect(parsed.level).toBe('error');
+    expect(parsed.message.startsWith('ERROR')).toBe(false);
+    expect(parsed.message).toBe('MCP server exited');
+  });
+
+  it('extracts TRACE level and strips it from the message', () => {
+    const parsed = parseLogLine(
+      'info',
+      '2026-05-20T17:54:47.123Z TRACE endara_relay::core: very noisy',
+    );
+    expect(parsed.level).toBe('trace');
+    expect(parsed.message.startsWith('TRACE')).toBe(false);
+  });
+
+  it('preserves the passed-in level when no level token is present in the message', () => {
+    const parsed = parseLogLine('warn', 'raw text from an adapter');
+    expect(parsed.level).toBe('warn');
+    expect(parsed.message).toBe('raw text from an adapter');
+  });
+
+  it('does not strip lower-case level words from the message body', () => {
+    // The regex is case-sensitive and anchored — only the upper-case token
+    // immediately after the timestamp counts. An English "error" later in
+    // the line must stay in the message text.
+    const parsed = parseLogLine('info', '2026-05-20T17:54:47.123Z some error occurred');
+    // No upper-case level token → fall back to the passed-in arg.
+    expect(parsed.level).toBe('info');
+    expect(parsed.message).toBe('some error occurred');
+  });
+});

--- a/src/lib/logParser.ts
+++ b/src/lib/logParser.ts
@@ -28,6 +28,11 @@ export interface ParsedLogLine {
 const SPAN_RE = /(\w+)\{([^}]+)\}/g;
 const FIELD_RE = /(\w+)=([^\s,}]+|"[^"]*")/g;
 const TIMESTAMP_RE = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z?)\s+/;
+// Whole-word level token that the relay emits right after the timestamp. The
+// regex is case-sensitive because the relay always emits these upper-case;
+// matching lower-case "error" would also swallow English words in the message
+// body.
+const LEVEL_RE = /^(ERROR|WARN|INFO|DEBUG|TRACE)\s+/;
 
 export function extractTimestamp(message: string): { timestamp: Date; rest: string } {
   const match = message.match(TIMESTAMP_RE);
@@ -60,7 +65,19 @@ export function parseLogLine(
   message: string,
   options?: ParseLogLineOptions,
 ): ParsedLogLine {
-  const { timestamp, rest } = extractTimestamp(message);
+  const { timestamp, rest: afterTimestamp } = extractTimestamp(message);
+
+  // Strip the level token (ERROR/WARN/INFO/DEBUG/TRACE) that the relay emits
+  // right after the timestamp. The extracted token is the authoritative pill
+  // level — the Rust sidecar may have defaulted to "info" when the line
+  // arrived on stdout, so the in-text token wins when present.
+  let rest = afterTimestamp;
+  let extractedLevel: string | undefined;
+  const lvlMatch = rest.match(LEVEL_RE);
+  if (lvlMatch) {
+    extractedLevel = lvlMatch[1].toLowerCase();
+    rest = rest.slice(lvlMatch[0].length);
+  }
 
   const spans: Record<string, Record<string, string>> = {};
   const fields: Record<string, string> = {};
@@ -108,7 +125,7 @@ export function parseLogLine(
 
   return {
     timestamp,
-    level: normalizeLevel(level),
+    level: normalizeLevel(extractedLevel ?? level),
     endpoint,
     transport: spans.endpoint?.transport,
     serverType: spans.endpoint?.server_type,


### PR DESCRIPTION
Hotfix on top of the merged log overhaul (Slices A–D.2).

## Bugs fixed

1. **Level pill always showed "INFO"** even for DEBUG/WARN/ERROR/TRACE lines. Root cause: the Tauri stdout capture hardcoded `level: "info"` and the stderr branch's substring match missed `DEBUG`/`TRACE` and was fragile (false positives on plain English).
2. **Message column duplicated the level prefix** (e.g. pill "INFO" + message "DEBUG endara_relay::registry: …"). The TS parser stripped the ISO timestamp but not the level token that followed.
3. **INFO log rows had no color** (rendered as neutral `--fg2`); user asked for green.
4. **DEBUG and TRACE shared styling** in the row pill — visually indistinguishable.
5. **Filter-bar level toggle had no visible "on" state** for DEBUG/TRACE, and a barely-visible one for INFO. The active class for DEBUG/TRACE was literally identical to the inactive class.

## Changes

### Rust — `packages/desktop/src-tauri/src/lib.rs`
- New `parse_level_from_line(&str) -> Option<&'static str>` using `OnceLock<Regex>` (anchored after the timestamp).
- Wired into both stdout and stderr capture branches; falls back to the current heuristic when no level token is present (preserves non-tracing/raw-stdout behaviour).
- 7 new unit tests covering ERROR/WARN/INFO/DEBUG/TRACE, multi-space padding, raw lines with no level token, and body-only mentions of "error" that must NOT match.

### TypeScript — `packages/desktop/src/lib/logParser.ts`
- New `LEVEL_RE = /^(ERROR|WARN|INFO|DEBUG|TRACE)\s+/` applied to `rest` after `extractTimestamp`. In-text level becomes the authoritative pill level when present; the argument is used as fallback otherwise.
- 7 new test cases covering each level + the no-level-token fallback path.

### Styling — `packages/desktop/src/lib/components/LogRow.svelte` + `LogFilterBar.svelte`
- Row pills: ERROR red · WARN orange · INFO green (`--healthy`) · DEBUG blue (`--accent`) · TRACE muted (`--fg3`, no background).
- Filter-bar active state: colored border + bg tint + text for all 5 levels so the "on" state is unambiguous.

## Verification

- `pnpm test` — 445 pass / 24 skipped
- `pnpm check` — 0 errors
- `pnpm build` — green
- `cargo fmt --check` · `cargo clippy --all-targets -- -D warnings` · `cargo test` — green (57 tests)
- Manual smoke against the running relay confirmed the bug fixes and the new color treatment.

## Out of scope

- `endpoint:endpoint:` artifact / compact-format brace-stripping in `parse_endpoint_from_span` — separate follow-up.