### PR TITLE
feat: add TOON output toggle to Settings

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -390,6 +390,22 @@ fn read_js_execution_mode() -> bool {
         .unwrap_or(false)
 }
 
+/// Read `relay.toon_output` from `~/.endara/config.toml`.
+/// Returns `true` on any error, missing section, or missing key — matches the
+/// relay's own default so a cold-started UI doesn't flash "disabled" before
+/// the on-disk value resolves.
+fn read_toon_output() -> bool {
+    let Ok(parsed) = read_config() else {
+        return true;
+    };
+    parsed
+        .get("relay")
+        .and_then(|v| v.as_table())
+        .and_then(|t| t.get("toon_output"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true)
+}
+
 /// Holds the relay sidecar child process handle.
 pub struct RelayState {
     child: Arc<Mutex<Option<tauri_plugin_shell::process::CommandChild>>>,
@@ -1416,6 +1432,44 @@ async fn set_js_execution_mode(enabled: bool) -> Result<(), String> {
     write_config(&table)
 }
 
+/// Get whether TOON output is enabled in the relay config.
+/// Returns `true` (the relay's own default) if the config is missing,
+/// malformed, has no `[relay]` section, or has no `toon_output` field.
+#[tauri::command]
+async fn get_toon_output() -> Result<bool, String> {
+    Ok(read_toon_output())
+}
+
+#[tauri::command]
+async fn set_toon_output(enabled: bool) -> Result<(), String> {
+    let mut table = read_config().unwrap_or_else(|_| toml::Table::new());
+
+    // Ensure [relay] section exists. The relay's `RelayConfig` requires
+    // `machine_name`, so populate it from the system hostname when creating
+    // the section from scratch — otherwise the relay's next config reload
+    // would fail to deserialize.
+    let relay = table
+        .entry("relay")
+        .or_insert_with(|| {
+            let mut t = toml::Table::new();
+            let machine_name = hostname::get()
+                .ok()
+                .and_then(|h| h.into_string().ok())
+                .unwrap_or_else(|| "unknown".to_string());
+            t.insert(
+                "machine_name".to_string(),
+                toml::Value::String(machine_name),
+            );
+            toml::Value::Table(t)
+        })
+        .as_table_mut()
+        .ok_or("Invalid [relay] section in config")?;
+
+    relay.insert("toon_output".to_string(), toml::Value::Boolean(enabled));
+
+    write_config(&table)
+}
+
 /// Get the current update channel ("stable" or "beta").
 #[tauri::command]
 async fn get_update_channel() -> Result<String, String> {
@@ -2291,6 +2345,8 @@ pub fn run() {
             get_mgmt_api_socket_path,
             get_js_execution_mode,
             set_js_execution_mode,
+            get_toon_output,
+            set_toon_output,
             get_config_path_display,
             get_buffered_relay_logs,
             get_update_channel,
@@ -3318,6 +3374,240 @@ mod js_execution_mode_tests {
             relay.get("local_js_execution").and_then(|v| v.as_bool()),
             Some(true),
             "local_js_execution should be set to true"
+        );
+
+        let endpoints = parsed
+            .get("endpoints")
+            .and_then(|v| v.as_array())
+            .expect("[[endpoints]] preserved");
+        assert_eq!(endpoints.len(), 1, "endpoint count should be unchanged");
+        let ep = endpoints[0].as_table().expect("endpoint is a table");
+        assert_eq!(ep.get("name").and_then(|v| v.as_str()), Some("gmail-acct"));
+        assert_eq!(ep.get("transport").and_then(|v| v.as_str()), Some("stdio"));
+        assert_eq!(
+            ep.get("tool_prefix").and_then(|v| v.as_str()),
+            Some("gmail")
+        );
+        assert_eq!(ep.get("command").and_then(|v| v.as_str()), Some("echo"));
+        let args = ep
+            .get("args")
+            .and_then(|v| v.as_array())
+            .expect("args preserved");
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0].as_str(), Some("hi"));
+    }
+}
+
+#[cfg(test)]
+mod toon_output_tests {
+    //! Round-trip coverage for `read_toon_output` and `set_toon_output`.
+    //! Mirrors `js_execution_mode_tests` but pins the default to `true` to
+    //! match the relay's own default — a missing field, missing section,
+    //! missing file, or malformed file all resolve to `true`.
+    use super::*;
+    use serial_test::serial;
+    use tempfile::TempDir;
+
+    struct HomeGuard {
+        prior: Option<String>,
+        _tmp: TempDir,
+    }
+
+    impl HomeGuard {
+        fn new() -> Self {
+            let prior = std::env::var("HOME").ok();
+            let tmp = tempfile::tempdir().expect("create tempdir");
+            std::env::set_var("HOME", tmp.path());
+            Self { prior, _tmp: tmp }
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            match &self.prior {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+    }
+
+    fn rt() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build tokio runtime")
+    }
+
+    fn write_config_str(contents: &str) {
+        let path = config_path().expect("config_path");
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent dir");
+        }
+        std::fs::write(&path, contents).expect("write config.toml");
+    }
+
+    fn read_config_str() -> String {
+        let path = config_path().expect("config_path");
+        std::fs::read_to_string(&path).expect("read config.toml")
+    }
+
+    #[test]
+    #[serial]
+    fn get_toon_output_returns_true_when_set() {
+        let _home = HomeGuard::new();
+        write_config_str("[relay]\ntoon_output = true\nmachine_name = \"x\"\n");
+        assert!(read_toon_output());
+    }
+
+    #[test]
+    #[serial]
+    fn get_toon_output_returns_false_when_unset_explicitly() {
+        let _home = HomeGuard::new();
+        write_config_str("[relay]\ntoon_output = false\nmachine_name = \"x\"\n");
+        assert!(!read_toon_output());
+    }
+
+    #[test]
+    #[serial]
+    fn get_toon_output_returns_true_when_field_missing() {
+        let _home = HomeGuard::new();
+        write_config_str("[relay]\nmachine_name = \"x\"\n");
+        assert!(read_toon_output());
+    }
+
+    #[test]
+    #[serial]
+    fn get_toon_output_returns_true_when_no_relay_section() {
+        let _home = HomeGuard::new();
+        write_config_str("[desktop]\nupdate_channel = \"stable\"\n");
+        assert!(read_toon_output());
+    }
+
+    #[test]
+    #[serial]
+    fn get_toon_output_returns_true_when_file_missing() {
+        let _home = HomeGuard::new();
+        // No config.toml written.
+        assert!(read_toon_output());
+    }
+
+    #[test]
+    #[serial]
+    fn get_toon_output_returns_true_when_file_malformed() {
+        let _home = HomeGuard::new();
+        write_config_str("not valid toml ====\n");
+        assert!(read_toon_output());
+    }
+
+    #[test]
+    #[serial]
+    fn set_toon_output_roundtrips() {
+        let _home = HomeGuard::new();
+        let rt = rt();
+        write_config_str("[relay]\nmachine_name = \"x\"\n");
+
+        rt.block_on(set_toon_output(false)).expect("set false");
+        assert!(!read_toon_output());
+
+        rt.block_on(set_toon_output(true)).expect("set true");
+        assert!(read_toon_output());
+    }
+
+    #[test]
+    #[serial]
+    fn set_toon_output_creates_missing_relay_section() {
+        let _home = HomeGuard::new();
+        let rt = rt();
+        write_config_str("[desktop]\nupdate_channel = \"stable\"\n");
+
+        rt.block_on(set_toon_output(false))
+            .expect("set_toon_output should succeed");
+
+        let toml_str = read_config_str();
+        let parsed: toml::Table =
+            toml::from_str(&toml_str).expect("re-parse config.toml as toml::Table");
+
+        let relay = parsed
+            .get("relay")
+            .and_then(|v| v.as_table())
+            .expect("[relay] section should exist");
+        assert_eq!(
+            relay.get("toon_output").and_then(|v| v.as_bool()),
+            Some(false),
+            "toon_output should be false"
+        );
+        let machine_name = relay
+            .get("machine_name")
+            .and_then(|v| v.as_str())
+            .expect("machine_name should be set");
+        assert!(
+            !machine_name.is_empty(),
+            "machine_name should be non-empty, got {machine_name:?}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn set_toon_output_preserves_other_fields() {
+        let _home = HomeGuard::new();
+        let rt = rt();
+        write_config_str(
+            "[desktop]\n\
+             update_channel = \"beta\"\n\
+             \n\
+             [relay]\n\
+             machine_name = \"host\"\n\
+             token_dir = \"/tmp/x\"\n\
+             local_js_execution = true\n\
+             \n\
+             [[endpoints]]\n\
+             name = \"gmail-acct\"\n\
+             transport = \"stdio\"\n\
+             tool_prefix = \"gmail\"\n\
+             command = \"echo\"\n\
+             args = [\"hi\"]\n",
+        );
+
+        rt.block_on(set_toon_output(false))
+            .expect("set_toon_output should succeed");
+
+        let toml_str = read_config_str();
+        let parsed: toml::Table =
+            toml::from_str(&toml_str).expect("re-parse config.toml as toml::Table");
+
+        let desktop = parsed
+            .get("desktop")
+            .and_then(|v| v.as_table())
+            .expect("[desktop] preserved");
+        assert_eq!(
+            desktop.get("update_channel").and_then(|v| v.as_str()),
+            Some("beta"),
+            "update_channel should be preserved"
+        );
+
+        let relay = parsed
+            .get("relay")
+            .and_then(|v| v.as_table())
+            .expect("[relay] preserved");
+        assert_eq!(
+            relay.get("machine_name").and_then(|v| v.as_str()),
+            Some("host"),
+            "machine_name should be preserved"
+        );
+        assert_eq!(
+            relay.get("token_dir").and_then(|v| v.as_str()),
+            Some("/tmp/x"),
+            "token_dir should be preserved"
+        );
+        assert_eq!(
+            relay.get("local_js_execution").and_then(|v| v.as_bool()),
+            Some(true),
+            "local_js_execution should be preserved"
+        );
+        assert_eq!(
+            relay.get("toon_output").and_then(|v| v.as_bool()),
+            Some(false),
+            "toon_output should be set to false"
         );
 
         let endpoints = parsed

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-  import { theme, jsExecutionMode, relayPort, relayConnected, relaySidecarStatus, relaySidecarError, updateStatus, updateVersion, updateError, updateChannel, lastCheckedChannel } from '$lib/stores';
+  import { theme, jsExecutionMode, toonOutput, relayPort, relayConnected, relaySidecarStatus, relaySidecarError, updateStatus, updateVersion, updateError, updateChannel, lastCheckedChannel } from '$lib/stores';
   import { autoStartEnabled, fetchAutoStart, toggleAutoStart } from '$lib/stores/autostart';
   import type { Theme, RelayStatus } from '$lib/types';
   import { invoke } from '@tauri-apps/api/core';
   import { getStatus } from '$lib/api';
   import { canRetryRelay, getSettingsStatusLabel, restartRelay } from '$lib/relaySidecarUi';
   import { fetchJsExecutionMode, toggleJsExecutionMode } from '$lib/jsExecutionModeUi';
+  import { fetchToonOutput, toggleToonOutput } from '$lib/toonOutputUi';
   import { checkAndAutoDownload, restartApp, getUpdateChannel, setUpdateChannel } from '$lib/updater';
   import { onMount, onDestroy } from 'svelte';
   import { toast } from 'svelte-sonner';
@@ -135,6 +136,7 @@
     }
     fetchRelayStatus();
     fetchJsExecutionMode();
+    fetchToonOutput();
     fetchAutoStart();
     fetchUpdateChannel();
     invoke('get_config_path_display').then((p: unknown) => {
@@ -284,6 +286,23 @@
         aria-label="Toggle JS execution mode"
       >
         <span class="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform {$jsExecutionMode ? 'translate-x-5' : ''}"></span>
+      </button>
+    </div>
+
+    <div class="flex items-start justify-between gap-4">
+      <div>
+        <div class="text-sm font-medium">TOON Output Format</div>
+        <div class="text-xs text-(--fg2) mt-0.5">Tool responses are returned in TOON format (Token-Oriented Object Notation), a compact alternative to JSON that reduces token usage by 40–60% on structured data. AI clients parse it natively.</div>
+        <div class="text-xs text-(--fg2)/70 mt-1">Disable if a connected AI client has trouble parsing TOON output.</div>
+      </div>
+      <button
+        class="shrink-0 relative w-10 h-5 rounded-full transition-colors {$toonOutput ? 'bg-green-500' : 'bg-gray-300 dark:bg-gray-600'}"
+        onclick={() => toggleToonOutput()}
+        role="switch"
+        aria-checked={$toonOutput}
+        aria-label="Toggle TOON output format"
+      >
+        <span class="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform {$toonOutput ? 'translate-x-5' : ''}"></span>
       </button>
     </div>
 

--- a/src/lib/components/Settings.test.ts
+++ b/src/lib/components/Settings.test.ts
@@ -181,3 +181,101 @@ describe('Settings JS execution mode helpers', () => {
   });
 });
 
+describe('Settings TOON output helpers', () => {
+  const invokeMock = invoke as unknown as ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    invokeMock.mockReset();
+    getConfigMock.mockReset();
+    reloadConfigMock.mockReset();
+    // Reset the shared store to its default (`true`) before each test so
+    // order doesn't matter.
+    const { toonOutput } = await import('$lib/stores');
+    toonOutput.set(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetchToonOutput updates the store from the Tauri command (false)', async () => {
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'get_toon_output') return Promise.resolve(false);
+      return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
+    });
+    const { fetchToonOutput } = await import('$lib/toonOutputUi');
+    const { toonOutput } = await import('$lib/stores');
+
+    await fetchToonOutput();
+
+    expect(invokeMock).toHaveBeenCalledWith('get_toon_output');
+    expect(get(toonOutput)).toBe(false);
+  });
+
+  it('fetchToonOutput is resilient to a failing relay path', async () => {
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'get_toon_output') return Promise.resolve(false);
+      return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
+    });
+    getConfigMock.mockRejectedValue(new Error('relay socket not ready'));
+    reloadConfigMock.mockRejectedValue(new Error('relay socket not ready'));
+    const { fetchToonOutput } = await import('$lib/toonOutputUi');
+    const { toonOutput } = await import('$lib/stores');
+
+    await expect(fetchToonOutput()).resolves.toBeUndefined();
+    expect(get(toonOutput)).toBe(false);
+  });
+
+  it('fetchToonOutput does NOT call getConfig (relay is no longer in the read path)', async () => {
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'get_toon_output') return Promise.resolve(true);
+      return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
+    });
+    const { fetchToonOutput } = await import('$lib/toonOutputUi');
+
+    await fetchToonOutput();
+
+    expect(getConfigMock).not.toHaveBeenCalled();
+  });
+
+  it('toggleToonOutput calls set_toon_output then reloadConfig, in order', async () => {
+    const callOrder: string[] = [];
+    invokeMock.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
+      if (cmd === 'set_toon_output') {
+        callOrder.push(`set:${args?.enabled}`);
+        return Promise.resolve(undefined);
+      }
+      return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
+    });
+    reloadConfigMock.mockImplementation(() => {
+      callOrder.push('reload');
+      return Promise.resolve();
+    });
+    const { toggleToonOutput } = await import('$lib/toonOutputUi');
+    const { toonOutput } = await import('$lib/stores');
+    toonOutput.set(true);
+
+    await toggleToonOutput();
+
+    expect(invokeMock).toHaveBeenCalledWith('set_toon_output', { enabled: false });
+    expect(reloadConfigMock).toHaveBeenCalledTimes(1);
+    expect(callOrder).toEqual(['set:false', 'reload']);
+    expect(get(toonOutput)).toBe(false);
+  });
+
+  it('toggleToonOutput reverts the store when set_toon_output rejects', async () => {
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'set_toon_output') return Promise.reject(new Error('write failed'));
+      return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
+    });
+    const { toggleToonOutput } = await import('$lib/toonOutputUi');
+    const { toonOutput } = await import('$lib/stores');
+    toonOutput.set(true);
+
+    await toggleToonOutput();
+
+    expect(get(toonOutput)).toBe(true);
+    expect(reloadConfigMock).not.toHaveBeenCalled();
+  });
+});
+

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -5,6 +5,7 @@ import type { ParsedLogLine } from './logParser';
 export const endpoints = writable<Endpoint[]>([]);
 export const selectedEndpoint = writable<string | null>(null);
 export const jsExecutionMode = writable<boolean>(false);
+export const toonOutput = writable<boolean>(true);
 
 function createThemeStore() {
   const stored = typeof window !== 'undefined' ? localStorage.getItem('endara-theme') as Theme | null : null;

--- a/src/lib/toonOutputUi.ts
+++ b/src/lib/toonOutputUi.ts
@@ -1,0 +1,38 @@
+import { invoke } from '@tauri-apps/api/core';
+import { get } from 'svelte/store';
+import { toonOutput } from './stores';
+import { reloadConfig } from './api';
+
+// Read the TOON output setting from the Tauri backend, which reads
+// `~/.endara/config.toml` directly. The relay is intentionally NOT in the
+// read path: a cold-started UI used to call `getConfig` against the relay
+// while the relay socket was still coming up, race-losing and leaving the
+// toggle stuck at the default `true` even when the on-disk config had it
+// disabled.
+export async function fetchToonOutput(): Promise<void> {
+  try {
+    const enabled = await invoke<boolean>('get_toon_output');
+    toonOutput.set(enabled);
+  } catch (e) {
+    // Swallow and leave the store at its current value; matches the prior
+    // "default-and-move-on" behavior so a transient failure never throws
+    // during Settings mount.
+    console.error('Failed to get TOON output:', e);
+  }
+}
+
+// Toggle TOON output: write through Tauri (which updates
+// `~/.endara/config.toml`), then ask the running relay to re-read its
+// config so the live sidecar picks up the new value without a restart.
+// Optimistically flips the store first and reverts on failure.
+export async function toggleToonOutput(): Promise<void> {
+  const newValue = !get(toonOutput);
+  toonOutput.set(newValue);
+  try {
+    await invoke('set_toon_output', { enabled: newValue });
+    await reloadConfig();
+  } catch (e) {
+    toonOutput.set(!newValue);
+    console.error('Failed to set TOON output:', e);
+  }
+}


### PR DESCRIPTION
Adds a **TOON Output Format** toggle to the Settings page, directly below the existing **JS Execution Mode** toggle. Mirrors the JS Execution Mode pattern as closely as possible.

This is the desktop-side counterpart to the relay-side TOON output feature shipped in **[endara-ai/endara-relay#73](https://github.com/endara-ai/endara-relay/pull/73)** (released in `v0.1.7-rc.4`).

## Behavior

- Toggle persists to `~/.endara/config.toml` at `relay.toon_output`.
- After write, calls `reloadConfig()` so the running sidecar picks up the change without a restart.
- Optimistic-flip-and-revert-on-failure pattern matches `toggleJsExecutionMode`.
- **Default is `true`** — matching the relay's own default. A missing field, missing section, missing file, or malformed file all resolve to `true`. (This is the opposite of JS Execution Mode, which defaults to `false`.)

## Changes

**New file:**
- `src/lib/toonOutputUi.ts` — `fetchToonOutput()` and `toggleToonOutput()`, mirrors `jsExecutionModeUi.ts`.

**Modified files:**
- `src-tauri/src/lib.rs`:
  - New helper `read_toon_output()` (defaults `true`).
  - New `#[tauri::command]`s `get_toon_output` and `set_toon_output`, both registered in `invoke_handler`. `set_toon_output` uses the same hostname-fallback `machine_name` pattern as `set_js_execution_mode` when creating a missing `[relay]` section.
  - 9 new unit tests under `mod toon_output_tests` covering all defaults, the roundtrip, missing-section creation, and other-field preservation (including `local_js_execution`).
- `src/lib/stores.ts` — `export const toonOutput = writable<boolean>(true);` (default `true` to avoid a flash of "disabled" before `fetchToonOutput` resolves).
- `src/lib/components/Settings.svelte` — imports + `fetchToonOutput()` in `onMount` + new toggle row between JS Execution Mode and Start on Login.
- `src/lib/components/Settings.test.ts` — 5 new Vitest cases mirror the JS execution mode helper coverage.

## Verification

```
pnpm test           # 450 passed, 24 skipped — Settings TOON output helpers covered
pnpm check          # svelte-check 0 errors
cd src-tauri
cargo fmt --check   # clean
cargo clippy --all-targets -- -D warnings   # clean
cargo test --lib    # 66 passed, includes 9 new toon_output_tests
```
