### PR TITLE
chore: bump version to 0.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endara/desktop",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "description": "Endara Desktop — Tauri + Svelte tray app for relay management",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1114,7 +1114,7 @@ dependencies = [
 
 [[package]]
 name = "endara-desktop"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "dirs 5.0.1",
  "hostname",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endara-desktop"
-version = "0.1.7"
+version = "0.1.8"
 description = "Endara Desktop — relay management tray app"
 authors = ["Endara"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Endara Desktop",
   "mainBinaryName": "Endara Desktop",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "identifier": "ai.endara.desktop",
   "build": {
     "beforeDevCommand": "ENDARA_DEV_PORT=9500 bash scripts/kill-relay.sh; npm run dev",


### PR DESCRIPTION
Scenario 3 post-stable base-version bump from 0.1.7 to 0.1.8 — `package.json` + `src-tauri/Cargo.toml` + `src-tauri/tauri.conf.json` in lockstep. v0.1.7 stable shipped successfully (https://github.com/endara-ai/endara-desktop/releases/tag/v0.1.7). No rc suffix in committed files — the release workflow patches `tauri.conf.json` with the tag version at build time.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author