### PR TITLE
fix(logs): restore endpoint column by pinning relay sidecar to text log format

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -246,15 +246,27 @@ fn strip_ansi(s: &str) -> String {
     result
 }
 
-/// Extract the endpoint name from the relay's compact-format tracing span
-/// (e.g. `endpoint{endpoint=github transport=stdio}: Initialize handshake ...`).
+/// Extract the endpoint name from the relay's tracing span.
 ///
-/// Returns `Some("github")` when the span is present and `None` for
-/// relay-level events that have no `endpoint{...}` span. The match mirrors the
-/// front-end `SPAN_RE` parser: the field value runs from after the `=` up to
-/// the next space or closing brace and is not unquoted (the relay never quotes
-/// the endpoint name in compact format), but a leading `"` is trimmed so a
-/// hypothetical `endpoint{endpoint="my name"}` still yields a plausible token.
+/// The relay sidecar is launched with `--log-format text` (see
+/// [`build_sidecar_args`]) so tracing-subscriber emits its "Full" formatter
+/// shape, with span fields inline:
+///
+/// ```text
+/// 2026-05-22T15:10:43Z  INFO endpoint{endpoint="github" transport="stdio"}: <target>: <msg>
+/// ```
+///
+/// Returns `Some("github")` when the `endpoint{...}` span is present and
+/// `None` for relay-level events that have no span context (e.g. "Relay
+/// listening on …"). A leading and trailing pair of double-quotes is stripped
+/// from the captured token so callers get the bare endpoint name — the Full
+/// formatter quotes string-typed field values, while older test fixtures and
+/// the compact format used unquoted values, so the parser accepts both.
+///
+/// Lines emitted in the relay's `compact` format (`INFO endpoint: <target>:
+/// <msg> endpoint="NAME" transport="…"`) do NOT match because the span fields
+/// trail the message instead of appearing inline — this is why the sidecar
+/// must run with `--log-format text`.
 fn parse_endpoint_from_span(line: &str) -> Option<String> {
     use std::sync::OnceLock;
     static RE: OnceLock<regex::Regex> = OnceLock::new();
@@ -264,8 +276,20 @@ fn parse_endpoint_from_span(line: &str) -> Option<String> {
     });
     re.captures(line)
         .and_then(|c| c.get(1))
-        .map(|m| m.as_str().trim_matches('"').to_string())
+        .map(|m| strip_quote_pair(m.as_str()).to_string())
         .filter(|s| !s.is_empty())
+}
+
+/// Strip exactly one leading and one trailing `"` from `s` when both are
+/// present. Returns the input unchanged if the value is not double-quoted on
+/// both sides — this avoids over-eager trimming of values that legitimately
+/// begin or end with a quote character.
+fn strip_quote_pair(s: &str) -> &str {
+    if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
+        &s[1..s.len() - 1]
+    } else {
+        s
+    }
 }
 
 /// Extract the tracing level token from a relay compact-format log line.
@@ -3675,28 +3699,33 @@ mod toon_output_tests {
 #[cfg(test)]
 mod parse_endpoint_from_span_tests {
     //! Coverage for [`parse_endpoint_from_span`] — the helper that lifts the
-    //! endpoint name out of the relay's compact-format tracing span so each
+    //! endpoint name out of the relay's Full-format tracing span so each
     //! `relay-log` Tauri event carries an authoritative `endpoint` field.
     //!
-    //! Corresponds to engineering spec §5 test rows #18 (endpoint present in
-    //! span) and #19 (relay-level event with no span yields `None`).
+    //! The sidecar is pinned to `--log-format text` ([`build_sidecar_args`]),
+    //! which produces tracing-subscriber's Full-formatter shape with QUOTED
+    //! span field values: `endpoint{endpoint="github" transport="stdio"}`.
+    //! Fixtures here use that real wire shape so a future regression in the
+    //! quote-stripping path would fail loudly. One backward-compatible
+    //! unquoted fixture is retained, and a negative compact-format fixture
+    //! documents why the sidecar must run with `--log-format text`.
 
     use super::*;
 
     #[test]
     fn endpoint_present_in_span_returns_some() {
-        // Spec §5 test #18 — typical tool-call event with span context.
-        let line = "2026-05-20T10:00:00.000Z  INFO endpoint{endpoint=github transport=stdio}: Tool call completed";
+        // Real Full-format wire shape — tracing-subscriber quotes the field.
+        let line = "2026-05-20T10:00:00.000Z  INFO endpoint{endpoint=\"github\" transport=\"stdio\"}: Tool call completed";
         assert_eq!(
             parse_endpoint_from_span(line),
             Some("github".to_string()),
-            "endpoint name should be extracted from endpoint{{endpoint=NAME ...}} span"
+            "endpoint name should be extracted from endpoint{{endpoint=\"NAME\" ...}} span"
         );
     }
 
     #[test]
     fn no_span_returns_none() {
-        // Spec §5 test #19 — relay-level event with no endpoint span.
+        // Relay-level event with no endpoint span.
         let line = "2026-05-20T10:00:00.000Z  INFO Relay listening on 127.0.0.1:47107";
         assert_eq!(
             parse_endpoint_from_span(line),
@@ -3707,17 +3736,16 @@ mod parse_endpoint_from_span_tests {
 
     #[test]
     fn nested_request_and_endpoint_spans_still_extract_endpoint() {
-        // Compact format with multiple span scopes (request{...} endpoint{...}).
-        let line = "2026-05-20T10:00:00.000Z  INFO request{method=tools/call id=42} endpoint{endpoint=gmail transport=stdio}: handled";
+        // Full format with multiple span scopes (request{...} endpoint{...}).
+        let line = "2026-05-20T10:00:00.000Z  INFO request{method=\"tools/call\" id=42} endpoint{endpoint=\"gmail\" transport=\"stdio\"}: handled";
         assert_eq!(parse_endpoint_from_span(line), Some("gmail".to_string()),);
     }
 
     #[test]
     fn quoted_endpoint_name_is_unquoted() {
-        // The relay does not quote endpoint names today, but if it ever did
-        // (e.g. names with spaces), the leading/trailing `"` should be trimmed
-        // to keep the parsed value usable as a key.
-        let line = "endpoint{endpoint=\"slack-prod\" transport=http}: connected";
+        // A name with a hyphen — the surrounding pair of double-quotes from
+        // the Full formatter must be stripped to yield the bare key.
+        let line = "endpoint{endpoint=\"slack-prod\" transport=\"http\"}: connected";
         assert_eq!(
             parse_endpoint_from_span(line),
             Some("slack-prod".to_string()),
@@ -3725,18 +3753,50 @@ mod parse_endpoint_from_span_tests {
     }
 
     #[test]
+    fn unquoted_endpoint_name_still_parses_for_backward_compat() {
+        // Older relay builds (and the spec §5 fixtures predating PR #67's
+        // log-format flag) emitted bare unquoted values. Keep parsing them so
+        // a stale buffered log line from a previous run still surfaces an
+        // endpoint name.
+        let line = "endpoint{endpoint=postgres transport=stdio}: ready";
+        assert_eq!(parse_endpoint_from_span(line), Some("postgres".to_string()),);
+    }
+
+    #[test]
     fn empty_endpoint_field_returns_none() {
         // Defensive: a malformed `endpoint{endpoint=}` should not produce an
         // empty-string endpoint that the front-end might display as a row.
-        let line = "endpoint{endpoint= transport=stdio}: weird";
+        let line = "endpoint{endpoint= transport=\"stdio\"}: weird";
+        assert_eq!(parse_endpoint_from_span(line), None);
+    }
+
+    #[test]
+    fn empty_quoted_endpoint_field_returns_none() {
+        // Same defense for the quoted shape — `endpoint=""` strips to "" and
+        // must be filtered out so the front-end never renders a blank row.
+        let line = "endpoint{endpoint=\"\" transport=\"stdio\"}: weird";
         assert_eq!(parse_endpoint_from_span(line), None);
     }
 
     #[test]
     fn endpoint_at_end_of_span_closing_brace() {
-        // Endpoint field with no trailing space — terminator is the `}`.
-        let line = "endpoint{endpoint=postgres}: ready";
+        // Quoted endpoint field with no trailing space — terminator is `}`.
+        let line = "endpoint{endpoint=\"postgres\"}: ready";
         assert_eq!(parse_endpoint_from_span(line), Some("postgres".to_string()),);
+    }
+
+    #[test]
+    fn compact_format_line_returns_none() {
+        // Documents why the sidecar must run with `--log-format text`: the
+        // relay's CLI default (`compact`) emits span fields at the END of
+        // the line, not inline. The parser intentionally returns `None` for
+        // this shape so future maintainers see the dependency.
+        let line = "2026-05-22T15:10:11Z  INFO endpoint: endara_relay::adapter::http: MCP server reported serverInfo.name endpoint=\"github\" transport=\"stdio\"";
+        assert_eq!(
+            parse_endpoint_from_span(line),
+            None,
+            "compact-format lines have trailing span fields and must not match"
+        );
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -315,6 +315,14 @@ fn config_path() -> Result<std::path::PathBuf, String> {
 /// In dev mode we pass `--data-dir` (letting the relay derive its config path and
 /// perform the first-run copy from production). In production we pass `--config`
 /// directly. Extracted as a pure helper so it is trivially unit-testable.
+///
+/// We also force `--log-format text` (tracing-subscriber's "Full" formatter)
+/// so span fields appear inline as `endpoint{endpoint="NAME" ...}:` instead of
+/// the relay's CLI default `compact` shape, which trails the span fields at
+/// the end of the line. Both [`parse_endpoint_from_span`] and the front-end
+/// `SPAN_RE` parser are written against the inline shape — without this pin
+/// every relay-log event would report a `null` endpoint and the Logs view's
+/// "Endpoint" column would render `---` for every row.
 fn build_sidecar_args<'a>(
     dev: bool,
     data_dir: &'a str,
@@ -322,9 +330,25 @@ fn build_sidecar_args<'a>(
     port: &'a str,
 ) -> Vec<&'a str> {
     if dev {
-        vec!["start", "--data-dir", data_dir, "--port", port]
+        vec![
+            "start",
+            "--data-dir",
+            data_dir,
+            "--port",
+            port,
+            "--log-format",
+            "text",
+        ]
     } else {
-        vec!["start", "--config", config, "--port", port]
+        vec![
+            "start",
+            "--config",
+            config,
+            "--port",
+            port,
+            "--log-format",
+            "text",
+        ]
     }
 }
 
@@ -2779,10 +2803,24 @@ mod dev_mode_tests {
 
     #[test]
     fn build_sidecar_args_dev_vs_prod() {
+        // Both branches must end with `--log-format text` so the relay's
+        // tracing layer emits the inline span shape the desktop parsers
+        // (`parse_endpoint_from_span` + the front-end `SPAN_RE`) expect.
+        // Without it the relay's compact-format default would hide span
+        // fields at the end of the line and the Logs view's Endpoint
+        // column would render `---` for every row.
         let dev = build_sidecar_args(true, "/tmp/dev", "/tmp/dev/config.toml", "9500");
         assert_eq!(
             dev,
-            vec!["start", "--data-dir", "/tmp/dev", "--port", "9500"]
+            vec![
+                "start",
+                "--data-dir",
+                "/tmp/dev",
+                "--port",
+                "9500",
+                "--log-format",
+                "text",
+            ]
         );
 
         let prod = build_sidecar_args(false, "/tmp/dev", "/tmp/prod/config.toml", "9400");
@@ -2793,7 +2831,9 @@ mod dev_mode_tests {
                 "--config",
                 "/tmp/prod/config.toml",
                 "--port",
-                "9400"
+                "9400",
+                "--log-format",
+                "text",
             ]
         );
     }

--- a/src/lib/logParser.test.ts
+++ b/src/lib/logParser.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import { parseLogLine, extractTimestamp } from '$lib/logParser';
 
+// The relay sidecar is launched with `--log-format text` (Full formatter),
+// which emits span field values WITH surrounding double-quotes — e.g.
+// `endpoint{endpoint="github" transport="stdio"}`. Fixtures below match that
+// real wire shape so a regression in the unquoting path would fail loudly.
 describe('parseLogLine', () => {
-  it('extracts endpoint name from endpoint{endpoint=github} span', () => {
-    const parsed = parseLogLine('info', 'endpoint{endpoint=github}: Initialize handshake complete');
+  it('extracts endpoint name from endpoint{endpoint="github"} span', () => {
+    const parsed = parseLogLine('info', 'endpoint{endpoint="github"}: Initialize handshake complete');
     expect(parsed.endpoint).toBe('github');
     expect(parsed.message).toBe('Initialize handshake complete');
     expect(parsed.level).toBe('info');
@@ -12,7 +16,7 @@ describe('parseLogLine', () => {
   it('extracts multiple span fields (endpoint, transport, server_type)', () => {
     const parsed = parseLogLine(
       'info',
-      'endpoint{endpoint=github transport=stdio server_type=github}: Initialize handshake complete'
+      'endpoint{endpoint="github" transport="stdio" server_type="github"}: Initialize handshake complete'
     );
     expect(parsed.endpoint).toBe('github');
     expect(parsed.transport).toBe('stdio');
@@ -23,7 +27,7 @@ describe('parseLogLine', () => {
   it('extracts inline fields (tool, status, duration_ms) and request span', () => {
     const parsed = parseLogLine(
       'info',
-      'request{method=tools/call id=42} endpoint{endpoint=github}: Tool call completed tool=get_file_contents status=ok duration_ms=312'
+      'request{method="tools/call" id=42} endpoint{endpoint="github"}: Tool call completed tool=get_file_contents status=ok duration_ms=312'
     );
     expect(parsed.endpoint).toBe('github');
     expect(parsed.method).toBe('tools/call');
@@ -46,7 +50,7 @@ describe('parseLogLine', () => {
   it('extracts ISO timestamp from message prefix', () => {
     const parsed = parseLogLine(
       'info',
-      '2026-05-20T10:32:05.123Z endpoint{endpoint=github}: Initialize handshake complete'
+      '2026-05-20T10:32:05.123Z endpoint{endpoint="github"}: Initialize handshake complete'
     );
     expect(parsed.timestamp.toISOString()).toBe('2026-05-20T10:32:05.123Z');
     expect(parsed.endpoint).toBe('github');
@@ -55,7 +59,7 @@ describe('parseLogLine', () => {
 
   it('falls back to client-side timestamp when no timestamp in message', () => {
     const before = Date.now();
-    const parsed = parseLogLine('info', 'endpoint{endpoint=github}: Initialize handshake complete');
+    const parsed = parseLogLine('info', 'endpoint{endpoint="github"}: Initialize handshake complete');
     const after = Date.now();
     const t = parsed.timestamp.getTime();
     expect(t).toBeGreaterThanOrEqual(before);
@@ -73,7 +77,7 @@ describe('parseLogLine', () => {
     it('flags completed tool calls when tool field is present', () => {
       const parsed = parseLogLine(
         'info',
-        'endpoint{endpoint=github}: Tool call completed tool=get_file_contents status=ok duration_ms=312'
+        'endpoint{endpoint="github"}: Tool call completed tool=get_file_contents status=ok duration_ms=312'
       );
       expect(parsed.isToolCall).toBe(true);
       expect(parsed.tool).toBe('get_file_contents');
@@ -82,7 +86,7 @@ describe('parseLogLine', () => {
     it('flags failed tool calls when tool field is present', () => {
       const parsed = parseLogLine(
         'warn',
-        'endpoint{endpoint=slack}: Tool call failed tool=send_message status=error duration_ms=1204'
+        'endpoint{endpoint="slack"}: Tool call failed tool=send_message status=error duration_ms=1204'
       );
       expect(parsed.isToolCall).toBe(true);
       expect(parsed.tool).toBe('send_message');
@@ -93,7 +97,7 @@ describe('parseLogLine', () => {
     it('flags rows that carry status + duration_ms even without "Tool call" phrasing', () => {
       const parsed = parseLogLine(
         'info',
-        'endpoint{endpoint=github}: handled status=ok duration_ms=42'
+        'endpoint{endpoint="github"}: handled status=ok duration_ms=42'
       );
       expect(parsed.isToolCall).toBe(true);
       expect(parsed.status).toBe('ok');
@@ -101,7 +105,7 @@ describe('parseLogLine', () => {
     });
 
     it('does not flag plain informational lines as tool calls', () => {
-      const parsed = parseLogLine('info', 'endpoint{endpoint=github}: Initialize handshake complete');
+      const parsed = parseLogLine('info', 'endpoint{endpoint="github"}: Initialize handshake complete');
       expect(parsed.isToolCall).toBe(false);
     });
   });
@@ -111,7 +115,7 @@ describe('parseLogLine — endpointOverride (Slice D.2)', () => {
   it('uses the override when provided, ignoring the parsed span value', () => {
     const parsed = parseLogLine(
       'info',
-      'endpoint{endpoint=github transport=stdio}: hello',
+      'endpoint{endpoint="github" transport="stdio"}: hello',
       { endpointOverride: 'gmail' },
     );
     expect(parsed.endpoint).toBe('gmail');
@@ -122,7 +126,7 @@ describe('parseLogLine — endpointOverride (Slice D.2)', () => {
   it('falls back to the parsed value when override is null', () => {
     const parsed = parseLogLine(
       'info',
-      'endpoint{endpoint=github}: hello',
+      'endpoint{endpoint="github"}: hello',
       { endpointOverride: null },
     );
     expect(parsed.endpoint).toBe('github');
@@ -131,7 +135,7 @@ describe('parseLogLine — endpointOverride (Slice D.2)', () => {
   it('falls back to the parsed value when override is undefined', () => {
     const parsed = parseLogLine(
       'info',
-      'endpoint{endpoint=github}: hello',
+      'endpoint{endpoint="github"}: hello',
       { endpointOverride: undefined },
     );
     expect(parsed.endpoint).toBe('github');
@@ -146,19 +150,19 @@ describe('parseLogLine — endpointOverride (Slice D.2)', () => {
 describe('extractTimestamp', () => {
   it('parses an ISO timestamp prefix and returns the rest of the message', () => {
     const { timestamp, rest } = extractTimestamp(
-      '2026-05-20T10:32:05.123Z endpoint{endpoint=github}: hello'
+      '2026-05-20T10:32:05.123Z endpoint{endpoint="github"}: hello'
     );
     expect(timestamp.toISOString()).toBe('2026-05-20T10:32:05.123Z');
-    expect(rest).toBe('endpoint{endpoint=github}: hello');
+    expect(rest).toBe('endpoint{endpoint="github"}: hello');
   });
 
   it('falls back to the current time when no timestamp prefix is present', () => {
     const before = Date.now();
-    const { timestamp, rest } = extractTimestamp('endpoint{endpoint=github}: hello');
+    const { timestamp, rest } = extractTimestamp('endpoint{endpoint="github"}: hello');
     const after = Date.now();
     expect(timestamp.getTime()).toBeGreaterThanOrEqual(before);
     expect(timestamp.getTime()).toBeLessThanOrEqual(after);
-    expect(rest).toBe('endpoint{endpoint=github}: hello');
+    expect(rest).toBe('endpoint{endpoint="github"}: hello');
   });
 });
 
@@ -178,7 +182,7 @@ describe('parseLogLine — in-text level extraction (hotfix)', () => {
   it('extracts INFO level even when the sidecar passed a different default', () => {
     const parsed = parseLogLine(
       'info',
-      '2026-05-20T17:54:47.123Z INFO endpoint{endpoint=github transport=stdio}: Initialize handshake complete',
+      '2026-05-20T17:54:47.123Z INFO endpoint{endpoint="github" transport="stdio"}: Initialize handshake complete',
     );
     expect(parsed.level).toBe('info');
     expect(parsed.message.startsWith('INFO')).toBe(false);
@@ -189,7 +193,7 @@ describe('parseLogLine — in-text level extraction (hotfix)', () => {
   it('extracts WARN level and strips it from the message', () => {
     const parsed = parseLogLine(
       'info',
-      '2026-05-20T17:54:47.123Z WARN endpoint{endpoint=slack}: Connection lost, reconnecting',
+      '2026-05-20T17:54:47.123Z WARN endpoint{endpoint="slack"}: Connection lost, reconnecting',
     );
     expect(parsed.level).toBe('warn');
     expect(parsed.message.startsWith('WARN')).toBe(false);
@@ -199,7 +203,7 @@ describe('parseLogLine — in-text level extraction (hotfix)', () => {
   it('extracts ERROR level and strips it from the message', () => {
     const parsed = parseLogLine(
       'info',
-      '2026-05-20T17:54:47.123Z ERROR endpoint{endpoint=postgres}: MCP server exited',
+      '2026-05-20T17:54:47.123Z ERROR endpoint{endpoint="postgres"}: MCP server exited',
     );
     expect(parsed.level).toBe('error');
     expect(parsed.message.startsWith('ERROR')).toBe(false);


### PR DESCRIPTION
## Bug

Logs view "Endpoint" column shows `---` for every line in Endara Desktop 0.1.8-rc3 — no per-endpoint event surfaces a name to the UI.

## Root cause

The relay's CLI default log format became `compact` (endara-relay#67). Compact format emits span fields at the **end** of the line:

```
2026-05-22T15:10:11Z  INFO endpoint: endara_relay::adapter::http: MCP server reported serverInfo.name endpoint="github" transport="stdio"
```

Both desktop parsers (`parse_endpoint_from_span` in Rust and `SPAN_RE` in TypeScript) are written against tracing-subscriber's **Full** shape with span fields **inline**:

```
2026-05-22T15:10:43Z  INFO endpoint{endpoint="github" transport="stdio"}: <target>: <msg>
```

Because the Tauri sidecar spawn never passed `--log-format`, the relay defaulted to compact and neither parser ever extracted an endpoint → `endpoint` was always `null` on every `relay-log` event → the UI rendered `---`.

A secondary latent issue: the existing `parse_endpoint_from_span_tests` fixtures used unquoted span values (`endpoint=github`), which don't reflect what tracing-subscriber's Full formatter actually emits (quoted values: `endpoint="github"`). Tests would not have caught a quote-handling regression because no fixture exercised the real wire shape.

## Fix — two commits, desktop only

### 1. `fix(sidecar): pass --log-format text when launching relay so span fields appear inline`

Append `--log-format text` to `build_sidecar_args` in both dev and prod branches so the relay emits the inline Full-format shape the parsers expect. CLI/dev users keep `compact` as their default — this is a desktop-only pin. Existing `build_sidecar_args_dev_vs_prod` test updated.

### 2. `fix(logs): strip quotes in parse_endpoint_from_span and align tests with real Full-format wire shape`

- Replace the previous `trim_matches('"')` with a deliberate `strip_quote_pair` helper that removes exactly one surrounding pair, with an accurate docstring explaining the Full vs compact wire shapes.
- Update `parse_endpoint_from_span_tests` fixtures to the actual quoted Full-format shape. Keep one unquoted fixture so older buffered lines from a previous run still parse. Add an empty-quoted defense, plus a **negative compact-format test** that documents WHY the sidecar must run with `--log-format text`.
- Align `logParser.test.ts` span fixtures with the same quoted shape. **No** `logParser.ts` logic changes — its `FIELD_RE` already handles quoted values.

## Verification

```
cd packages/desktop/src-tauri && cargo fmt --check && cargo test
# → 69 passed; 0 failed
cd packages/desktop && npm test
# → 26 test files, 450 passed | 24 skipped
```

After this PR, opening the Logs tab on a build with this fix shows real endpoint names (`Household Workspace`, `Personal Workspace`, `github`, …) for adapter lines, and `---` only for relay-level events with no endpoint span (intentional).

## Out of scope

- No `packages/relay` change — relay's default stays `compact` for CLI users.
- No JSON-format migration.
- No new robustness pass making the desktop parsers handle compact-format trailing fields (separate follow-up if we want zero coupling to `--log-format`).
