### PR TITLE
feat: endpoint profiles UI

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,1912 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@tauri-apps/api':
+        specifier: ^2.11.0
+        version: 2.11.0
+      '@tauri-apps/plugin-autostart':
+        specifier: ^2.5.1
+        version: 2.5.1
+      '@tauri-apps/plugin-dialog':
+        specifier: ^2.7.1
+        version: 2.7.1
+      '@tauri-apps/plugin-notification':
+        specifier: ^2.3.3
+        version: 2.3.3
+      '@tauri-apps/plugin-opener':
+        specifier: ^2
+        version: 2.5.4
+      '@tauri-apps/plugin-process':
+        specifier: ^2.3.1
+        version: 2.3.1
+      '@tauri-apps/plugin-shell':
+        specifier: ^2.3.5
+        version: 2.3.5
+      '@tauri-apps/plugin-updater':
+        specifier: ^2.10.0
+        version: 2.10.1
+      svelte-sonner:
+        specifier: ^1.1.0
+        version: 1.1.1(svelte@5.55.9)
+    devDependencies:
+      '@sveltejs/adapter-static':
+        specifier: ^3.0.6
+        version: 3.0.10(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.9)(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.55.9)(typescript@5.6.3)(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0)))
+      '@sveltejs/kit':
+        specifier: ^2.59.1
+        version: 2.61.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.9)(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.55.9)(typescript@5.6.3)(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0))
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^5.0.0
+        version: 5.1.1(svelte@5.55.9)(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0))
+      '@tailwindcss/vite':
+        specifier: ^4
+        version: 4.3.0(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0))
+      '@tauri-apps/cli':
+        specifier: ^2
+        version: 2.11.2
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      svelte:
+        specifier: ^5.0.0
+        version: 5.55.9
+      svelte-check:
+        specifier: ^4.0.0
+        version: 4.4.8(picomatch@4.0.4)(svelte@5.55.9)(typescript@5.6.3)
+      tailwindcss:
+        specifier: ^4
+        version: 4.3.0
+      typescript:
+        specifier: ~5.6.2
+        version: 5.6.3
+      vite:
+        specifier: ^6.0.3
+        version: 6.4.2(jiti@2.7.0)(lightningcss@1.32.0)
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.7(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0))
+
+packages:
+
+  '@adobe/css-tools@4.5.0':
+    resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    resolution: {integrity: sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    resolution: {integrity: sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    resolution: {integrity: sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    resolution: {integrity: sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    resolution: {integrity: sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    resolution: {integrity: sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    resolution: {integrity: sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    resolution: {integrity: sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@sveltejs/acorn-typescript@1.0.10':
+    resolution: {integrity: sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==}
+    peerDependencies:
+      acorn: ^8.9.0
+
+  '@sveltejs/adapter-static@3.0.10':
+    resolution: {integrity: sha512-7D9lYFWJmB7zxZyTE/qxjksvMqzMuYrrsyh1f4AlZqeZeACPRySjbC3aFiY55wb1tWUaKOQG9PVbm74JcN2Iew==}
+    peerDependencies:
+      '@sveltejs/kit': ^2.0.0
+
+  '@sveltejs/kit@2.61.1':
+    resolution: {integrity: sha512-Ny8s1SR1TyQS2hD2Rvw0XKzU2Nw1eUF52dTb6T2bdcgz7wSC+Nyb5IwjWYlR4b2dvbbR5NJDiQwHg3rnNseghg==}
+    engines: {node: '>=18.13'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+      '@sveltejs/vite-plugin-svelte': ^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      typescript: ^5.3.3 || ^6.0.0
+      vite: ^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      typescript:
+        optional: true
+
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1':
+    resolution: {integrity: sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22}
+    peerDependencies:
+      '@sveltejs/vite-plugin-svelte': ^5.0.0
+      svelte: ^5.0.0
+      vite: ^6.0.0
+
+  '@sveltejs/vite-plugin-svelte@5.1.1':
+    resolution: {integrity: sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22}
+    peerDependencies:
+      svelte: ^5.0.0
+      vite: ^6.0.0
+
+  '@tailwindcss/node@4.3.0':
+    resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
+
+  '@tailwindcss/oxide-android-arm64@4.3.0':
+    resolution: {integrity: sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.0':
+    resolution: {integrity: sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.0':
+    resolution: {integrity: sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.0':
+    resolution: {integrity: sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
+    resolution: {integrity: sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
+    resolution: {integrity: sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
+    resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
+    resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.0':
+    resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.0':
+    resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
+    resolution: {integrity: sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
+    resolution: {integrity: sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.3.0':
+    resolution: {integrity: sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.3.0':
+    resolution: {integrity: sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tauri-apps/api@2.11.0':
+    resolution: {integrity: sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==}
+
+  '@tauri-apps/cli-darwin-arm64@2.11.2':
+    resolution: {integrity: sha512-+4UZzLt+eOAEQCwgd+TqKgyUJMrvx+BgdXLLaqJYmPqzP+nE6YZr/hY6CWLYGQb8jFn99jEkmC6uA3tNvamA1w==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tauri-apps/cli-darwin-x64@2.11.2':
+    resolution: {integrity: sha512-VjYYtZUPqDMLutSfJEyxFE3Bz+DPi7c8wC3imckgvciLDZLq4qwKJxBicg0BXGhXjJsl8vKWgWRFNMPELQ+Xyg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.2':
+    resolution: {integrity: sha512-yMemD6f4i95AQriS8EazyOFzbE34yjnP16i3IOzpHGQvBoy2DjypFMFBq0NtPuITURv/cOGguRtHR5d79/9CSA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tauri-apps/cli-linux-arm64-gnu@2.11.2':
+    resolution: {integrity: sha512-cgI91D2wL8GSgoWwZXDqt+DwnuZCP2/bz03QAE4TrhgAKIsrB4hX26W/H1EONPUUNkqrsgeCD0wU6pcNjV/5kw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tauri-apps/cli-linux-arm64-musl@2.11.2':
+    resolution: {integrity: sha512-X1rm0BERqAAggtYTESSgXrS3sz4Sb/OiPiz54UqISlXW+GkR3vNIGnsy/lejNmoXGVqri3Q53BCfQiclOIyRPw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tauri-apps/cli-linux-riscv64-gnu@2.11.2':
+    resolution: {integrity: sha512-usbMLJbT3KtkOrBMDVeGYNM35aTHXx38SJSzTMSqqjeUIOQ+iVPjb2yAGNAE+KqmBbAx4FOFIyMeKXx2M/JKGQ==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tauri-apps/cli-linux-x64-gnu@2.11.2':
+    resolution: {integrity: sha512-Ru4gwJKPG0ctVGchRGpRup4Y4lW2SSfFnrbQcyHhCliKy4g8Qz97TrUgCur4CbWyAgKxvGh3SjrkA0LDYzDGiw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tauri-apps/cli-linux-x64-musl@2.11.2':
+    resolution: {integrity: sha512-eUm7T6clN1MMmNSRQ9gaWsQdyehQx2Gmn5hht/QUlqZQI/qcP2OJK5dnaxqwFzCr2HdsEo9ydxaqcS1oJzMvUw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tauri-apps/cli-win32-arm64-msvc@2.11.2':
+    resolution: {integrity: sha512-HeeZW80jU+gVTOEX4X/hC6NVSAdDVXajwP5fxIZ/3z9WvUC7qrudX2GMTilYq6Dg0e0sk0XgsAJD1hZ5wPBXUA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tauri-apps/cli-win32-ia32-msvc@2.11.2':
+    resolution: {integrity: sha512-YhjQNZcXfbkCLyazSv1nPnJ9iRFE1wm6kc51FDbU10/Dk09io+6PAGMLjkxnX2GdM0qMnDmTjstY8mTDVvtKeA==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@tauri-apps/cli-win32-x64-msvc@2.11.2':
+    resolution: {integrity: sha512-d2JchlFIpZevZVReyqhQOekJmb1UH3rhZ5VX6sH3ty9ETE0TKQavpihvoScUXfKKpW6HZC0MrFGRU0ZtD+w3gA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tauri-apps/cli@2.11.2':
+    resolution: {integrity: sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw==}
+    engines: {node: '>= 10'}
+    hasBin: true
+
+  '@tauri-apps/plugin-autostart@2.5.1':
+    resolution: {integrity: sha512-zS/xx7yzveCcotkA+8TqkI2lysmG2wvQXv2HGAVExITmnFfHAdj1arGsbbfs3o6EktRHf6l34pJxc3YGG2mg7w==}
+
+  '@tauri-apps/plugin-dialog@2.7.1':
+    resolution: {integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==}
+
+  '@tauri-apps/plugin-notification@2.3.3':
+    resolution: {integrity: sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==}
+
+  '@tauri-apps/plugin-opener@2.5.4':
+    resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
+
+  '@tauri-apps/plugin-process@2.3.1':
+    resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
+
+  '@tauri-apps/plugin-shell@2.3.5':
+    resolution: {integrity: sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==}
+
+  '@tauri-apps/plugin-updater@2.10.1':
+    resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/cookie@0.6.0':
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@vitest/expect@4.1.7':
+    resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
+
+  '@vitest/mocker@4.1.7':
+    resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.7':
+    resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
+
+  '@vitest/runner@4.1.7':
+    resolution: {integrity: sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==}
+
+  '@vitest/snapshot@4.1.7':
+    resolution: {integrity: sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==}
+
+  '@vitest/spy@4.1.7':
+    resolution: {integrity: sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==}
+
+  '@vitest/utils@4.1.7':
+    resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  aria-query@5.3.1:
+    resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
+    engines: {node: '>= 0.4'}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@0.6.0:
+    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
+    engines: {node: '>= 0.6'}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  devalue@5.8.1:
+    resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  enhanced-resolve@5.22.0:
+    resolution: {integrity: sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A==}
+    engines: {node: '>=10.13.0'}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
+  esrap@2.2.9:
+    resolution: {integrity: sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A==}
+    peerDependencies:
+      '@typescript-eslint/types': ^8.2.0
+    peerDependenciesMeta:
+      '@typescript-eslint/types':
+        optional: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
+  rollup@4.60.4:
+    resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  runed@0.28.0:
+    resolution: {integrity: sha512-k2xx7RuO9hWcdd9f+8JoBeqWtYrm5CALfgpkg2YDB80ds/QE4w0qqu34A7fqiAwiBBSBQOid7TLxwxVC27ymWQ==}
+    peerDependencies:
+      svelte: ^5.7.0
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
+
+  set-cookie-parser@3.1.0:
+    resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
+  svelte-check@4.4.8:
+    resolution: {integrity: sha512-67adfgBox5eNSNIvIIwgFizKGdcRrGpiMoNO2obHcYuLz7iTa8Xgm/NGU3ntMFnNm8K1grFOIG6HhMLX/vcN8w==}
+    engines: {node: '>= 18.0.0'}
+    hasBin: true
+    peerDependencies:
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      typescript: '>=5.0.0'
+
+  svelte-sonner@1.1.1:
+    resolution: {integrity: sha512-5cd3p7wa4cq0NsqslMwdlPb7x1JglEZ/GKrLePWNr5bCxR1nagAVrY01FRFrXfUGs41miLt3C327+8XJo5BzZw==}
+    peerDependencies:
+      svelte: ^5.0.0
+
+  svelte@5.55.9:
+    resolution: {integrity: sha512-fTjjT8cHLDwigcu2j3pv7Jq04LklXevPB8uBgyHNiTXv+RMNvVnrjS4UEYrLMkhuq1vpCodHjiW+z/95SDs/fg==}
+    engines: {node: '>=18'}
+
+  tailwindcss@4.3.0:
+    resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.2:
+    resolution: {integrity: sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
+
+  typescript@5.6.3:
+    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitefu@1.1.3:
+    resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
+  vitest@4.1.7:
+    resolution: {integrity: sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.7
+      '@vitest/browser-preview': 4.1.7
+      '@vitest/browser-webdriverio': 4.1.7
+      '@vitest/coverage-istanbul': 4.1.7
+      '@vitest/coverage-v8': 4.1.7
+      '@vitest/ui': 4.1.7
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  zimmerframe@1.1.4:
+    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
+
+snapshots:
+
+  '@adobe/css-tools@4.5.0': {}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@polka/url@1.0.0-next.29': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    optional: true
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@sveltejs/acorn-typescript@1.0.10(acorn@8.16.0)':
+    dependencies:
+      acorn: 8.16.0
+
+  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.9)(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.55.9)(typescript@5.6.3)(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0)))':
+    dependencies:
+      '@sveltejs/kit': 2.61.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.9)(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.55.9)(typescript@5.6.3)(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0))
+
+  '@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.9)(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.55.9)(typescript@5.6.3)(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@sveltejs/acorn-typescript': 1.0.10(acorn@8.16.0)
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.9)(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0))
+      '@types/cookie': 0.6.0
+      acorn: 8.16.0
+      cookie: 0.6.0
+      devalue: 5.8.1
+      esm-env: 1.2.2
+      kleur: 4.1.5
+      magic-string: 0.30.21
+      mrmime: 2.0.1
+      set-cookie-parser: 3.1.0
+      sirv: 3.0.2
+      svelte: 5.55.9
+      vite: 6.4.2(jiti@2.7.0)(lightningcss@1.32.0)
+    optionalDependencies:
+      typescript: 5.6.3
+
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.9)(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.55.9)(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.9)(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0))
+      debug: 4.4.3
+      svelte: 5.55.9
+      vite: 6.4.2(jiti@2.7.0)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.9)(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.9)(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.55.9)(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0))
+      debug: 4.4.3
+      deepmerge: 4.3.1
+      kleur: 4.1.5
+      magic-string: 0.30.21
+      svelte: 5.55.9
+      vite: 6.4.2(jiti@2.7.0)(lightningcss@1.32.0)
+      vitefu: 1.1.3(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0))
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tailwindcss/node@4.3.0':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.22.0
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.0
+
+  '@tailwindcss/oxide-android-arm64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide@4.3.0':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.0
+      '@tailwindcss/oxide-darwin-arm64': 4.3.0
+      '@tailwindcss/oxide-darwin-x64': 4.3.0
+      '@tailwindcss/oxide-freebsd-x64': 4.3.0
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.0
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.0
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.0
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.0
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.0
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.0
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
+
+  '@tailwindcss/vite@4.3.0(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.0
+      '@tailwindcss/oxide': 4.3.0
+      tailwindcss: 4.3.0
+      vite: 6.4.2(jiti@2.7.0)(lightningcss@1.32.0)
+
+  '@tauri-apps/api@2.11.0': {}
+
+  '@tauri-apps/cli-darwin-arm64@2.11.2':
+    optional: true
+
+  '@tauri-apps/cli-darwin-x64@2.11.2':
+    optional: true
+
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.2':
+    optional: true
+
+  '@tauri-apps/cli-linux-arm64-gnu@2.11.2':
+    optional: true
+
+  '@tauri-apps/cli-linux-arm64-musl@2.11.2':
+    optional: true
+
+  '@tauri-apps/cli-linux-riscv64-gnu@2.11.2':
+    optional: true
+
+  '@tauri-apps/cli-linux-x64-gnu@2.11.2':
+    optional: true
+
+  '@tauri-apps/cli-linux-x64-musl@2.11.2':
+    optional: true
+
+  '@tauri-apps/cli-win32-arm64-msvc@2.11.2':
+    optional: true
+
+  '@tauri-apps/cli-win32-ia32-msvc@2.11.2':
+    optional: true
+
+  '@tauri-apps/cli-win32-x64-msvc@2.11.2':
+    optional: true
+
+  '@tauri-apps/cli@2.11.2':
+    optionalDependencies:
+      '@tauri-apps/cli-darwin-arm64': 2.11.2
+      '@tauri-apps/cli-darwin-x64': 2.11.2
+      '@tauri-apps/cli-linux-arm-gnueabihf': 2.11.2
+      '@tauri-apps/cli-linux-arm64-gnu': 2.11.2
+      '@tauri-apps/cli-linux-arm64-musl': 2.11.2
+      '@tauri-apps/cli-linux-riscv64-gnu': 2.11.2
+      '@tauri-apps/cli-linux-x64-gnu': 2.11.2
+      '@tauri-apps/cli-linux-x64-musl': 2.11.2
+      '@tauri-apps/cli-win32-arm64-msvc': 2.11.2
+      '@tauri-apps/cli-win32-ia32-msvc': 2.11.2
+      '@tauri-apps/cli-win32-x64-msvc': 2.11.2
+
+  '@tauri-apps/plugin-autostart@2.5.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
+  '@tauri-apps/plugin-dialog@2.7.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
+  '@tauri-apps/plugin-notification@2.3.3':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
+  '@tauri-apps/plugin-opener@2.5.4':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
+  '@tauri-apps/plugin-process@2.3.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
+  '@tauri-apps/plugin-shell@2.3.5':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
+  '@tauri-apps/plugin-updater@2.10.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.5.0
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/cookie@0.6.0': {}
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/trusted-types@2.0.7': {}
+
+  '@vitest/expect@4.1.7':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.7(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@vitest/spy': 4.1.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.2(jiti@2.7.0)(lightningcss@1.32.0)
+
+  '@vitest/pretty-format@4.1.7':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.7':
+    dependencies:
+      '@vitest/utils': 4.1.7
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/utils': 4.1.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.7': {}
+
+  '@vitest/utils@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  acorn@8.16.0: {}
+
+  aria-query@5.3.1: {}
+
+  aria-query@5.3.2: {}
+
+  assertion-error@2.0.1: {}
+
+  axobject-query@4.1.0: {}
+
+  chai@6.2.2: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  clsx@2.1.1: {}
+
+  convert-source-map@2.0.0: {}
+
+  cookie@0.6.0: {}
+
+  css.escape@1.5.1: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deepmerge@4.3.1: {}
+
+  detect-libc@2.1.2: {}
+
+  devalue@5.8.1: {}
+
+  dom-accessibility-api@0.6.3: {}
+
+  enhanced-resolve@5.22.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
+  es-module-lexer@2.1.0: {}
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  esm-env@1.2.2: {}
+
+  esrap@2.2.9:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.3.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.3:
+    optional: true
+
+  graceful-fs@4.2.11: {}
+
+  indent-string@4.0.0: {}
+
+  is-reference@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  jiti@2.7.0: {}
+
+  kleur@4.1.5: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  locate-character@3.0.0: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  min-indent@1.0.1: {}
+
+  mri@1.2.0: {}
+
+  mrmime@2.0.1: {}
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.12: {}
+
+  obug@2.1.1: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  readdirp@4.1.2: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
+  rollup@4.60.4:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.4
+      '@rollup/rollup-android-arm64': 4.60.4
+      '@rollup/rollup-darwin-arm64': 4.60.4
+      '@rollup/rollup-darwin-x64': 4.60.4
+      '@rollup/rollup-freebsd-arm64': 4.60.4
+      '@rollup/rollup-freebsd-x64': 4.60.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.4
+      '@rollup/rollup-linux-arm64-gnu': 4.60.4
+      '@rollup/rollup-linux-arm64-musl': 4.60.4
+      '@rollup/rollup-linux-loong64-gnu': 4.60.4
+      '@rollup/rollup-linux-loong64-musl': 4.60.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.4
+      '@rollup/rollup-linux-ppc64-musl': 4.60.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.4
+      '@rollup/rollup-linux-riscv64-musl': 4.60.4
+      '@rollup/rollup-linux-s390x-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-musl': 4.60.4
+      '@rollup/rollup-openbsd-x64': 4.60.4
+      '@rollup/rollup-openharmony-arm64': 4.60.4
+      '@rollup/rollup-win32-arm64-msvc': 4.60.4
+      '@rollup/rollup-win32-ia32-msvc': 4.60.4
+      '@rollup/rollup-win32-x64-gnu': 4.60.4
+      '@rollup/rollup-win32-x64-msvc': 4.60.4
+      fsevents: 2.3.3
+
+  runed@0.28.0(svelte@5.55.9):
+    dependencies:
+      esm-env: 1.2.2
+      svelte: 5.55.9
+
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
+
+  set-cookie-parser@3.1.0: {}
+
+  siginfo@2.0.0: {}
+
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
+  svelte-check@4.4.8(picomatch@4.0.4)(svelte@5.55.9)(typescript@5.6.3):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      chokidar: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picocolors: 1.1.1
+      sade: 1.8.1
+      svelte: 5.55.9
+      typescript: 5.6.3
+    transitivePeerDependencies:
+      - picomatch
+
+  svelte-sonner@1.1.1(svelte@5.55.9):
+    dependencies:
+      runed: 0.28.0(svelte@5.55.9)
+      svelte: 5.55.9
+
+  svelte@5.55.9:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@sveltejs/acorn-typescript': 1.0.10(acorn@8.16.0)
+      '@types/estree': 1.0.9
+      '@types/trusted-types': 2.0.7
+      acorn: 8.16.0
+      aria-query: 5.3.1
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      devalue: 5.8.1
+      esm-env: 1.2.2
+      esrap: 2.2.9
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.21
+      zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
+
+  tailwindcss@4.3.0: {}
+
+  tapable@2.3.3: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  totalist@3.0.1: {}
+
+  typescript@5.6.3: {}
+
+  vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.60.4
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+
+  vitefu@1.1.3(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0)):
+    optionalDependencies:
+      vite: 6.4.2(jiti@2.7.0)(lightningcss@1.32.0)
+
+  vitest@4.1.7(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0)):
+    dependencies:
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 6.4.2(jiti@2.7.0)(lightningcss@1.32.0)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  zimmerframe@1.1.4: {}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -392,3 +392,65 @@ export async function oauthSetupCancel(sessionId: string): Promise<void> {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Profiles
+// ---------------------------------------------------------------------------
+
+export interface ProfileSummary {
+  name: string;
+  path: string;
+  endpoints: string[];
+  /** `null` = inherit from `RelayConfig::local_js_execution`. */
+  js_execution: boolean | null;
+  /** `null` = inherit from `RelayConfig::toon_output`. */
+  toon_output: boolean | null;
+  endpoint_count: number;
+  tool_count: number;
+}
+
+export interface ProfileDetail extends ProfileSummary {
+  /** Full catalog scoped to the profile's endpoints. */
+  tools: Tool[];
+}
+
+export interface CreateProfileParams {
+  name: string;
+  path: string;
+  endpoints: string[];
+  js_execution?: boolean | null;
+  toon_output?: boolean | null;
+}
+
+export type UpdateProfileParams = CreateProfileParams;
+
+export async function listProfiles(): Promise<ProfileSummary[]> {
+  return fetchJson<ProfileSummary[]>('/profiles');
+}
+
+export async function getProfile(path: string): Promise<ProfileDetail> {
+  return fetchJson<ProfileDetail>(`/profiles/${encodeURIComponent(path)}`);
+}
+
+export async function createProfile(params: CreateProfileParams): Promise<ProfileSummary> {
+  return fetchJson<ProfileSummary>('/profiles', { method: 'POST', body: params });
+}
+
+export async function updateProfile(
+  path: string,
+  params: UpdateProfileParams,
+): Promise<ProfileSummary> {
+  return fetchJson<ProfileSummary>(`/profiles/${encodeURIComponent(path)}`, {
+    method: 'PUT',
+    body: params,
+  });
+}
+
+export async function deleteProfile(path: string): Promise<void> {
+  await fetchJson(`/profiles/${encodeURIComponent(path)}`, { method: 'DELETE' });
+}
+
+export async function getEndpointProfiles(name: string): Promise<{ profiles: string[] }> {
+  return fetchJson<{ profiles: string[] }>(
+    `/endpoints/${encodeURIComponent(name)}/profiles`,
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -400,10 +400,10 @@ export interface ProfileSummary {
   name: string;
   path: string;
   endpoints: string[];
-  /** `null` = inherit from `RelayConfig::local_js_execution`. */
-  js_execution: boolean | null;
-  /** `null` = inherit from `RelayConfig::toon_output`. */
-  toon_output: boolean | null;
+  /** Per-profile JS-execution toggle. Always a concrete boolean. */
+  js_execution: boolean;
+  /** Per-profile TOON output toggle. Always a concrete boolean. */
+  toon_output: boolean;
   endpoint_count: number;
   tool_count: number;
 }
@@ -417,8 +417,10 @@ export interface CreateProfileParams {
   name: string;
   path: string;
   endpoints: string[];
-  js_execution?: boolean | null;
-  toon_output?: boolean | null;
+  /** Required; relay rejects requests that omit it. */
+  js_execution: boolean;
+  /** Required; relay rejects requests that omit it. */
+  toon_output: boolean;
 }
 
 export type UpdateProfileParams = CreateProfileParams;

--- a/src/lib/components/CreateProfileModal.svelte
+++ b/src/lib/components/CreateProfileModal.svelte
@@ -97,6 +97,10 @@
             oninput={() => { pathTouched = true; }}
             onblur={() => { pathTouched = true; }}
             placeholder="work"
+            autocapitalize="off"
+            autocorrect="off"
+            spellcheck="false"
+            autocomplete="off"
             aria-invalid={!!pathError}
             class="flex-1 text-sm px-3 py-1.5 bg-transparent text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none"
           />

--- a/src/lib/components/CreateProfileModal.svelte
+++ b/src/lib/components/CreateProfileModal.svelte
@@ -1,0 +1,169 @@
+<script lang="ts">
+  import { createProfile, type ProfileSummary } from '$lib/api';
+  import { focusTrap } from '$lib/actions/focusTrap';
+  import { toast } from 'svelte-sonner';
+  import {
+    buildCreateProfilePayload,
+    isCreateProfileFormValid,
+    validateProfileName,
+    validateProfilePath,
+  } from './create-profile-helpers';
+
+  let { onclose, oncreated }: {
+    onclose: () => void;
+    oncreated?: (profile: ProfileSummary) => void;
+  } = $props();
+
+  let name = $state('');
+  let path = $state('');
+  let jsExecution = $state(true);
+  let toonOutput = $state(true);
+
+  let nameTouched = $state(false);
+  let pathTouched = $state(false);
+  let submitting = $state(false);
+  let submitError = $state('');
+
+  let nameError = $derived(nameTouched ? validateProfileName(name) : null);
+  let pathError = $derived(pathTouched ? validateProfilePath(path) : null);
+  let formValid = $derived(isCreateProfileFormValid(name, path));
+
+  async function handleCreate() {
+    nameTouched = true;
+    pathTouched = true;
+    submitError = '';
+    if (!isCreateProfileFormValid(name, path)) return;
+
+    submitting = true;
+    try {
+      const created = await createProfile(
+        buildCreateProfilePayload({ name, path, jsExecution, toonOutput }),
+      );
+      toast.success(`Profile "${created.name}" created`);
+      oncreated?.(created);
+      onclose();
+    } catch (e) {
+      submitError = e instanceof Error ? e.message : String(e);
+      toast.error(`Failed to create "${name.trim()}"`);
+    } finally {
+      submitting = false;
+    }
+  }
+
+  function handleCancel() {
+    if (submitting) return;
+    onclose();
+  }
+</script>
+
+<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="presentation" onclick={handleCancel}>
+  <div
+    class="bg-(--surface) rounded-xl shadow-xl border border-(--border) p-6 w-[28rem] max-w-[90vw] max-h-[90vh] overflow-y-auto"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Create Profile"
+    tabindex="-1"
+    use:focusTrap={{ onEscape: handleCancel }}
+    onclick={(e) => e.stopPropagation()}
+    onkeydown={(e) => e.stopPropagation()}
+  >
+    <h3 class="text-base font-semibold mb-4 text-(--fg1)">Create Profile</h3>
+
+    <div class="space-y-3">
+      <div>
+        <label for="create-profile-name" class="block text-xs font-medium mb-1 text-(--fg2)">Name</label>
+        <input
+          id="create-profile-name"
+          type="text"
+          bind:value={name}
+          onblur={() => { nameTouched = true; }}
+          placeholder="Work"
+          aria-invalid={!!nameError}
+          class="w-full text-sm px-3 py-1.5 rounded-lg border bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) {nameError ? 'border-(--offline)' : 'border-(--border)'}"
+        />
+        {#if nameError}
+          <p class="text-[11px] text-(--offline) mt-0.5">{nameError}</p>
+        {/if}
+      </div>
+
+      <div>
+        <label for="create-profile-path" class="block text-xs font-medium mb-1 text-(--fg2)">Path</label>
+        <div class="flex items-stretch rounded-lg border {pathError ? 'border-(--offline)' : 'border-(--border)'} bg-(--surface) overflow-hidden focus-within:border-(--accent)">
+          <span class="flex items-center px-2 text-xs text-(--fg2) bg-(--surface-hover) border-r border-(--border) select-none">/mcp/</span>
+          <input
+            id="create-profile-path"
+            type="text"
+            bind:value={path}
+            oninput={() => { pathTouched = true; }}
+            onblur={() => { pathTouched = true; }}
+            placeholder="work"
+            aria-invalid={!!pathError}
+            class="flex-1 text-sm px-3 py-1.5 bg-transparent text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none"
+          />
+        </div>
+        {#if pathError}
+          <p class="text-[11px] text-(--offline) mt-0.5">{pathError}</p>
+        {:else}
+          <p class="text-[11px] text-(--fg2) mt-0.5">Letters, numbers, _ or - only. Served at <code>/mcp/{path || 'work'}</code>.</p>
+        {/if}
+      </div>
+
+      <div class="flex items-start justify-between gap-4 pt-1">
+        <div>
+          <div class="text-sm font-medium">JS Execution Mode</div>
+          <div class="text-xs text-(--fg2) mt-0.5">When on, this profile exposes only the three meta-tools (list_tools, search_tools, execute_tools).</div>
+        </div>
+        <button
+          type="button"
+          class="shrink-0 relative w-10 h-5 rounded-full transition-colors {jsExecution ? 'bg-green-500' : 'bg-gray-300 dark:bg-gray-600'}"
+          onclick={() => { jsExecution = !jsExecution; }}
+          role="switch"
+          aria-checked={jsExecution}
+          aria-label="Toggle JS execution mode for this profile"
+        >
+          <span class="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform {jsExecution ? 'translate-x-5' : ''}"></span>
+        </button>
+      </div>
+
+      <div class="flex items-start justify-between gap-4">
+        <div>
+          <div class="text-sm font-medium">TOON Output</div>
+          <div class="text-xs text-(--fg2) mt-0.5">When on, tool responses for this profile are TOON-encoded.</div>
+        </div>
+        <button
+          type="button"
+          class="shrink-0 relative w-10 h-5 rounded-full transition-colors {toonOutput ? 'bg-green-500' : 'bg-gray-300 dark:bg-gray-600'}"
+          onclick={() => { toonOutput = !toonOutput; }}
+          role="switch"
+          aria-checked={toonOutput}
+          aria-label="Toggle TOON output for this profile"
+        >
+          <span class="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform {toonOutput ? 'translate-x-5' : ''}"></span>
+        </button>
+      </div>
+
+      {#if submitError}
+        <p class="text-xs text-(--offline)">{submitError}</p>
+      {/if}
+
+      <div class="flex justify-end gap-2 pt-2">
+        <button
+          type="button"
+          class="px-3 py-1.5 text-sm rounded-lg border border-(--border) hover:bg-(--surface-hover) transition-colors disabled:opacity-50"
+          onclick={handleCancel}
+          disabled={submitting}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          class="px-3 py-1.5 text-sm rounded-lg bg-(--accent) text-white hover:bg-(--accent-hover) transition-colors disabled:opacity-50"
+          onclick={handleCreate}
+          disabled={!formValid || submitting}
+        >
+          {submitting ? 'Creating…' : 'Create'}
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/lib/components/CreateProfileModal.svelte
+++ b/src/lib/components/CreateProfileModal.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { createProfile, type ProfileSummary } from '$lib/api';
   import { focusTrap } from '$lib/actions/focusTrap';
+  import { jsExecutionMode, toonOutput as toonOutputStore } from '$lib/stores';
+  import { get } from 'svelte/store';
   import { toast } from 'svelte-sonner';
   import {
     buildCreateProfilePayload,
@@ -16,8 +18,11 @@
 
   let name = $state('');
   let path = $state('');
-  let jsExecution = $state(true);
-  let toonOutput = $state(true);
+  // Copy-on-write from the current global relay defaults, snapshotted once at
+  // modal open. If the user changes the global setting elsewhere while the
+  // modal is open, the toggles here don't shift under them.
+  let jsExecution = $state(get(jsExecutionMode));
+  let toonOutput = $state(get(toonOutputStore));
 
   let nameTouched = $state(false);
   let pathTouched = $state(false);

--- a/src/lib/components/CreateProfileModal.test.ts
+++ b/src/lib/components/CreateProfileModal.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import {
+  RESERVED_PROFILE_PATHS,
+  buildCreateProfilePayload,
+  isCreateProfileFormValid,
+  validateProfileName,
+  validateProfilePath,
+} from './create-profile-helpers';
+
+// Engineering Spec §11 desktop test matrix — rows #1, #2, #3 cover the
+// CreateProfileModal validation + submit pipeline. Component markup lives in
+// `CreateProfileModal.svelte`; the validation + payload-building logic is
+// pulled into `create-profile-helpers.ts` so it can be exercised without a
+// DOM-rendering test setup (vitest runs in the Node environment here).
+
+describe('validateProfilePath — matrix #1 (valid paths)', () => {
+  it.each([
+    ['work'],
+    ['my-project'],
+    ['side_project'],
+    ['A1'],
+    ['a'],
+    ['9'],
+    ['a-b_c-1'],
+  ])('accepts %s', (path) => {
+    expect(validateProfilePath(path)).toBeNull();
+  });
+});
+
+describe('validateProfilePath — matrix #2 (invalid paths)', () => {
+  it('rejects an empty string', () => {
+    expect(validateProfilePath('')).toBe('Path is required');
+  });
+
+  it.each([
+    ['-leading-dash'],
+    ['_leading-underscore'],
+    ['has space'],
+    ['has/slash'],
+    ['has.dot'],
+    ['unicodé'],
+    ['emoji🚀'],
+  ])('rejects %s with a regex-violation message', (path) => {
+    const msg = validateProfilePath(path);
+    expect(msg).not.toBeNull();
+    expect(msg).toMatch(/letters, numbers/);
+  });
+
+  it.each(RESERVED_PROFILE_PATHS)('rejects reserved path %s', (path) => {
+    const msg = validateProfilePath(path);
+    expect(msg).not.toBeNull();
+    expect(msg).toMatch(/reserved/);
+  });
+
+  it('rejects reserved paths case-insensitively', () => {
+    expect(validateProfilePath('SSE')).toMatch(/reserved/);
+    expect(validateProfilePath('Tools')).toMatch(/reserved/);
+    expect(validateProfilePath('OAUTH')).toMatch(/reserved/);
+  });
+});
+
+describe('validateProfileName', () => {
+  it('requires a non-empty name', () => {
+    expect(validateProfileName('')).toBe('Name is required');
+    expect(validateProfileName('   ')).toBe('Name is required');
+  });
+
+  it('accepts any non-empty freeform name', () => {
+    expect(validateProfileName('Work')).toBeNull();
+    expect(validateProfileName('Side Project 🚀')).toBeNull();
+  });
+});
+
+describe('isCreateProfileFormValid', () => {
+  it('is false when path is invalid even if name is valid', () => {
+    expect(isCreateProfileFormValid('Work', 'has space')).toBe(false);
+  });
+
+  it('is false when name is empty even if path is valid', () => {
+    expect(isCreateProfileFormValid('', 'work')).toBe(false);
+  });
+
+  it('is true when both fields pass validation', () => {
+    expect(isCreateProfileFormValid('Work', 'work')).toBe(true);
+  });
+});
+
+describe('buildCreateProfilePayload — matrix #3 (submit payload)', () => {
+  it('builds the POST /api/profiles body with the modal inputs', () => {
+    const payload = buildCreateProfilePayload({
+      name: 'Work',
+      path: 'work',
+      jsExecution: true,
+      toonOutput: true,
+    });
+    expect(payload).toEqual({
+      name: 'Work',
+      path: 'work',
+      endpoints: [],
+      js_execution: true,
+      toon_output: true,
+    });
+  });
+
+  it('trims surrounding whitespace from the name (path is regex-enforced)', () => {
+    const payload = buildCreateProfilePayload({
+      name: '  Side Project  ',
+      path: 'side-project',
+      jsExecution: false,
+      toonOutput: true,
+    });
+    expect(payload.name).toBe('Side Project');
+    expect(payload.path).toBe('side-project');
+  });
+
+  it('preserves the explicit toggle values without coercing to null', () => {
+    const payload = buildCreateProfilePayload({
+      name: 'Personal',
+      path: 'personal',
+      jsExecution: false,
+      toonOutput: false,
+    });
+    expect(payload.js_execution).toBe(false);
+    expect(payload.toon_output).toBe(false);
+  });
+
+  it('seeds an empty endpoints list (assignment happens after creation)', () => {
+    const payload = buildCreateProfilePayload({
+      name: 'Work',
+      path: 'work',
+      jsExecution: true,
+      toonOutput: true,
+    });
+    expect(payload.endpoints).toEqual([]);
+  });
+});

--- a/src/lib/components/DetailPanel.svelte
+++ b/src/lib/components/DetailPanel.svelte
@@ -13,6 +13,7 @@
   import EndpointIcon from './EndpointIcon.svelte';
   import TransportBadge from './TransportBadge.svelte';
   import AuthTab from './AuthTab.svelte';
+  import ProfilesTab from './ProfilesTab.svelte';
   import {
     shouldShowRestartButton,
     shouldShowRefreshButton,
@@ -42,7 +43,7 @@
 
   $effect(() => {
     const ep = $selectedEndpointData;
-    if (ep?.disabled && ($activeTab === 'tools' || $activeTab === 'logs')) {
+    if (ep?.disabled && ($activeTab === 'tools' || $activeTab === 'logs' || $activeTab === 'profiles')) {
       activeTab.set('config');
     }
   });
@@ -226,6 +227,8 @@
         <LogsTab />
       {:else if $activeTab === 'auth' && ep.transport === 'oauth'}
         <AuthTab />
+      {:else if $activeTab === 'profiles' && !ep.disabled}
+        <ProfilesTab />
       {:else}
         <ConfigTab />
       {/if}

--- a/src/lib/components/LogFilterBar.svelte
+++ b/src/lib/components/LogFilterBar.svelte
@@ -10,6 +10,7 @@
     filteredCount: number;
     activeLevels: Set<LogLevel>;
     selectedEndpoints: Set<string>;
+    selectedProfiles: Set<string>;
     searchText: string;
     toolCallsOnly: boolean;
     onclear: () => void;
@@ -20,6 +21,7 @@
     filteredCount,
     activeLevels = $bindable(),
     selectedEndpoints = $bindable(),
+    selectedProfiles = $bindable(),
     searchText = $bindable(),
     toolCallsOnly = $bindable(),
     onclear,
@@ -29,6 +31,7 @@
   // the bindable `searchText` prop. 150ms matches the engineering spec.
   let searchInput = $state(searchText);
   let endpointMenuOpen = $state(false);
+  let profileMenuOpen = $state(false);
 
   let debounceTimer: ReturnType<typeof setTimeout> | undefined;
   $effect(() => {
@@ -54,6 +57,12 @@
     return Array.from(set).sort();
   });
 
+  const allProfiles = $derived.by(() => {
+    const set = new Set<string>();
+    for (const line of lines) if (line.profile) set.add(line.profile);
+    return Array.from(set).sort();
+  });
+
   const toolCallCount = $derived.by(() => {
     let n = 0;
     for (const line of lines) if (line.isToolCall) n++;
@@ -76,6 +85,17 @@
 
   function selectAllEndpoints() {
     selectedEndpoints = new Set();
+  }
+
+  function toggleProfile(name: string) {
+    const next = new Set(selectedProfiles);
+    if (next.has(name)) next.delete(name);
+    else next.add(name);
+    selectedProfiles = next;
+  }
+
+  function selectAllProfiles() {
+    selectedProfiles = new Set();
   }
 
   function levelPillClass(level: LogLevel, active: boolean): string {
@@ -148,6 +168,44 @@
             </li>
           {:else}
             <li class="px-3 py-1.5 text-(--fg3) italic">No endpoints yet</li>
+          {/each}
+        </ul>
+      {/if}
+    </div>
+
+    <div class="relative">
+      <button
+        type="button"
+        class="btn-sec btn-sm"
+        aria-haspopup="listbox"
+        aria-expanded={profileMenuOpen}
+        onclick={() => (profileMenuOpen = !profileMenuOpen)}
+      >
+        Profile: {selectedProfiles.size === 0
+          ? 'All'
+          : selectedProfiles.size === 1
+            ? Array.from(selectedProfiles)[0]
+            : `${selectedProfiles.size} selected`} ▾
+      </button>
+      {#if profileMenuOpen}
+        <ul
+          role="listbox"
+          aria-multiselectable="true"
+          class="absolute right-0 mt-1 z-10 min-w-[12rem] max-h-64 overflow-y-auto rounded-md border border-(--border) bg-(--surface) shadow-lg text-sm"
+        >
+          <li>
+            <button type="button" class="w-full text-left px-3 py-1.5 hover:bg-(--surface-hover)" onclick={selectAllProfiles}>
+              {selectedProfiles.size === 0 ? '✓ ' : '  '}All
+            </button>
+          </li>
+          {#each allProfiles as pr (pr)}
+            <li>
+              <button type="button" class="w-full text-left px-3 py-1.5 hover:bg-(--surface-hover) font-mono" onclick={() => toggleProfile(pr)}>
+                {selectedProfiles.has(pr) ? '✓ ' : '  '}{pr}
+              </button>
+            </li>
+          {:else}
+            <li class="px-3 py-1.5 text-(--fg3) italic">No profiles yet</li>
           {/each}
         </ul>
       {/if}

--- a/src/lib/components/LogFilterBar.test.ts
+++ b/src/lib/components/LogFilterBar.test.ts
@@ -11,18 +11,23 @@ interface LogFilterState {
   activeLevels: Set<LogLevel>;
   searchText: string;
   selectedEndpoints: Set<string>; // empty = "All"
+  selectedProfiles?: Set<string>; // empty / undefined = "All"
   toolCallsOnly?: boolean;
 }
 
 function applyLogFilters(lines: ParsedLogLine[], state: LogFilterState): ParsedLogLine[] {
   const q = state.searchText.trim().toLowerCase();
   const hasEndpointFilter = state.selectedEndpoints.size > 0;
+  const hasProfileFilter = (state.selectedProfiles?.size ?? 0) > 0;
   const toolCallsOnly = state.toolCallsOnly === true;
   return lines.filter((line) => {
     if (!state.activeLevels.has(line.level)) return false;
     if (toolCallsOnly && !line.isToolCall) return false;
     if (hasEndpointFilter) {
       if (!line.endpoint || !state.selectedEndpoints.has(line.endpoint)) return false;
+    }
+    if (hasProfileFilter) {
+      if (!line.profile || !state.selectedProfiles!.has(line.profile)) return false;
     }
     if (q.length > 0 && !line.raw.toLowerCase().includes(q)) return false;
     return true;
@@ -150,6 +155,69 @@ describe('applyLogFilters', () => {
       selectedEndpoints: new Set(['github']),
     });
     expect(noMatch).toHaveLength(0);
+  });
+
+  // #8 — Profile filter shows only lines matching the selected profile(s).
+  // Mirrors the engineering-spec test matrix row "Log filter — profile" and
+  // exercises the multi-select dropdown locked decision (Desktop #5).
+  it('restricts to the selected profiles (empty set = All)', () => {
+    const lines: ParsedLogLine[] = [
+      parseLogLine('info', 'mcp_request{profile=work} endpoint{endpoint=gmail}: tools/list ok'),
+      parseLogLine('info', 'mcp_request{profile=work} endpoint{endpoint=linear}: tools/call ok'),
+      parseLogLine('info', 'mcp_request{profile=personal} endpoint{endpoint=gmail}: tools/list ok'),
+      parseLogLine('info', 'endpoint{endpoint=github}: Initialize handshake complete'),
+    ];
+
+    const justWork = applyLogFilters(lines, {
+      activeLevels: ALL_LEVELS,
+      searchText: '',
+      selectedEndpoints: new Set(),
+      selectedProfiles: new Set(['work']),
+    });
+    expect(justWork).toHaveLength(2);
+    expect(justWork.every((l) => l.profile === 'work')).toBe(true);
+
+    const workOrPersonal = applyLogFilters(lines, {
+      activeLevels: ALL_LEVELS,
+      searchText: '',
+      selectedEndpoints: new Set(),
+      selectedProfiles: new Set(['work', 'personal']),
+    });
+    expect(workOrPersonal).toHaveLength(3);
+    expect(workOrPersonal.every((l) => l.profile !== undefined)).toBe(true);
+
+    // Lines with no profile (the github init) are excluded when a profile
+    // filter is active — same shape as the endpoint filter's "All" semantics.
+    const noProfileless = workOrPersonal.find((l) => l.profile === undefined);
+    expect(noProfileless).toBeUndefined();
+
+    // Empty set = "All" — the profile-less line is kept alongside the rest.
+    const all = applyLogFilters(lines, {
+      activeLevels: ALL_LEVELS,
+      searchText: '',
+      selectedEndpoints: new Set(),
+      selectedProfiles: new Set(),
+    });
+    expect(all).toHaveLength(lines.length);
+
+    // Undefined selectedProfiles is also treated as "All".
+    const allUndefined = applyLogFilters(lines, {
+      activeLevels: ALL_LEVELS,
+      searchText: '',
+      selectedEndpoints: new Set(),
+    });
+    expect(allUndefined).toHaveLength(lines.length);
+
+    // AND-combines with the endpoint filter: work + gmail keeps just the one row.
+    const workAndGmail = applyLogFilters(lines, {
+      activeLevels: ALL_LEVELS,
+      searchText: '',
+      selectedEndpoints: new Set(['gmail']),
+      selectedProfiles: new Set(['work']),
+    });
+    expect(workAndGmail).toHaveLength(1);
+    expect(workAndGmail[0].profile).toBe('work');
+    expect(workAndGmail[0].endpoint).toBe('gmail');
   });
 
   // #16 — "Tool calls only" filter shows only isToolCall === true lines, and

--- a/src/lib/components/ProfileDetail.svelte
+++ b/src/lib/components/ProfileDetail.svelte
@@ -1,0 +1,383 @@
+<script lang="ts">
+  import type { ProfileDetail, ProfileSummary } from '$lib/api';
+  import { getProfile, listProfiles, updateProfile, deleteProfile } from '$lib/api';
+  import { endpoints } from '$lib/stores';
+  import { registerDirtyChecker } from '$lib/stores/unsavedChangesGuard';
+  import { toast } from 'svelte-sonner';
+  import ConfirmModal from './ConfirmModal.svelte';
+  import TransportBadge from './TransportBadge.svelte';
+  import { validateProfileName, validateProfilePath } from './create-profile-helpers';
+  import {
+    buildUpdateProfileParams,
+    computeProfileIsDirty,
+    formFromDetail,
+    runDeleteProfile,
+    runSaveProfile,
+    toggleStagedEndpoint,
+    type ProfileEditForm,
+  } from './profile-detail-helpers';
+
+  let {
+    selectedPath,
+    onprofilesreload,
+    onselect,
+  }: {
+    selectedPath: string | null;
+    onprofilesreload: (profiles: ProfileSummary[]) => void;
+    onselect: (path: string | null) => void;
+  } = $props();
+
+  let detail = $state<ProfileDetail | null>(null);
+  let form = $state<ProfileEditForm | null>(null);
+  let loading = $state(false);
+  let saving = $state(false);
+  let deleting = $state(false);
+  let loadError = $state('');
+  let showDeleteConfirm = $state(false);
+
+  // Load detail when the selected path changes. Cleared when nothing is
+  // selected so the empty-state placeholder renders.
+  $effect(() => {
+    const path = selectedPath;
+    if (!path) {
+      detail = null;
+      form = null;
+      loadError = '';
+      return;
+    }
+    loading = true;
+    loadError = '';
+    getProfile(path)
+      .then((d) => {
+        // Bail if the user moved on while we were loading.
+        if (selectedPath !== path) return;
+        detail = d;
+        form = formFromDetail(d);
+      })
+      .catch(() => {
+        if (selectedPath !== path) return;
+        detail = null;
+        form = null;
+        loadError = `Failed to load profile "${path}"`;
+      })
+      .finally(() => {
+        if (selectedPath === path) loading = false;
+      });
+  });
+
+  let nameError = $derived(form ? validateProfileName(form.name) : null);
+  let pathError = $derived(form ? validateProfilePath(form.path) : null);
+  let isDirty = $derived(
+    detail && form ? computeProfileIsDirty(detail, form) : false,
+  );
+  let canSave = $derived(
+    !!form && !nameError && !pathError && isDirty && !saving && !deleting,
+  );
+
+  // Register a dirty-checker with the shared navigation guard so that any nav
+  // site wrapped with `requestNavigation` (top-level tabs, sidebar profile
+  // rows, etc.) prompts before discarding unsaved edits. The closure reads the
+  // live `isDirty` derived value, and the cleanup returned from
+  // registerDirtyChecker tears the entry down on unmount so a stale checker
+  // from a previously-selected profile can't fire.
+  $effect(() => {
+    return registerDirtyChecker(() => isDirty);
+  });
+
+  function toggleEndpoint(name: string) {
+    if (!form) return;
+    form.endpoints = toggleStagedEndpoint(form.endpoints, name);
+  }
+
+  function setJsExecution(value: boolean | null) {
+    if (!form) return;
+    form.jsExecution = value;
+  }
+
+  function setToonOutput(value: boolean | null) {
+    if (!form) return;
+    form.toonOutput = value;
+  }
+
+  async function handleSave() {
+    if (!detail || !form || !canSave) return;
+    saving = true;
+    await runSaveProfile({
+      originalPath: detail.path,
+      params: buildUpdateProfileParams(form),
+      updateProfile,
+      listProfiles,
+      setProfiles: (data) => onprofilesreload(data),
+      setSelectedPath: (path) => onselect(path),
+      applyDetail: (summary) => {
+        // Rebase detail/form on the saved-summary shape so isDirty resets.
+        // `tools` is preserved from the prior detail (the relay returns the
+        // summary shape on PUT; the catalog refresh comes on the next load).
+        if (detail) {
+          detail = {
+            ...detail,
+            name: summary.name,
+            path: summary.path,
+            endpoints: summary.endpoints,
+            js_execution: summary.js_execution,
+            toon_output: summary.toon_output,
+            endpoint_count: summary.endpoint_count,
+            tool_count: summary.tool_count,
+          };
+          form = formFromDetail(detail);
+        }
+      },
+      toastSuccess: toast.success,
+      toastError: toast.error,
+    });
+    saving = false;
+  }
+
+  async function handleDelete() {
+    if (!detail) {
+      showDeleteConfirm = false;
+      return;
+    }
+    deleting = true;
+    showDeleteConfirm = false;
+    await runDeleteProfile({
+      path: detail.path,
+      name: detail.name,
+      deleteProfile,
+      listProfiles,
+      setProfiles: (data) => onprofilesreload(data),
+      clearSelection: () => onselect(null),
+      toastSuccess: toast.success,
+      toastError: toast.error,
+    });
+    deleting = false;
+  }
+
+  function handleRevert() {
+    if (detail) form = formFromDetail(detail);
+  }
+</script>
+
+<div class="flex-1 h-full flex flex-col bg-(--surface) min-w-0 overflow-hidden">
+  {#if !selectedPath}
+    <div class="flex-1 flex items-center justify-center text-(--fg3)">
+      <div class="text-center">
+        <div class="text-sm">Select a profile to view details</div>
+        <div class="text-xs mt-1">or create a new one with the button on the left</div>
+      </div>
+    </div>
+  {:else if loading && !detail}
+    <div class="flex-1 flex items-center justify-center text-(--fg3)">
+      <div class="flex flex-col items-center gap-3">
+        <div
+          class="h-6 w-6 animate-spin rounded-full border-2 border-(--border) border-t-(--accent)"
+          role="status"
+          aria-label="Loading profile"
+        ></div>
+        <p class="text-sm">Loading profile…</p>
+      </div>
+    </div>
+  {:else if loadError}
+    <div class="flex-1 flex items-center justify-center text-(--offline) text-sm">
+      {loadError}
+    </div>
+  {:else if detail && form}
+    <div class="dhdr flex items-center justify-between">
+      <div class="min-w-0">
+        <h2 class="dhdr-name truncate">{detail.name}</h2>
+        <div class="flex items-center gap-2 mt-0.5">
+          <span class="text-[11px] text-(--accent)" style="font-family: var(--font-mono);"
+            >/mcp/{detail.path}</span
+          >
+          <span class="text-[11px] text-(--fg3)"
+            >{detail.endpoint_count} server{detail.endpoint_count === 1 ? '' : 's'} ·
+            {detail.tool_count} tool{detail.tool_count === 1 ? '' : 's'}</span
+          >
+          {#if isDirty}
+            <span
+              class="text-[10px] uppercase tracking-wide text-(--accent) font-semibold"
+              data-testid="profile-dirty-indicator"
+              title="Unsaved changes"
+            >• Unsaved</span>
+          {/if}
+        </div>
+      </div>
+      <div class="flex items-center gap-1.5 flex-shrink-0">
+        {#if isDirty}
+          <button
+            class="btn-sec btn-sm"
+            onclick={handleRevert}
+            disabled={saving || deleting}
+          >Revert</button>
+        {/if}
+        <button
+          class="btn-pri btn-sm"
+          onclick={handleSave}
+          disabled={!canSave}
+          aria-label="Save profile"
+        >{saving ? 'Saving…' : 'Save'}</button>
+        <button
+          class="btn-sec btn-sm btn-danger"
+          onclick={() => (showDeleteConfirm = true)}
+          disabled={saving || deleting}
+        >Delete</button>
+      </div>
+    </div>
+
+    <div class="flex-1 overflow-y-auto p-5 space-y-5">
+      <div class="space-y-3">
+        <div>
+          <label for="profile-detail-name" class="block text-xs font-medium mb-1 text-(--fg2)"
+            >Name</label
+          >
+          <input
+            id="profile-detail-name"
+            type="text"
+            bind:value={form.name}
+            class="w-full px-2.5 py-1.5 text-sm rounded-lg border bg-(--surface) text-(--fg1) border-(--border) focus:outline-none focus:border-(--accent) {nameError
+              ? 'border-(--offline)'
+              : ''}"
+            aria-invalid={!!nameError}
+          />
+          {#if nameError}
+            <div class="text-[11px] text-(--offline) mt-1">{nameError}</div>
+          {/if}
+        </div>
+
+        <div>
+          <label for="profile-detail-path" class="block text-xs font-medium mb-1 text-(--fg2)"
+            >Path</label
+          >
+          <div class="flex items-center gap-1.5">
+            <span
+              class="text-[12px] text-(--fg3)"
+              style="font-family: var(--font-mono);">/mcp/</span
+            >
+            <input
+              id="profile-detail-path"
+              type="text"
+              bind:value={form.path}
+              class="flex-1 px-2.5 py-1.5 text-sm rounded-lg border bg-(--surface) text-(--fg1) border-(--border) focus:outline-none focus:border-(--accent) {pathError
+                ? 'border-(--offline)'
+                : ''}"
+              style="font-family: var(--font-mono);"
+              aria-invalid={!!pathError}
+            />
+          </div>
+          {#if pathError}
+            <div class="text-[11px] text-(--offline) mt-1">{pathError}</div>
+          {/if}
+        </div>
+
+        <div class="flex items-center justify-between gap-3">
+          <div class="min-w-0">
+            <div class="text-xs font-medium text-(--fg2)">JS Execution</div>
+            <div class="text-[11px] text-(--fg3)">
+              {form.jsExecution === null
+                ? 'Inherit from relay default'
+                : form.jsExecution
+                  ? 'execute_tools sandbox enabled'
+                  : 'Direct tool calls only'}
+            </div>
+          </div>
+          <select
+            class="px-2 py-1 text-xs rounded-lg border border-(--border) bg-(--surface) text-(--fg1)"
+            value={form.jsExecution === null ? 'inherit' : form.jsExecution ? 'on' : 'off'}
+            onchange={(e) => {
+              const v = (e.currentTarget as HTMLSelectElement).value;
+              setJsExecution(v === 'inherit' ? null : v === 'on');
+            }}
+            aria-label="JS execution mode"
+          >
+            <option value="on">On</option>
+            <option value="off">Off</option>
+            <option value="inherit">Inherit</option>
+          </select>
+        </div>
+
+        <div class="flex items-center justify-between gap-3">
+          <div class="min-w-0">
+            <div class="text-xs font-medium text-(--fg2)">TOON Output</div>
+            <div class="text-[11px] text-(--fg3)">
+              {form.toonOutput === null
+                ? 'Inherit from relay default'
+                : form.toonOutput
+                  ? 'Tool responses encoded as TOON'
+                  : 'Tool responses as raw JSON'}
+            </div>
+          </div>
+          <select
+            class="px-2 py-1 text-xs rounded-lg border border-(--border) bg-(--surface) text-(--fg1)"
+            value={form.toonOutput === null ? 'inherit' : form.toonOutput ? 'on' : 'off'}
+            onchange={(e) => {
+              const v = (e.currentTarget as HTMLSelectElement).value;
+              setToonOutput(v === 'inherit' ? null : v === 'on');
+            }}
+            aria-label="TOON output"
+          >
+            <option value="on">On</option>
+            <option value="off">Off</option>
+            <option value="inherit">Inherit</option>
+          </select>
+        </div>
+      </div>
+
+      <div>
+        <div class="text-xs font-medium text-(--fg2) mb-2">
+          Servers ({form.endpoints.size} of {$endpoints.length})
+        </div>
+        {#if $endpoints.length === 0}
+          <div class="text-[11px] text-(--fg3) p-3 border border-dashed border-(--border) rounded-lg">
+            No servers configured. Add servers from the Servers tab first.
+          </div>
+        {:else}
+          <div class="space-y-0.5 border border-(--border) rounded-lg overflow-hidden">
+            {#each $endpoints as ep (ep.name)}
+              <label
+                class="flex items-center gap-2.5 px-3 py-1.5 hover:bg-(--hover-bg) cursor-pointer"
+              >
+                <input
+                  type="checkbox"
+                  checked={form.endpoints.has(ep.name)}
+                  onchange={() => toggleEndpoint(ep.name)}
+                  aria-label={`Include ${ep.name} in profile`}
+                />
+                <div class="flex-1 min-w-0">
+                  <div class="text-[13px] truncate text-(--fg1)">{ep.name}</div>
+                </div>
+                <TransportBadge transport={ep.transport} />
+                <span class="text-[11px] text-(--fg3) w-16 text-right" style="font-family: var(--font-mono);"
+                  >{ep.tool_count} tool{ep.tool_count === 1 ? '' : 's'}</span
+                >
+              </label>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    </div>
+
+    {#if showDeleteConfirm}
+      <ConfirmModal
+        title="Delete Profile"
+        message="Are you sure you want to delete '{detail.name}'? This removes the /mcp/{detail.path} route."
+        confirmLabel="Delete"
+        onconfirm={handleDelete}
+        oncancel={() => (showDeleteConfirm = false)}
+      />
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .dhdr {
+    padding: 12px 20px;
+    border-bottom: 1px solid var(--border);
+    background: var(--hd-bg);
+  }
+  .dhdr-name {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--fg1);
+    line-height: 1.2;
+  }
+</style>

--- a/src/lib/components/ProfileDetail.svelte
+++ b/src/lib/components/ProfileDetail.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
   import type { ProfileDetail, ProfileSummary } from '$lib/api';
   import { getProfile, listProfiles, updateProfile, deleteProfile } from '$lib/api';
-  import { endpoints, relayPort, jsExecutionMode, toonOutput } from '$lib/stores';
+  import { endpoints, relayPort } from '$lib/stores';
   import { registerDirtyChecker } from '$lib/stores/unsavedChangesGuard';
-  import { get } from 'svelte/store';
   import { toast } from 'svelte-sonner';
   import ConfirmModal from './ConfirmModal.svelte';
   import TransportBadge from './TransportBadge.svelte';
@@ -30,14 +29,6 @@
 
   let detail = $state<ProfileDetail | null>(null);
   let form = $state<ProfileEditForm | null>(null);
-  // Snapshot of `{ jsExecution, toonOutput }` taken once when the form is
-  // built so copy-on-write seeding (and the dirty check that pairs with it)
-  // stays stable for the duration of the edit session. Reseeded only on the
-  // next load/revert.
-  let formDefaults = $state<{ jsExecution: boolean; toonOutput: boolean }>({
-    jsExecution: false,
-    toonOutput: true,
-  });
   let loading = $state(false);
   let saving = $state(false);
   let deleting = $state(false);
@@ -61,12 +52,7 @@
         // Bail if the user moved on while we were loading.
         if (selectedPath !== path) return;
         detail = d;
-        // Snapshot the current global defaults once at load time so
-        // copy-on-write resolution is stable for this edit session — if the
-        // user changes the global setting elsewhere while editing, the
-        // profile's seeded value doesn't shift under them.
-        formDefaults = { jsExecution: get(jsExecutionMode), toonOutput: get(toonOutput) };
-        form = formFromDetail(d, formDefaults);
+        form = formFromDetail(d);
       })
       .catch(() => {
         if (selectedPath !== path) return;
@@ -82,7 +68,7 @@
   let nameError = $derived(form ? validateProfileName(form.name) : null);
   let pathError = $derived(form ? validateProfilePath(form.path) : null);
   let isDirty = $derived(
-    detail && form ? computeProfileIsDirty(detail, form, formDefaults) : false,
+    detail && form ? computeProfileIsDirty(detail, form) : false,
   );
   let canSave = $derived(
     !!form && !nameError && !pathError && isDirty && !saving && !deleting,
@@ -128,7 +114,7 @@
             endpoint_count: summary.endpoint_count,
             tool_count: summary.tool_count,
           };
-          form = formFromDetail(detail, formDefaults);
+          form = formFromDetail(detail);
         }
       },
       toastSuccess: toast.success,
@@ -158,7 +144,7 @@
   }
 
   function handleRevert() {
-    if (detail) form = formFromDetail(detail, formDefaults);
+    if (detail) form = formFromDetail(detail);
   }
 
   // Connect-your-MCP-client snippet. Derived from the live relay port and the

--- a/src/lib/components/ProfileDetail.svelte
+++ b/src/lib/components/ProfileDetail.svelte
@@ -257,6 +257,10 @@
               id="profile-detail-path"
               type="text"
               bind:value={form.path}
+              autocapitalize="off"
+              autocorrect="off"
+              spellcheck="false"
+              autocomplete="off"
               class="flex-1 px-2.5 py-1.5 text-sm rounded-lg border bg-(--surface) text-(--fg1) border-(--border) focus:outline-none focus:border-(--accent) {pathError
                 ? 'border-(--offline)'
                 : ''}"

--- a/src/lib/components/ProfileDetail.svelte
+++ b/src/lib/components/ProfileDetail.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import type { ProfileDetail, ProfileSummary } from '$lib/api';
   import { getProfile, listProfiles, updateProfile, deleteProfile } from '$lib/api';
-  import { endpoints, relayPort } from '$lib/stores';
+  import { endpoints, relayPort, jsExecutionMode, toonOutput } from '$lib/stores';
   import { registerDirtyChecker } from '$lib/stores/unsavedChangesGuard';
+  import { get } from 'svelte/store';
   import { toast } from 'svelte-sonner';
   import ConfirmModal from './ConfirmModal.svelte';
   import TransportBadge from './TransportBadge.svelte';
@@ -29,6 +30,14 @@
 
   let detail = $state<ProfileDetail | null>(null);
   let form = $state<ProfileEditForm | null>(null);
+  // Snapshot of `{ jsExecution, toonOutput }` taken once when the form is
+  // built so copy-on-write seeding (and the dirty check that pairs with it)
+  // stays stable for the duration of the edit session. Reseeded only on the
+  // next load/revert.
+  let formDefaults = $state<{ jsExecution: boolean; toonOutput: boolean }>({
+    jsExecution: false,
+    toonOutput: true,
+  });
   let loading = $state(false);
   let saving = $state(false);
   let deleting = $state(false);
@@ -52,7 +61,12 @@
         // Bail if the user moved on while we were loading.
         if (selectedPath !== path) return;
         detail = d;
-        form = formFromDetail(d);
+        // Snapshot the current global defaults once at load time so
+        // copy-on-write resolution is stable for this edit session — if the
+        // user changes the global setting elsewhere while editing, the
+        // profile's seeded value doesn't shift under them.
+        formDefaults = { jsExecution: get(jsExecutionMode), toonOutput: get(toonOutput) };
+        form = formFromDetail(d, formDefaults);
       })
       .catch(() => {
         if (selectedPath !== path) return;
@@ -68,7 +82,7 @@
   let nameError = $derived(form ? validateProfileName(form.name) : null);
   let pathError = $derived(form ? validateProfilePath(form.path) : null);
   let isDirty = $derived(
-    detail && form ? computeProfileIsDirty(detail, form) : false,
+    detail && form ? computeProfileIsDirty(detail, form, formDefaults) : false,
   );
   let canSave = $derived(
     !!form && !nameError && !pathError && isDirty && !saving && !deleting,
@@ -87,16 +101,6 @@
   function toggleEndpoint(name: string) {
     if (!form) return;
     form.endpoints = toggleStagedEndpoint(form.endpoints, name);
-  }
-
-  function setJsExecution(value: boolean | null) {
-    if (!form) return;
-    form.jsExecution = value;
-  }
-
-  function setToonOutput(value: boolean | null) {
-    if (!form) return;
-    form.toonOutput = value;
   }
 
   async function handleSave() {
@@ -124,7 +128,7 @@
             endpoint_count: summary.endpoint_count,
             tool_count: summary.tool_count,
           };
-          form = formFromDetail(detail);
+          form = formFromDetail(detail, formDefaults);
         }
       },
       toastSuccess: toast.success,
@@ -154,7 +158,7 @@
   }
 
   function handleRevert() {
-    if (detail) form = formFromDetail(detail);
+    if (detail) form = formFromDetail(detail, formDefaults);
   }
 
   // Connect-your-MCP-client snippet. Derived from the live relay port and the
@@ -315,52 +319,42 @@
           <div class="min-w-0">
             <div class="text-xs font-medium text-(--fg2)">JS Execution</div>
             <div class="text-[11px] text-(--fg3)">
-              {form.jsExecution === null
-                ? 'Inherit from relay default'
-                : form.jsExecution
-                  ? 'execute_tools sandbox enabled'
-                  : 'Direct tool calls only'}
+              {form.jsExecution
+                ? 'execute_tools sandbox enabled'
+                : 'Direct tool calls only'}
             </div>
           </div>
-          <select
-            class="px-2 py-1 text-xs rounded-lg border border-(--border) bg-(--surface) text-(--fg1)"
-            value={form.jsExecution === null ? 'inherit' : form.jsExecution ? 'on' : 'off'}
-            onchange={(e) => {
-              const v = (e.currentTarget as HTMLSelectElement).value;
-              setJsExecution(v === 'inherit' ? null : v === 'on');
-            }}
-            aria-label="JS execution mode"
+          <button
+            type="button"
+            class="shrink-0 relative w-10 h-5 rounded-full transition-colors {form.jsExecution ? 'bg-green-500' : 'bg-gray-300 dark:bg-gray-600'}"
+            onclick={() => { if (form) form.jsExecution = !form.jsExecution; }}
+            role="switch"
+            aria-checked={form.jsExecution}
+            aria-label="Toggle JS execution mode for this profile"
           >
-            <option value="on">On</option>
-            <option value="off">Off</option>
-            <option value="inherit">Inherit</option>
-          </select>
+            <span class="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform {form.jsExecution ? 'translate-x-5' : ''}"></span>
+          </button>
         </div>
 
         <div class="flex items-center justify-between gap-3">
           <div class="min-w-0">
             <div class="text-xs font-medium text-(--fg2)">TOON Output</div>
             <div class="text-[11px] text-(--fg3)">
-              {form.toonOutput === null
-                ? 'Inherit from relay default'
-                : form.toonOutput
-                  ? 'Tool responses encoded as TOON'
-                  : 'Tool responses as raw JSON'}
+              {form.toonOutput
+                ? 'Tool responses encoded as TOON'
+                : 'Tool responses as raw JSON'}
             </div>
           </div>
-          <select
-            class="px-2 py-1 text-xs rounded-lg border border-(--border) bg-(--surface) text-(--fg1)"
-            value={form.toonOutput === null ? 'inherit' : form.toonOutput ? 'on' : 'off'}
-            onchange={(e) => {
-              const v = (e.currentTarget as HTMLSelectElement).value;
-              setToonOutput(v === 'inherit' ? null : v === 'on');
-            }}
-            aria-label="TOON output"
+          <button
+            type="button"
+            class="shrink-0 relative w-10 h-5 rounded-full transition-colors {form.toonOutput ? 'bg-green-500' : 'bg-gray-300 dark:bg-gray-600'}"
+            onclick={() => { if (form) form.toonOutput = !form.toonOutput; }}
+            role="switch"
+            aria-checked={form.toonOutput}
+            aria-label="Toggle TOON output for this profile"
           >
-            <option value="on">On</option>
-            <option value="off">Off</option>
-            <option value="inherit">Inherit</option>
-          </select>
+            <span class="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform {form.toonOutput ? 'translate-x-5' : ''}"></span>
+          </button>
         </div>
       </div>
 

--- a/src/lib/components/ProfileDetail.svelte
+++ b/src/lib/components/ProfileDetail.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { ProfileDetail, ProfileSummary } from '$lib/api';
   import { getProfile, listProfiles, updateProfile, deleteProfile } from '$lib/api';
-  import { endpoints } from '$lib/stores';
+  import { endpoints, relayPort } from '$lib/stores';
   import { registerDirtyChecker } from '$lib/stores/unsavedChangesGuard';
   import { toast } from 'svelte-sonner';
   import ConfirmModal from './ConfirmModal.svelte';
@@ -155,6 +155,44 @@
 
   function handleRevert() {
     if (detail) form = formFromDetail(detail);
+  }
+
+  // Connect-your-MCP-client snippet. Derived from the live relay port and the
+  // saved profile path so renaming the path (and saving) or changing the port
+  // in Settings updates both the URL and the JSON snippet immediately.
+  const profileMcpUrl = $derived(
+    detail ? `http://localhost:${$relayPort}/mcp/${detail.path}` : '',
+  );
+  const claudeConfigSnippet = $derived(
+    detail
+      ? `{
+  "mcpServers": {
+    "endara-${detail.path}": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "http://localhost:${$relayPort}/mcp/${detail.path}"
+      ]
+    }
+  }
+}`
+      : '',
+  );
+
+  // Independent copy-button state so the URL and JSON buttons don't flicker
+  // each other's checkmark when one is clicked.
+  let urlCopied = $state(false);
+  let jsonCopied = $state(false);
+  function copyUrl() {
+    navigator.clipboard.writeText(profileMcpUrl);
+    urlCopied = true;
+    setTimeout(() => (urlCopied = false), 2000);
+  }
+  function copyJson() {
+    navigator.clipboard.writeText(claudeConfigSnippet);
+    jsonCopied = true;
+    setTimeout(() => (jsonCopied = false), 2000);
   }
 </script>
 
@@ -357,6 +395,36 @@
             {/each}
           </div>
         {/if}
+      </div>
+
+      <div class="rounded-lg border border-(--border) bg-(--surface-alt) p-4 space-y-2">
+        <h3 class="text-sm font-semibold text-(--fg1)">Connect your MCP client</h3>
+        <p class="text-xs text-(--fg2)">
+          Point Claude Desktop or other MCP clients to this profile:
+        </p>
+        <div class="flex items-center gap-2">
+          <code class="flex-1 text-xs font-mono bg-(--surface) border border-(--border) rounded px-2 py-1.5 text-(--accent) truncate">
+            {profileMcpUrl}
+          </code>
+          <button
+            class="text-xs px-2 py-1.5 rounded border border-(--border) hover:bg-(--surface-hover) transition-colors"
+            onclick={copyUrl}
+          >
+            {urlCopied ? '✓' : 'Copy'}
+          </button>
+        </div>
+        <div class="flex items-start gap-2">
+          <pre class="flex-1 text-xs font-mono bg-(--surface) border border-(--border) rounded px-2 py-1.5 text-(--accent) overflow-x-auto whitespace-pre m-0"><code>{claudeConfigSnippet}</code></pre>
+          <button
+            class="text-xs px-2 py-1.5 rounded border border-(--border) hover:bg-(--surface-hover) transition-colors flex-shrink-0"
+            onclick={copyJson}
+          >
+            {jsonCopied ? '✓' : 'Copy'}
+          </button>
+        </div>
+        <p class="text-xs text-(--fg2)">
+          Drop this into <code class="font-mono text-(--accent)">claude_desktop_config.json</code>. For Cursor/HTTP-capable clients, paste the URL above directly.
+        </p>
       </div>
     </div>
 

--- a/src/lib/components/ProfileSidebar.svelte
+++ b/src/lib/components/ProfileSidebar.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import type { ProfileSummary } from '$lib/api';
+  import ProfileSidebarRow from './ProfileSidebarRow.svelte';
+  import CreateProfileModal from './CreateProfileModal.svelte';
+  import { sortProfilesByName } from './profile-detail-helpers';
+
+  let {
+    profiles,
+    selectedPath,
+    loading,
+    onselect,
+    oncreated,
+  }: {
+    profiles: ProfileSummary[];
+    selectedPath: string | null;
+    loading: boolean;
+    onselect: (path: string) => void;
+    oncreated: (profile: ProfileSummary) => void;
+  } = $props();
+
+  let showCreateModal = $state(false);
+
+  let sorted = $derived(sortProfilesByName(profiles));
+</script>
+
+<aside class="w-60 h-full flex flex-col border-r border-(--border) bg-(--side-bg)">
+  <div class="p-3 border-b border-(--border)">
+    <button
+      class="w-full btn-pri btn-sm flex items-center justify-center gap-1.5"
+      onclick={() => (showCreateModal = true)}
+    >
+      <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+      </svg>
+      <span>Create Profile</span>
+    </button>
+  </div>
+
+  <div class="flex-1 overflow-y-auto p-2">
+    {#if loading}
+      <div class="space-y-0.5" aria-hidden="true" data-testid="profile-sidebar-skeleton">
+        {#each [0, 1, 2] as i (i)}
+          <div class="w-full flex items-center gap-2.5 px-2.5 py-1.5 rounded-lg animate-pulse">
+            <div class="flex-1 min-w-0 space-y-1.5">
+              <div class="h-3 rounded bg-(--border) w-3/4"></div>
+              <div class="h-2 rounded bg-(--border) w-1/2"></div>
+            </div>
+          </div>
+        {/each}
+      </div>
+    {:else if sorted.length === 0}
+      <div class="p-3 text-center text-[12px] text-(--fg3) leading-relaxed">
+        No profiles yet. Create one to namespace your servers by project.
+      </div>
+    {:else}
+      <div class="space-y-0.5">
+        {#each sorted as profile (profile.path)}
+          <ProfileSidebarRow
+            {profile}
+            selected={profile.path === selectedPath}
+            {onselect}
+          />
+        {/each}
+      </div>
+    {/if}
+  </div>
+
+  {#if showCreateModal}
+    <CreateProfileModal
+      onclose={() => (showCreateModal = false)}
+      oncreated={(p) => oncreated(p)}
+    />
+  {/if}
+</aside>

--- a/src/lib/components/ProfileSidebarRow.svelte
+++ b/src/lib/components/ProfileSidebarRow.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import type { ProfileSummary } from '$lib/api';
+  import { requestNavigation } from '$lib/stores/unsavedChangesGuard';
+
+  let {
+    profile,
+    selected,
+    onselect,
+  }: {
+    profile: ProfileSummary;
+    selected: boolean;
+    onselect: (path: string) => void;
+  } = $props();
+
+  function select() {
+    // Same row that's already selected → no-op so we don't show the
+    // discard-changes prompt for a navigation that wouldn't move anywhere.
+    if (selected) return;
+    requestNavigation(() => onselect(profile.path));
+  }
+</script>
+
+<button
+  class="w-full flex items-center gap-2.5 px-2.5 py-1.5 rounded-lg text-left transition-colors
+    hover:bg-(--hover-bg)
+    {selected ? 'bg-(--hover-bg)' : ''}"
+  onclick={select}
+  aria-current={selected ? 'true' : undefined}
+>
+  <div class="flex-1 min-w-0">
+    <div class="text-[13px] font-medium truncate text-(--fg1)">{profile.name}</div>
+    <div class="flex items-baseline gap-1.5 mt-px">
+      <span
+        class="text-[11px] text-(--accent) truncate"
+        style="font-family: var(--font-mono);"
+      >/mcp/{profile.path}</span>
+      <span class="text-[11px] text-(--fg3)" style="font-family: var(--font-mono);">
+        {profile.endpoint_count} server{profile.endpoint_count === 1 ? '' : 's'}
+      </span>
+    </div>
+  </div>
+</button>

--- a/src/lib/components/Profiles.svelte
+++ b/src/lib/components/Profiles.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { listProfiles, type ProfileSummary } from '$lib/api';
+  import { requestNavigation } from '$lib/stores/unsavedChangesGuard';
+  import ProfileSidebar from './ProfileSidebar.svelte';
+  import ProfileDetail from './ProfileDetail.svelte';
+  import CreateProfileModal from './CreateProfileModal.svelte';
+
+  let profiles: ProfileSummary[] = $state([]);
+  let selectedPath: string | null = $state(null);
+  let loading = $state(true);
+  let loadError = $state('');
+  let showCreateModal = $state(false);
+
+  async function load() {
+    try {
+      const data = await listProfiles();
+      profiles = data;
+      loadError = '';
+    } catch {
+      profiles = [];
+      loadError = 'Failed to load profiles';
+    } finally {
+      loading = false;
+    }
+  }
+
+  onMount(() => {
+    load();
+  });
+
+  function handleSelect(path: string | null) {
+    selectedPath = path;
+  }
+
+  function handleCreated(profile: ProfileSummary) {
+    // Insert (or update) the created profile in the local list immediately so
+    // the sidebar shows it before the next refresh, then select it. Wrapped
+    // in requestNavigation in case the detail pane is dirty.
+    requestNavigation(() => {
+      const existing = profiles.findIndex((p) => p.path === profile.path);
+      if (existing >= 0) {
+        profiles = profiles.map((p, i) => (i === existing ? profile : p));
+      } else {
+        profiles = [...profiles, profile];
+      }
+      selectedPath = profile.path;
+    });
+    // Best-effort full refresh so endpoint/tool counts stay accurate.
+    void load();
+  }
+
+  function handleProfilesReload(data: ProfileSummary[]) {
+    profiles = data;
+  }
+</script>
+
+<div class="h-full flex flex-col">
+  {#if loadError && profiles.length === 0}
+    <div class="flex-1 flex items-center justify-center text-(--offline) text-sm">
+      {loadError}
+    </div>
+  {:else if !loading && profiles.length === 0}
+    <div
+      class="flex-1 flex items-center justify-center p-8"
+      data-testid="profiles-empty-state"
+    >
+      <div class="text-center max-w-sm">
+        <h2 class="text-base font-semibold text-(--fg1) mb-1">No profiles yet</h2>
+        <p class="text-sm text-(--fg2) mb-4 leading-relaxed">
+          Create one to namespace your servers by project.
+        </p>
+        <button
+          class="btn-pri btn-sm inline-flex items-center justify-center gap-1.5"
+          onclick={() => (showCreateModal = true)}
+        >
+          <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+          </svg>
+          <span>Create Profile</span>
+        </button>
+      </div>
+    </div>
+    {#if showCreateModal}
+      <CreateProfileModal
+        onclose={() => (showCreateModal = false)}
+        oncreated={(p) => handleCreated(p)}
+      />
+    {/if}
+  {:else}
+    <div class="flex-1 flex overflow-hidden">
+      <ProfileSidebar
+        {profiles}
+        {selectedPath}
+        {loading}
+        onselect={handleSelect}
+        oncreated={handleCreated}
+      />
+      <ProfileDetail
+        {selectedPath}
+        onprofilesreload={handleProfilesReload}
+        onselect={handleSelect}
+      />
+    </div>
+  {/if}
+</div>

--- a/src/lib/components/Profiles.unsaved.test.ts
+++ b/src/lib/components/Profiles.unsaved.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+
+import profileDetailSource from './ProfileDetail.svelte?raw';
+import profileSidebarRowSource from './ProfileSidebarRow.svelte?raw';
+import profilesSource from './Profiles.svelte?raw';
+import {
+  cancelPendingNavigation,
+  confirmPendingNavigation,
+  isAnyDirty,
+  pendingNavigationAction,
+  registerDirtyChecker,
+  requestNavigation,
+} from '$lib/stores/unsavedChangesGuard';
+
+// Matrix-row coverage for D3.A — "unsaved-changes guard on profile detail".
+//
+// The guard is composed of three independent pieces that all have to be wired
+// for the flow to work end-to-end:
+//   1. ProfileDetail registers a dirty-checker so `isAnyDirty()` reflects its
+//      `isDirty` derived value (mirrors ConfigTab.svelte:134–136).
+//   2. ProfileSidebarRow wraps the row click with `requestNavigation` so a
+//      sibling profile switch is gated by the guard (mirrors
+//      EndpointRow.svelte:27).
+//   3. Profiles.svelte wraps the post-create selection with `requestNavigation`
+//      so creating a new profile while another is dirty also gates.
+//
+// The Svelte components themselves can't be mounted in the JSDOM environment
+// without significant scaffolding, so we assert the wiring at the source
+// level (matching the existing convention in profile-detail-helpers.test.ts
+// and detail-panel-helpers.test.ts) and exercise the guard store itself with
+// a representative dirty-state simulation.
+
+describe('Profiles unsaved-changes guard (D3.A — matrix row)', () => {
+  let unregistrators: Array<() => void> = [];
+
+  function register(check: () => boolean) {
+    const unreg = registerDirtyChecker(check);
+    unregistrators.push(unreg);
+    return unreg;
+  }
+
+  beforeEach(() => {
+    for (const u of unregistrators) u();
+    unregistrators = [];
+    pendingNavigationAction.set(null);
+  });
+
+  // ── 1. ProfileDetail registers a checker tied to its `isDirty` value ──
+  it('ProfileDetail imports registerDirtyChecker from the shared guard store', () => {
+    expect(profileDetailSource).toMatch(
+      /import\s*\{\s*registerDirtyChecker\s*\}\s*from\s*['"]\$lib\/stores\/unsavedChangesGuard['"]/,
+    );
+  });
+
+  it('ProfileDetail registers a dirty-checker that returns `isDirty`', () => {
+    // $effect block returning the unregister handle, mirroring ConfigTab.
+    expect(profileDetailSource).toMatch(
+      /\$effect\(\s*\(\)\s*=>\s*\{[\s\S]*?return\s+registerDirtyChecker\(\s*\(\)\s*=>\s*isDirty\s*\)[\s\S]*?\}\s*\)/,
+    );
+  });
+
+  // ── 2. Left-rail row clicks gate navigation via requestNavigation ────
+  it('ProfileSidebarRow wraps the row click with requestNavigation', () => {
+    expect(profileSidebarRowSource).toMatch(
+      /import\s*\{\s*requestNavigation\s*\}\s*from\s*['"]\$lib\/stores\/unsavedChangesGuard['"]/,
+    );
+    expect(profileSidebarRowSource).toMatch(
+      /requestNavigation\(\s*\(\)\s*=>\s*onselect\(profile\.path\)\s*\)/,
+    );
+  });
+
+  it('ProfileSidebarRow short-circuits when clicking the already-selected row', () => {
+    // Mirrors EndpointRow.svelte:27 — prevents an unnecessary discard prompt
+    // when the user clicks the row that is already active.
+    expect(profileSidebarRowSource).toMatch(/if\s*\(\s*selected\s*\)\s*return/);
+  });
+
+  // ── 3. Post-create selection is also gated ────────────────────────────
+  it('Profiles.svelte gates the post-create selection with requestNavigation', () => {
+    expect(profilesSource).toMatch(
+      /import\s*\{\s*requestNavigation\s*\}\s*from\s*['"]\$lib\/stores\/unsavedChangesGuard['"]/,
+    );
+    expect(profilesSource).toMatch(
+      /requestNavigation\(\s*\(\)\s*=>\s*\{[\s\S]*?selectedPath\s*=\s*profile\.path[\s\S]*?\}\s*\)/,
+    );
+  });
+
+  // ── 4. Behavioural simulation of the registered checker ──────────────
+  it('switching profiles with dirty state queues the action (clean state runs immediately)', () => {
+    let dirty = false;
+    register(() => dirty);
+
+    const switchToOther = vi.fn();
+    requestNavigation(switchToOther);
+    // Clean state — switch happens immediately, nothing queued.
+    expect(switchToOther).toHaveBeenCalledTimes(1);
+    expect(get(pendingNavigationAction)).toBeNull();
+
+    // Now simulate a dirty form (e.g. the user toggled an endpoint).
+    dirty = true;
+    expect(isAnyDirty()).toBe(true);
+
+    const switchAgain = vi.fn();
+    requestNavigation(switchAgain);
+    expect(switchAgain).not.toHaveBeenCalled();
+    expect(get(pendingNavigationAction)).toBe(switchAgain);
+  });
+
+  it('confirmPendingNavigation discards changes and runs the queued switch', () => {
+    register(() => true);
+    const switchToOther = vi.fn();
+    requestNavigation(switchToOther);
+    expect(switchToOther).not.toHaveBeenCalled();
+
+    confirmPendingNavigation();
+    expect(switchToOther).toHaveBeenCalledTimes(1);
+    expect(get(pendingNavigationAction)).toBeNull();
+  });
+
+  it('cancelPendingNavigation keeps the dirty state and drops the queued switch', () => {
+    register(() => true);
+    const switchToOther = vi.fn();
+    requestNavigation(switchToOther);
+
+    cancelPendingNavigation();
+    expect(switchToOther).not.toHaveBeenCalled();
+    expect(get(pendingNavigationAction)).toBeNull();
+    // The dirty state itself is unchanged — the profile stays editable.
+    expect(isAnyDirty()).toBe(true);
+  });
+});

--- a/src/lib/components/ProfilesTab.svelte
+++ b/src/lib/components/ProfilesTab.svelte
@@ -78,6 +78,9 @@
       No profiles yet — create one in the Profiles tab to namespace your servers.
     </div>
   {:else}
+    <p class="profile-description">
+      Enable this server in a profile to include its tools at <span class="mono">/mcp/{'{'}path{'}'}</span>. Disable to keep its tools out of that profile's endpoint.
+    </p>
     {#each rows as row (row.path)}
       {@const profile = allProfiles.find((p) => p.path === row.path)!}
       <label class="profile-row {togglingPath === row.path ? 'opacity-50' : ''}">
@@ -102,6 +105,16 @@
     height: 100%;
     overflow-y: auto;
     padding: 16px 20px;
+  }
+
+  .profile-description {
+    font-size: 12px;
+    color: var(--fg2);
+    margin-bottom: 12px;
+    line-height: 1.4;
+  }
+  .profile-description .mono {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   }
 
   .profile-row {

--- a/src/lib/components/ProfilesTab.svelte
+++ b/src/lib/components/ProfilesTab.svelte
@@ -1,0 +1,145 @@
+<script lang="ts">
+  import { selectedEndpoint } from '$lib/stores';
+  import {
+    listProfiles,
+    getEndpointProfiles,
+    updateProfile,
+    type ProfileSummary,
+  } from '$lib/api';
+  import { toast } from 'svelte-sonner';
+  import {
+    buildEndpointProfileRows,
+    buildToggleUpdatePayload,
+  } from './endpoint-profiles-helpers';
+
+  let allProfiles = $state<ProfileSummary[]>([]);
+  let memberPaths = $state<string[]>([]);
+  let loading = $state(true);
+  let error = $state('');
+  let togglingPath: string | null = $state(null);
+
+  let rows = $derived(buildEndpointProfileRows(allProfiles, memberPaths));
+
+  async function load(name: string) {
+    loading = true;
+    error = '';
+    try {
+      const [profiles, membership] = await Promise.all([
+        listProfiles(),
+        getEndpointProfiles(name),
+      ]);
+      allProfiles = profiles;
+      memberPaths = membership.profiles;
+    } catch {
+      error = 'Failed to load profiles';
+      allProfiles = [];
+      memberPaths = [];
+    } finally {
+      loading = false;
+    }
+  }
+
+  $effect(() => {
+    const name = $selectedEndpoint;
+    if (!name) return;
+    load(name);
+  });
+
+  async function handleToggle(profile: ProfileSummary, nextMember: boolean) {
+    const name = $selectedEndpoint;
+    if (!name || togglingPath) return;
+    togglingPath = profile.path;
+    try {
+      await updateProfile(profile.path, buildToggleUpdatePayload(profile, name, nextMember));
+      try {
+        const membership = await getEndpointProfiles(name);
+        memberPaths = membership.profiles;
+      } catch {
+        // Mutation already succeeded — silent on purpose; next reload reconciles.
+      }
+    } catch {
+      toast.error(`Failed to update profile "${profile.name}"`);
+    }
+    togglingPath = null;
+  }
+</script>
+
+<div class="dbody">
+  {#if loading}
+    <div class="space-y-2">
+      {#each [1, 2, 3] as _}
+        <div class="h-10 rounded-lg bg-(--surface-hover) animate-pulse"></div>
+      {/each}
+    </div>
+  {:else if error}
+    <div class="text-sm text-(--offline)">{error}</div>
+  {:else if rows.length === 0}
+    <div class="text-sm text-(--fg3) text-center py-6">
+      No profiles yet — create one in the Profiles tab to namespace your servers.
+    </div>
+  {:else}
+    {#each rows as row (row.path)}
+      {@const profile = allProfiles.find((p) => p.path === row.path)!}
+      <label class="profile-row {togglingPath === row.path ? 'opacity-50' : ''}">
+        <input
+          type="checkbox"
+          checked={row.member}
+          disabled={togglingPath !== null}
+          onchange={(e) => handleToggle(profile, (e.currentTarget as HTMLInputElement).checked)}
+          aria-label="{row.member ? 'Remove from' : 'Add to'} profile {row.name}"
+        />
+        <div class="min-w-0 flex-1">
+          <div class="profile-name">{row.name}</div>
+          <div class="profile-path">/mcp/{row.path}</div>
+        </div>
+      </label>
+    {/each}
+  {/if}
+</div>
+
+<style>
+  .dbody {
+    height: 100%;
+    overflow-y: auto;
+    padding: 16px 20px;
+  }
+
+  .profile-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 12px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--surface);
+    cursor: pointer;
+    margin-bottom: 8px;
+    transition: background-color 120ms var(--ease);
+  }
+  .profile-row:hover {
+    background: var(--surface-hover);
+  }
+  .profile-row input[type='checkbox'] {
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+    cursor: pointer;
+    accent-color: var(--accent);
+  }
+  .profile-row input[type='checkbox']:disabled {
+    cursor: not-allowed;
+  }
+
+  .profile-name {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--fg1);
+    line-height: 1.2;
+  }
+  .profile-path {
+    font-size: 11px;
+    color: var(--fg3);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    margin-top: 2px;
+  }
+</style>

--- a/src/lib/components/RelayLogs.svelte
+++ b/src/lib/components/RelayLogs.svelte
@@ -22,6 +22,7 @@
   // Filter state — local, not persisted (engineering spec §2.2).
   let activeLevels = $state<Set<LogLevel>>(new Set(['error', 'warn', 'info', 'debug', 'trace']));
   let selectedEndpoints = $state<Set<string>>(new Set());
+  let selectedProfiles = $state<Set<string>>(new Set());
   let searchText = $state('');
   let toolCallsOnly = $state(false);
 
@@ -37,11 +38,15 @@
   const filteredLines = $derived.by(() => {
     const q = searchText.trim().toLowerCase();
     const hasEndpointFilter = selectedEndpoints.size > 0;
+    const hasProfileFilter = selectedProfiles.size > 0;
     return $relayLogLines.filter((line) => {
       if (!activeLevels.has(line.level)) return false;
       if (toolCallsOnly && !line.isToolCall) return false;
       if (hasEndpointFilter) {
         if (!line.endpoint || !selectedEndpoints.has(line.endpoint)) return false;
+      }
+      if (hasProfileFilter) {
+        if (!line.profile || !selectedProfiles.has(line.profile)) return false;
       }
       if (q.length > 0 && !line.raw.toLowerCase().includes(q)) return false;
       return true;
@@ -148,6 +153,7 @@
     filteredCount={filteredLines.length}
     bind:activeLevels
     bind:selectedEndpoints
+    bind:selectedProfiles
     bind:searchText
     bind:toolCallsOnly
     onclear={clearLogs}

--- a/src/lib/components/create-profile-helpers.ts
+++ b/src/lib/components/create-profile-helpers.ts
@@ -66,9 +66,8 @@ export function isCreateProfileFormValid(name: string, path: string): boolean {
  *
  * The `js_execution` / `toon_output` toggles in `CreateProfileModal` are
  * seeded copy-on-write from the current global relay defaults at modal
- * open, so the payload always carries concrete booleans reflecting the
- * user's intent at create time. The relay still accepts `null` on the
- * wire (legacy "inherit from global"), but the desktop never produces it.
+ * open and the payload always carries concrete booleans — the relay
+ * rejects requests that omit either field.
  */
 export function buildCreateProfilePayload(input: {
   name: string;

--- a/src/lib/components/create-profile-helpers.ts
+++ b/src/lib/components/create-profile-helpers.ts
@@ -1,0 +1,85 @@
+import type { CreateProfileParams } from '$lib/api';
+
+/**
+ * Path-segment regex for a profile. Must match the relay's
+ * `validate_profile_path` (R1.A) byte-for-byte: starts with an
+ * alphanumeric character, followed by alphanumerics, `_`, or `-`.
+ */
+export const PROFILE_PATH_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/;
+
+/**
+ * Reserved path segments that conflict with existing relay routes
+ * mounted under `/mcp/...`. Comparison is case-insensitive — `SSE`,
+ * `Tools`, etc. are all rejected. Mirrors the relay-side reserved set.
+ */
+export const RESERVED_PROFILE_PATHS: readonly string[] = [
+  'sse',
+  'initialize',
+  'tools',
+  'oauth',
+  'healthz',
+];
+
+/**
+ * Validate a profile path slug.
+ *
+ * Returns `null` when the value is acceptable, otherwise a short,
+ * human-readable error message suitable for inline display below the
+ * field in `CreateProfileModal`. Matches the order/wording the relay
+ * uses when it rejects the path on submit so the user sees the same
+ * reason whether the modal blocks them client-side or the API does.
+ */
+export function validateProfilePath(path: string): string | null {
+  if (!path) return 'Path is required';
+  if (!PROFILE_PATH_REGEX.test(path)) {
+    return 'Use letters, numbers, _ or -; must start with a letter or number';
+  }
+  if (RESERVED_PROFILE_PATHS.includes(path.toLowerCase())) {
+    return `"${path}" is reserved — choose a different path`;
+  }
+  return null;
+}
+
+/**
+ * Validate the profile name. Currently the only rule is non-empty
+ * (after trimming) — the relay treats the friendly name as freeform.
+ */
+export function validateProfileName(name: string): string | null {
+  if (!name.trim()) return 'Name is required';
+  return null;
+}
+
+/**
+ * Aggregated form-level validity check used to drive the Create button's
+ * disabled state. Both name and path must be present and the path must
+ * match the regex + reserved checks.
+ */
+export function isCreateProfileFormValid(name: string, path: string): boolean {
+  return validateProfileName(name) === null && validateProfilePath(path) === null;
+}
+
+/**
+ * Build the JSON body submitted to `POST /api/profiles`. Trims the
+ * friendly name, leaves the path as-is (regex enforces no surrounding
+ * whitespace), and seeds an empty endpoints list — server assignment
+ * happens after creation in the right panel (Engineering Spec §9.3).
+ *
+ * The `js_execution` / `toon_output` toggles default to `true` per
+ * Engineering Spec §9.3 ("toggle, defaults to on"). The relay's
+ * `ProfileConfig` treats `null` as "inherit from global", so the modal
+ * always sends an explicit boolean to make the user's intent durable.
+ */
+export function buildCreateProfilePayload(input: {
+  name: string;
+  path: string;
+  jsExecution: boolean;
+  toonOutput: boolean;
+}): CreateProfileParams {
+  return {
+    name: input.name.trim(),
+    path: input.path,
+    endpoints: [],
+    js_execution: input.jsExecution,
+    toon_output: input.toonOutput,
+  };
+}

--- a/src/lib/components/create-profile-helpers.ts
+++ b/src/lib/components/create-profile-helpers.ts
@@ -64,10 +64,11 @@ export function isCreateProfileFormValid(name: string, path: string): boolean {
  * whitespace), and seeds an empty endpoints list — server assignment
  * happens after creation in the right panel (Engineering Spec §9.3).
  *
- * The `js_execution` / `toon_output` toggles default to `true` per
- * Engineering Spec §9.3 ("toggle, defaults to on"). The relay's
- * `ProfileConfig` treats `null` as "inherit from global", so the modal
- * always sends an explicit boolean to make the user's intent durable.
+ * The `js_execution` / `toon_output` toggles in `CreateProfileModal` are
+ * seeded copy-on-write from the current global relay defaults at modal
+ * open, so the payload always carries concrete booleans reflecting the
+ * user's intent at create time. The relay still accepts `null` on the
+ * wire (legacy "inherit from global"), but the desktop never produces it.
  */
 export function buildCreateProfilePayload(input: {
   name: string;

--- a/src/lib/components/detail-panel-helpers.test.ts
+++ b/src/lib/components/detail-panel-helpers.test.ts
@@ -43,28 +43,31 @@ describe('shouldShowRefreshButton', () => {
 });
 
 describe('visibleTabs', () => {
-  it('returns tools, logs, config for stdio when enabled', () => {
+  it('returns tools, logs, config, profiles for stdio when enabled', () => {
     expect(visibleTabs('stdio', false)).toEqual([
       { id: 'tools', label: 'Tools' },
       { id: 'logs', label: 'Logs' },
       { id: 'config', label: 'Config' },
+      { id: 'profiles', label: 'Profiles' },
     ]);
   });
 
-  it('returns tools, logs, config for http when enabled', () => {
+  it('returns tools, logs, config, profiles for http when enabled', () => {
     expect(visibleTabs('http', false)).toEqual([
       { id: 'tools', label: 'Tools' },
       { id: 'logs', label: 'Logs' },
       { id: 'config', label: 'Config' },
+      { id: 'profiles', label: 'Profiles' },
     ]);
   });
 
-  it('returns tools, logs, config, auth for oauth when enabled', () => {
+  it('returns tools, logs, config, auth, profiles for oauth when enabled', () => {
     expect(visibleTabs('oauth', false)).toEqual([
       { id: 'tools', label: 'Tools' },
       { id: 'logs', label: 'Logs' },
       { id: 'config', label: 'Config' },
       { id: 'auth', label: 'Auth' },
+      { id: 'profiles', label: 'Profiles' },
     ]);
   });
 
@@ -79,12 +82,19 @@ describe('visibleTabs', () => {
     ]);
   });
 
+  it('omits profiles tab when disabled', () => {
+    for (const t of ['stdio', 'sse', 'http', 'oauth'] as const) {
+      const ids = visibleTabs(t, true).map((tab) => tab.id);
+      expect(ids).not.toContain('profiles');
+    }
+  });
+
   it('preserves stable tab order across transports when enabled', () => {
     const order = (t: EndpointTransport) => visibleTabs(t, false).map((tab) => tab.id);
-    expect(order('stdio')).toEqual(['tools', 'logs', 'config']);
-    expect(order('sse')).toEqual(['tools', 'logs', 'config']);
-    expect(order('http')).toEqual(['tools', 'logs', 'config']);
-    expect(order('oauth')).toEqual(['tools', 'logs', 'config', 'auth']);
+    expect(order('stdio')).toEqual(['tools', 'logs', 'config', 'profiles']);
+    expect(order('sse')).toEqual(['tools', 'logs', 'config', 'profiles']);
+    expect(order('http')).toEqual(['tools', 'logs', 'config', 'profiles']);
+    expect(order('oauth')).toEqual(['tools', 'logs', 'config', 'auth', 'profiles']);
   });
 });
 

--- a/src/lib/components/detail-panel-helpers.ts
+++ b/src/lib/components/detail-panel-helpers.ts
@@ -17,7 +17,7 @@ export function shouldShowReauthorizeButton(
   return REAUTH_NEEDED_STATUSES.includes(oauthStatus);
 }
 
-export type DetailTabId = 'tools' | 'logs' | 'config' | 'auth';
+export type DetailTabId = 'tools' | 'logs' | 'config' | 'auth' | 'profiles';
 
 export interface DetailTab {
   id: DetailTabId;
@@ -42,6 +42,7 @@ export function visibleTabs(transport: EndpointTransport, disabled: boolean): De
   if (transport === 'oauth') {
     tabs.push({ id: 'auth', label: 'Auth' });
   }
+  tabs.push({ id: 'profiles', label: 'Profiles' });
   return tabs;
 }
 

--- a/src/lib/components/endpoint-profiles-helpers.test.ts
+++ b/src/lib/components/endpoint-profiles-helpers.test.ts
@@ -21,8 +21,8 @@ function p(
     name,
     path,
     endpoints,
-    js_execution: null,
-    toon_output: null,
+    js_execution: false,
+    toon_output: true,
     endpoint_count: endpoints.length,
     tool_count: 0,
     ...overrides,
@@ -100,15 +100,15 @@ describe('buildToggleUpdatePayload', () => {
     expect(payload).toEqual(expected);
   });
 
-  it('preserves null inherit-sentinels for js_execution/toon_output (remove)', () => {
+  it('mirrors the profile booleans through unchanged on remove', () => {
     const profile = p('Personal', 'personal', ['gmail', 'github']);
     const payload = buildToggleUpdatePayload(profile, 'github', false);
     expect(payload).toEqual({
       name: 'Personal',
       path: 'personal',
       endpoints: ['gmail'],
-      js_execution: null,
-      toon_output: null,
+      js_execution: false,
+      toon_output: true,
     });
   });
 });
@@ -146,8 +146,8 @@ describe('ProfilesTab toggle round-trip', () => {
       name: 'Work',
       path: 'work',
       endpoints: ['github', 'slack'],
-      js_execution: null,
-      toon_output: null,
+      js_execution: false,
+      toon_output: true,
     });
     expect(refresh).toHaveBeenCalledTimes(1);
     expect(toastError).not.toHaveBeenCalled();

--- a/src/lib/components/endpoint-profiles-helpers.test.ts
+++ b/src/lib/components/endpoint-profiles-helpers.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { ProfileSummary, UpdateProfileParams } from '$lib/api';
+import {
+  buildEndpointProfileRows,
+  toggleEndpointInProfile,
+  buildToggleUpdatePayload,
+} from './endpoint-profiles-helpers';
+
+// Engineering Spec §11 desktop test #10 — per-endpoint Profiles sub-tab shows
+// the correct membership checkboxes and toggling them sends a well-formed
+// PUT /api/profiles/{path} payload. Component is implemented in
+// `ProfilesTab.svelte`; pure logic lives in `endpoint-profiles-helpers.ts`.
+
+function p(
+  name: string,
+  path: string,
+  endpoints: string[],
+  overrides: Partial<ProfileSummary> = {},
+): ProfileSummary {
+  return {
+    name,
+    path,
+    endpoints,
+    js_execution: null,
+    toon_output: null,
+    endpoint_count: endpoints.length,
+    tool_count: 0,
+    ...overrides,
+  };
+}
+
+describe('buildEndpointProfileRows', () => {
+  const profiles: ProfileSummary[] = [
+    p('Work', 'work', ['github', 'slack']),
+    p('Personal', 'personal', ['gmail']),
+    p('Empty', 'empty', []),
+  ];
+
+  it('flags each profile as member iff endpoint appears in the membership list', () => {
+    const rows = buildEndpointProfileRows(profiles, ['work']);
+    expect(rows).toEqual([
+      { name: 'Work', path: 'work', member: true },
+      { name: 'Personal', path: 'personal', member: false },
+      { name: 'Empty', path: 'empty', member: false },
+    ]);
+  });
+
+  it('preserves the input profile order regardless of membership', () => {
+    const rows = buildEndpointProfileRows(profiles, ['personal', 'work']);
+    expect(rows.map((r) => r.path)).toEqual(['work', 'personal', 'empty']);
+    expect(rows.every((r) => r.member === (r.path !== 'empty'))).toBe(true);
+  });
+
+  it('returns all-unchecked rows when membership is empty', () => {
+    const rows = buildEndpointProfileRows(profiles, []);
+    expect(rows.every((r) => !r.member)).toBe(true);
+  });
+
+  it('ignores stale paths in the membership list', () => {
+    const rows = buildEndpointProfileRows(profiles, ['nonexistent']);
+    expect(rows.every((r) => !r.member)).toBe(true);
+  });
+});
+
+describe('toggleEndpointInProfile', () => {
+  it('adds the endpoint when nextMember=true and it is absent', () => {
+    expect(toggleEndpointInProfile({ endpoints: ['a', 'b'] }, 'c', true)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('is idempotent when adding an already-present endpoint', () => {
+    expect(toggleEndpointInProfile({ endpoints: ['a', 'b'] }, 'a', true)).toEqual(['a', 'b']);
+  });
+
+  it('removes every occurrence when nextMember=false', () => {
+    expect(toggleEndpointInProfile({ endpoints: ['a', 'b', 'a'] }, 'a', false)).toEqual(['b']);
+  });
+
+  it('is idempotent when removing an absent endpoint', () => {
+    expect(toggleEndpointInProfile({ endpoints: ['a', 'b'] }, 'c', false)).toEqual(['a', 'b']);
+  });
+
+  it('does not mutate the input array', () => {
+    const original: string[] = ['a', 'b'];
+    toggleEndpointInProfile({ endpoints: original }, 'c', true);
+    expect(original).toEqual(['a', 'b']);
+  });
+});
+
+describe('buildToggleUpdatePayload', () => {
+  it('preserves all profile-level fields and updates only endpoints (add)', () => {
+    const profile = p('Work', 'work', ['github'], { js_execution: true, toon_output: false });
+    const payload = buildToggleUpdatePayload(profile, 'slack', true);
+    const expected: UpdateProfileParams = {
+      name: 'Work',
+      path: 'work',
+      endpoints: ['github', 'slack'],
+      js_execution: true,
+      toon_output: false,
+    };
+    expect(payload).toEqual(expected);
+  });
+
+  it('preserves null inherit-sentinels for js_execution/toon_output (remove)', () => {
+    const profile = p('Personal', 'personal', ['gmail', 'github']);
+    const payload = buildToggleUpdatePayload(profile, 'github', false);
+    expect(payload).toEqual({
+      name: 'Personal',
+      path: 'personal',
+      endpoints: ['gmail'],
+      js_execution: null,
+      toon_output: null,
+    });
+  });
+});
+
+// Driver mirroring the handleToggle logic in ProfilesTab.svelte so we can
+// assert end-to-end membership refresh behaviour without mounting Svelte.
+interface ToggleDeps {
+  updateProfile: (path: string, params: UpdateProfileParams) => Promise<unknown>;
+  refresh: () => Promise<void>;
+  toastError: (msg: string) => void;
+}
+
+async function runHandleToggle(
+  profile: ProfileSummary,
+  endpointName: string,
+  nextMember: boolean,
+  deps: ToggleDeps,
+): Promise<void> {
+  try {
+    await deps.updateProfile(profile.path, buildToggleUpdatePayload(profile, endpointName, nextMember));
+    await deps.refresh();
+  } catch {
+    deps.toastError(`Failed to update profile "${profile.name}"`);
+  }
+}
+
+describe('ProfilesTab toggle round-trip', () => {
+  it('PUTs the correct payload and refreshes membership on success', async () => {
+    const profile = p('Work', 'work', ['github']);
+    const updateProfile = vi.fn(async () => undefined);
+    const refresh = vi.fn(async () => undefined);
+    const toastError = vi.fn();
+    await runHandleToggle(profile, 'slack', true, { updateProfile, refresh, toastError });
+    expect(updateProfile).toHaveBeenCalledWith('work', {
+      name: 'Work',
+      path: 'work',
+      endpoints: ['github', 'slack'],
+      js_execution: null,
+      toon_output: null,
+    });
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it('toasts an error and skips refresh when the PUT rejects', async () => {
+    const profile = p('Work', 'work', ['github']);
+    const updateProfile = vi.fn(async () => { throw new Error('HTTP 500'); });
+    const refresh = vi.fn(async () => undefined);
+    const toastError = vi.fn();
+    await runHandleToggle(profile, 'slack', true, { updateProfile, refresh, toastError });
+    expect(refresh).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledWith('Failed to update profile "Work"');
+  });
+});

--- a/src/lib/components/endpoint-profiles-helpers.ts
+++ b/src/lib/components/endpoint-profiles-helpers.ts
@@ -1,0 +1,68 @@
+import type { ProfileSummary, UpdateProfileParams } from '$lib/api';
+
+/**
+ * One row in the per-endpoint Profiles sub-tab checklist (Engineering Spec
+ * §9.4). Each row maps one profile to whether the currently-viewed endpoint
+ * is a member of it.
+ */
+export interface EndpointProfileRow {
+  name: string;
+  path: string;
+  member: boolean;
+}
+
+/**
+ * Build the checklist rows shown in the per-endpoint Profiles sub-tab. The
+ * rows preserve `allProfiles` order; membership comes from the dedicated
+ * `GET /api/endpoints/{name}/profiles` response so we don't have to scan every
+ * profile's `endpoints` array client-side.
+ */
+export function buildEndpointProfileRows(
+  allProfiles: ReadonlyArray<ProfileSummary>,
+  memberPaths: ReadonlyArray<string>,
+): EndpointProfileRow[] {
+  const memberSet = new Set(memberPaths);
+  return allProfiles.map((p) => ({
+    name: p.name,
+    path: p.path,
+    member: memberSet.has(p.path),
+  }));
+}
+
+/**
+ * Compute the new `endpoints` list for a profile after toggling membership of
+ * `endpointName`. When `nextMember` is true we add the endpoint if absent;
+ * when false we remove every occurrence. Order is preserved on add (append)
+ * and on remove (filter), matching the existing convention used by the
+ * Profiles detail editor.
+ */
+export function toggleEndpointInProfile(
+  profile: Pick<ProfileSummary, 'endpoints'>,
+  endpointName: string,
+  nextMember: boolean,
+): string[] {
+  const current = profile.endpoints;
+  if (nextMember) {
+    return current.includes(endpointName) ? [...current] : [...current, endpointName];
+  }
+  return current.filter((n) => n !== endpointName);
+}
+
+/**
+ * Build the `PUT /api/profiles/{path}` payload for a membership toggle. All
+ * profile-level fields are preserved verbatim; only the `endpoints` list is
+ * recomputed via {@link toggleEndpointInProfile}.
+ */
+export function buildToggleUpdatePayload(
+  profile: ProfileSummary,
+  endpointName: string,
+  nextMember: boolean,
+): UpdateProfileParams {
+  return {
+    name: profile.name,
+    path: profile.path,
+    endpoints: toggleEndpointInProfile(profile, endpointName, nextMember),
+    js_execution: profile.js_execution,
+    toon_output: profile.toon_output,
+  };
+}

--- a/src/lib/components/profile-detail-helpers.test.ts
+++ b/src/lib/components/profile-detail-helpers.test.ts
@@ -27,6 +27,12 @@ function makeDetail(overrides: Partial<ProfileDetail> = {}): ProfileDetail {
   };
 }
 
+// Default globals snapshot used by the form-loading copy-on-write contract.
+// Matches the production defaults in `stores.ts` so values feel realistic
+// when reading the tests, but the specific booleans are only meaningful in
+// tests that explicitly exercise the null→default resolution.
+const DEFAULTS = { jsExecution: false, toonOutput: true };
+
 describe('sortProfilesByName', () => {
   it('sorts by friendly name with path tiebreak', () => {
     const profiles: ProfileSummary[] = [
@@ -83,55 +89,80 @@ describe('toggleStagedEndpoint (matrix row #6 — checklist staging)', () => {
   });
 });
 
+describe('formFromDetail (copy-on-write from globals)', () => {
+  it('resolves stored null to the provided default for both toggles', () => {
+    const detail = makeDetail({ js_execution: null, toon_output: null });
+    const form = formFromDetail(detail, { jsExecution: true, toonOutput: false });
+    expect(form.jsExecution).toBe(true);
+    expect(form.toonOutput).toBe(false);
+  });
+
+  it('preserves stored true/false even when defaults differ', () => {
+    const detail = makeDetail({ js_execution: false, toon_output: true });
+    const form = formFromDetail(detail, { jsExecution: true, toonOutput: false });
+    expect(form.jsExecution).toBe(false);
+    expect(form.toonOutput).toBe(true);
+  });
+});
+
 describe('computeProfileIsDirty', () => {
   it('returns false when form is unchanged from detail', () => {
     const detail = makeDetail();
-    expect(computeProfileIsDirty(detail, formFromDetail(detail))).toBe(false);
+    expect(computeProfileIsDirty(detail, formFromDetail(detail, DEFAULTS), DEFAULTS)).toBe(false);
   });
 
   it('returns true when the name changes', () => {
     const detail = makeDetail();
-    const form = { ...formFromDetail(detail), name: 'Work Updated' };
-    expect(computeProfileIsDirty(detail, form)).toBe(true);
+    const form = { ...formFromDetail(detail, DEFAULTS), name: 'Work Updated' };
+    expect(computeProfileIsDirty(detail, form, DEFAULTS)).toBe(true);
   });
 
   it('returns true when the path changes', () => {
     const detail = makeDetail();
-    const form = { ...formFromDetail(detail), path: 'work-2' };
-    expect(computeProfileIsDirty(detail, form)).toBe(true);
+    const form = { ...formFromDetail(detail, DEFAULTS), path: 'work-2' };
+    expect(computeProfileIsDirty(detail, form, DEFAULTS)).toBe(true);
   });
 
   it('returns true when js_execution flips between booleans', () => {
     const detail = makeDetail({ js_execution: true });
-    const form = { ...formFromDetail(detail), jsExecution: false };
-    expect(computeProfileIsDirty(detail, form)).toBe(true);
+    const form = { ...formFromDetail(detail, DEFAULTS), jsExecution: false };
+    expect(computeProfileIsDirty(detail, form, DEFAULTS)).toBe(true);
   });
 
-  it('returns true when toon_output toggles between value and inherit (null)', () => {
-    const detail = makeDetail({ toon_output: true });
-    const form = { ...formFromDetail(detail), toonOutput: null };
-    expect(computeProfileIsDirty(detail, form)).toBe(true);
+  it('stored null + form matching default is NOT dirty (copy-on-write baseline)', () => {
+    const detail = makeDetail({ js_execution: null, toon_output: null });
+    const form = formFromDetail(detail, { jsExecution: true, toonOutput: false });
+    expect(
+      computeProfileIsDirty(detail, form, { jsExecution: true, toonOutput: false }),
+    ).toBe(false);
+  });
+
+  it('stored null + user toggles opposite of default IS dirty', () => {
+    const detail = makeDetail({ js_execution: null, toon_output: null });
+    const defaults = { jsExecution: true, toonOutput: false };
+    const form = { ...formFromDetail(detail, defaults), toonOutput: true };
+    expect(computeProfileIsDirty(detail, form, defaults)).toBe(true);
   });
 
   it('returns true when an endpoint is staged on', () => {
     const detail = makeDetail();
-    const form = formFromDetail(detail);
+    const form = formFromDetail(detail, DEFAULTS);
     form.endpoints = toggleStagedEndpoint(form.endpoints, 'Todoist');
-    expect(computeProfileIsDirty(detail, form)).toBe(true);
+    expect(computeProfileIsDirty(detail, form, DEFAULTS)).toBe(true);
   });
 
   it('returns true when an endpoint is staged off', () => {
     const detail = makeDetail();
-    const form = formFromDetail(detail);
+    const form = formFromDetail(detail, DEFAULTS);
     form.endpoints = toggleStagedEndpoint(form.endpoints, 'Gmail');
-    expect(computeProfileIsDirty(detail, form)).toBe(true);
+    expect(computeProfileIsDirty(detail, form, DEFAULTS)).toBe(true);
   });
 
   it('returns false when the endpoint set has the same members in different order', () => {
     const detail = makeDetail({ endpoints: ['Gmail', 'Linear'] });
-    const form = formFromDetail(detail);
+    const form = formFromDetail(detail, DEFAULTS);
     form.endpoints = new Set(['Linear', 'Gmail']);
-    expect(computeProfileIsDirty(detail, form)).toBe(false);
+    expect(computeProfileIsDirty(detail, form, DEFAULTS)).toBe(false);
   });
 });
 
@@ -139,7 +170,7 @@ describe('computeProfileIsDirty', () => {
 describe('buildUpdateProfileParams (matrix row #4 — save payload shape)', () => {
   it('emits the staged form as a UpdateProfileParams body', () => {
     const detail = makeDetail();
-    const form = formFromDetail(detail);
+    const form = formFromDetail(detail, DEFAULTS);
     form.name = 'Work Updated';
     form.endpoints = toggleStagedEndpoint(form.endpoints, 'Todoist');
     const params = buildUpdateProfileParams(form);
@@ -154,15 +185,19 @@ describe('buildUpdateProfileParams (matrix row #4 — save payload shape)', () =
 
   it('trims surrounding whitespace from the friendly name', () => {
     const detail = makeDetail();
-    const form = { ...formFromDetail(detail), name: '  Work  ' };
+    const form = { ...formFromDetail(detail, DEFAULTS), name: '  Work  ' };
     expect(buildUpdateProfileParams(form).name).toBe('Work');
   });
 
-  it('preserves null (inherit) on js_execution / toon_output', () => {
+  it('never emits null on js_execution / toon_output (copy-on-write resolves at load)', () => {
     const detail = makeDetail({ js_execution: null, toon_output: null });
-    const params = buildUpdateProfileParams(formFromDetail(detail));
-    expect(params.js_execution).toBeNull();
-    expect(params.toon_output).toBeNull();
+    const params = buildUpdateProfileParams(
+      formFromDetail(detail, { jsExecution: false, toonOutput: true }),
+    );
+    expect(typeof params.js_execution).toBe('boolean');
+    expect(typeof params.toon_output).toBe('boolean');
+    expect(params.js_execution).toBe(false);
+    expect(params.toon_output).toBe(true);
   });
 });
 
@@ -258,7 +293,7 @@ describe('runSaveProfile (matrix row #4 — Save calls PUT /api/profiles/{path})
 describe('checklist staging + save (matrix row #6 — staged, then committed)', () => {
   it('toggling does not call updateProfile; only Save does', async () => {
     const detail = makeDetail({ endpoints: ['Gmail', 'Linear'] });
-    let form = formFromDetail(detail);
+    let form = formFromDetail(detail, DEFAULTS);
 
     const updateProfile = vi.fn(async () => ({
       ...detail,

--- a/src/lib/components/profile-detail-helpers.test.ts
+++ b/src/lib/components/profile-detail-helpers.test.ts
@@ -1,0 +1,410 @@
+import { describe, it, expect, vi } from 'vitest';
+import profileDetailSource from './ProfileDetail.svelte?raw';
+import profilesSource from './Profiles.svelte?raw';
+import createProfileModalSource from './CreateProfileModal.svelte?raw';
+import type { ProfileDetail, ProfileSummary, UpdateProfileParams } from '$lib/api';
+import {
+  buildUpdateProfileParams,
+  computeProfileIsDirty,
+  formFromDetail,
+  runDeleteProfile,
+  runSaveProfile,
+  sortProfilesByName,
+  toggleStagedEndpoint,
+} from './profile-detail-helpers';
+
+function makeDetail(overrides: Partial<ProfileDetail> = {}): ProfileDetail {
+  return {
+    name: 'Work',
+    path: 'work',
+    endpoints: ['Gmail', 'Linear'],
+    js_execution: true,
+    toon_output: true,
+    endpoint_count: 2,
+    tool_count: 15,
+    tools: [],
+    ...overrides,
+  };
+}
+
+describe('sortProfilesByName', () => {
+  it('sorts by friendly name with path tiebreak', () => {
+    const profiles: ProfileSummary[] = [
+      { name: 'Personal', path: 'personal', endpoints: [], js_execution: null, toon_output: null, endpoint_count: 0, tool_count: 0 },
+      { name: 'Work', path: 'work-a', endpoints: [], js_execution: null, toon_output: null, endpoint_count: 0, tool_count: 0 },
+      { name: 'Work', path: 'work-b', endpoints: [], js_execution: null, toon_output: null, endpoint_count: 0, tool_count: 0 },
+      { name: 'Apex', path: 'apex', endpoints: [], js_execution: null, toon_output: null, endpoint_count: 0, tool_count: 0 },
+    ];
+    expect(sortProfilesByName(profiles).map((p) => p.path)).toEqual([
+      'apex',
+      'personal',
+      'work-a',
+      'work-b',
+    ]);
+  });
+
+  it('does not mutate the input array', () => {
+    const profiles: ProfileSummary[] = [
+      { name: 'B', path: 'b', endpoints: [], js_execution: null, toon_output: null, endpoint_count: 0, tool_count: 0 },
+      { name: 'A', path: 'a', endpoints: [], js_execution: null, toon_output: null, endpoint_count: 0, tool_count: 0 },
+    ];
+    const before = profiles.map((p) => p.path);
+    sortProfilesByName(profiles);
+    expect(profiles.map((p) => p.path)).toEqual(before);
+  });
+});
+
+// ── Test matrix row #6 — server checklist staging + commit ────────────────────
+describe('toggleStagedEndpoint (matrix row #6 — checklist staging)', () => {
+  it('adds a missing endpoint name to a new Set', () => {
+    const staged = new Set(['Gmail']);
+    const next = toggleStagedEndpoint(staged, 'Linear');
+    expect(next).not.toBe(staged);
+    expect(Array.from(next).sort()).toEqual(['Gmail', 'Linear']);
+  });
+
+  it('removes a present endpoint name', () => {
+    const staged = new Set(['Gmail', 'Linear']);
+    const next = toggleStagedEndpoint(staged, 'Gmail');
+    expect(Array.from(next)).toEqual(['Linear']);
+  });
+
+  it('does not mutate the input set', () => {
+    const staged = new Set(['Gmail']);
+    toggleStagedEndpoint(staged, 'Linear');
+    expect(Array.from(staged)).toEqual(['Gmail']);
+  });
+
+  it('repeated toggles round-trip back to the original membership', () => {
+    let staged = new Set(['Gmail']);
+    staged = toggleStagedEndpoint(staged, 'Linear');
+    staged = toggleStagedEndpoint(staged, 'Linear');
+    expect(Array.from(staged)).toEqual(['Gmail']);
+  });
+});
+
+describe('computeProfileIsDirty', () => {
+  it('returns false when form is unchanged from detail', () => {
+    const detail = makeDetail();
+    expect(computeProfileIsDirty(detail, formFromDetail(detail))).toBe(false);
+  });
+
+  it('returns true when the name changes', () => {
+    const detail = makeDetail();
+    const form = { ...formFromDetail(detail), name: 'Work Updated' };
+    expect(computeProfileIsDirty(detail, form)).toBe(true);
+  });
+
+  it('returns true when the path changes', () => {
+    const detail = makeDetail();
+    const form = { ...formFromDetail(detail), path: 'work-2' };
+    expect(computeProfileIsDirty(detail, form)).toBe(true);
+  });
+
+  it('returns true when js_execution flips between booleans', () => {
+    const detail = makeDetail({ js_execution: true });
+    const form = { ...formFromDetail(detail), jsExecution: false };
+    expect(computeProfileIsDirty(detail, form)).toBe(true);
+  });
+
+  it('returns true when toon_output toggles between value and inherit (null)', () => {
+    const detail = makeDetail({ toon_output: true });
+    const form = { ...formFromDetail(detail), toonOutput: null };
+    expect(computeProfileIsDirty(detail, form)).toBe(true);
+  });
+
+  it('returns true when an endpoint is staged on', () => {
+    const detail = makeDetail();
+    const form = formFromDetail(detail);
+    form.endpoints = toggleStagedEndpoint(form.endpoints, 'Todoist');
+    expect(computeProfileIsDirty(detail, form)).toBe(true);
+  });
+
+  it('returns true when an endpoint is staged off', () => {
+    const detail = makeDetail();
+    const form = formFromDetail(detail);
+    form.endpoints = toggleStagedEndpoint(form.endpoints, 'Gmail');
+    expect(computeProfileIsDirty(detail, form)).toBe(true);
+  });
+
+  it('returns false when the endpoint set has the same members in different order', () => {
+    const detail = makeDetail({ endpoints: ['Gmail', 'Linear'] });
+    const form = formFromDetail(detail);
+    form.endpoints = new Set(['Linear', 'Gmail']);
+    expect(computeProfileIsDirty(detail, form)).toBe(false);
+  });
+});
+
+// ── Test matrix row #4 — Profile detail save ─────────────────────────────────
+describe('buildUpdateProfileParams (matrix row #4 — save payload shape)', () => {
+  it('emits the staged form as a UpdateProfileParams body', () => {
+    const detail = makeDetail();
+    const form = formFromDetail(detail);
+    form.name = 'Work Updated';
+    form.endpoints = toggleStagedEndpoint(form.endpoints, 'Todoist');
+    const params = buildUpdateProfileParams(form);
+    expect(params).toEqual({
+      name: 'Work Updated',
+      path: 'work',
+      endpoints: ['Gmail', 'Linear', 'Todoist'],
+      js_execution: true,
+      toon_output: true,
+    });
+  });
+
+  it('trims surrounding whitespace from the friendly name', () => {
+    const detail = makeDetail();
+    const form = { ...formFromDetail(detail), name: '  Work  ' };
+    expect(buildUpdateProfileParams(form).name).toBe('Work');
+  });
+
+  it('preserves null (inherit) on js_execution / toon_output', () => {
+    const detail = makeDetail({ js_execution: null, toon_output: null });
+    const params = buildUpdateProfileParams(formFromDetail(detail));
+    expect(params.js_execution).toBeNull();
+    expect(params.toon_output).toBeNull();
+  });
+});
+
+describe('runSaveProfile (matrix row #4 — Save calls PUT /api/profiles/{path})', () => {
+  function makeDeps(overrides: Partial<Parameters<typeof runSaveProfile>[0]> = {}) {
+    const updated: ProfileSummary = {
+      name: 'Work Updated',
+      path: 'work',
+      endpoints: ['Gmail', 'Linear', 'Todoist'],
+      js_execution: true,
+      toon_output: true,
+      endpoint_count: 3,
+      tool_count: 25,
+    };
+    const params: UpdateProfileParams = {
+      name: 'Work Updated',
+      path: 'work',
+      endpoints: ['Gmail', 'Linear', 'Todoist'],
+      js_execution: true,
+      toon_output: true,
+    };
+    return {
+      originalPath: 'work',
+      params,
+      updateProfile: vi.fn(async () => updated),
+      listProfiles: vi.fn(async () => [updated]),
+      setProfiles: vi.fn(),
+      setSelectedPath: vi.fn(),
+      applyDetail: vi.fn(),
+      toastSuccess: vi.fn(),
+      toastError: vi.fn(),
+      ...overrides,
+    };
+  }
+
+  it('PUTs the staged params and refreshes the sidebar list', async () => {
+    const deps = makeDeps();
+    await runSaveProfile(deps);
+    expect(deps.updateProfile).toHaveBeenCalledTimes(1);
+    expect(deps.updateProfile).toHaveBeenCalledWith('work', deps.params);
+    expect(deps.listProfiles).toHaveBeenCalledTimes(1);
+    expect(deps.setProfiles).toHaveBeenCalledTimes(1);
+    expect(deps.toastSuccess).toHaveBeenCalledWith('Profile "Work Updated" saved');
+    expect(deps.toastError).not.toHaveBeenCalled();
+  });
+
+  it('rebases the selection on the new path when the profile is renamed', async () => {
+    const renamed: ProfileSummary = {
+      name: 'Work',
+      path: 'work-2',
+      endpoints: ['Gmail'],
+      js_execution: true,
+      toon_output: true,
+      endpoint_count: 1,
+      tool_count: 5,
+    };
+    const deps = makeDeps({ updateProfile: vi.fn(async () => renamed) });
+    await runSaveProfile(deps);
+    expect(deps.setSelectedPath).toHaveBeenCalledWith('work-2');
+    expect(deps.applyDetail).toHaveBeenCalledWith(renamed);
+  });
+
+  it('toasts an error and does NOT refresh when PUT rejects', async () => {
+    const deps = makeDeps({
+      updateProfile: vi.fn(async () => {
+        throw new Error('HTTP 400: invalid path');
+      }),
+    });
+    await runSaveProfile(deps);
+    expect(deps.toastError).toHaveBeenCalledWith('Failed to save "Work Updated"');
+    expect(deps.toastSuccess).not.toHaveBeenCalled();
+    expect(deps.listProfiles).not.toHaveBeenCalled();
+    expect(deps.setProfiles).not.toHaveBeenCalled();
+    expect(deps.setSelectedPath).not.toHaveBeenCalled();
+  });
+
+  it('post-PUT refresh failure stays silent and still toasts success', async () => {
+    const deps = makeDeps({
+      listProfiles: vi.fn(async () => {
+        throw new Error('HTTP 500: refresh failed');
+      }),
+    });
+    await runSaveProfile(deps);
+    expect(deps.toastSuccess).toHaveBeenCalledWith('Profile "Work Updated" saved');
+    expect(deps.toastError).not.toHaveBeenCalled();
+    expect(deps.setProfiles).not.toHaveBeenCalled();
+  });
+});
+
+// Verify the integrated staging+save flow that matrix row #6 mandates: a
+// toggle does NOT call PUT on its own, then a single Save PUTs the staged
+// state once.
+describe('checklist staging + save (matrix row #6 — staged, then committed)', () => {
+  it('toggling does not call updateProfile; only Save does', async () => {
+    const detail = makeDetail({ endpoints: ['Gmail', 'Linear'] });
+    let form = formFromDetail(detail);
+
+    const updateProfile = vi.fn(async () => ({
+      ...detail,
+      endpoints: ['Gmail', 'Todoist'],
+    }) as ProfileSummary);
+
+    form.endpoints = toggleStagedEndpoint(form.endpoints, 'Todoist');
+    form.endpoints = toggleStagedEndpoint(form.endpoints, 'Linear');
+    expect(updateProfile).not.toHaveBeenCalled();
+
+    await runSaveProfile({
+      originalPath: detail.path,
+      params: buildUpdateProfileParams(form),
+      updateProfile,
+      listProfiles: vi.fn(async () => []),
+      setProfiles: vi.fn(),
+      setSelectedPath: vi.fn(),
+      applyDetail: vi.fn(),
+      toastSuccess: vi.fn(),
+      toastError: vi.fn(),
+    });
+
+    expect(updateProfile).toHaveBeenCalledTimes(1);
+    expect(updateProfile).toHaveBeenCalledWith('work', {
+      name: 'Work',
+      path: 'work',
+      endpoints: ['Gmail', 'Todoist'],
+      js_execution: true,
+      toon_output: true,
+    });
+  });
+});
+
+// ── Test matrix row #5 — Profile detail delete ────────────────────────────────
+describe('runDeleteProfile (matrix row #5 — confirmation, then DELETE)', () => {
+  function makeDeps(overrides: Partial<Parameters<typeof runDeleteProfile>[0]> = {}) {
+    return {
+      path: 'work',
+      name: 'Work',
+      deleteProfile: vi.fn(async () => undefined),
+      listProfiles: vi.fn(async () => []),
+      setProfiles: vi.fn(),
+      clearSelection: vi.fn(),
+      toastSuccess: vi.fn(),
+      toastError: vi.fn(),
+      ...overrides,
+    };
+  }
+
+  it('DELETEs the profile, clears selection, refreshes list and toasts success', async () => {
+    const deps = makeDeps();
+    await runDeleteProfile(deps);
+    expect(deps.deleteProfile).toHaveBeenCalledTimes(1);
+    expect(deps.deleteProfile).toHaveBeenCalledWith('work');
+    expect(deps.clearSelection).toHaveBeenCalledTimes(1);
+    expect(deps.listProfiles).toHaveBeenCalledTimes(1);
+    expect(deps.setProfiles).toHaveBeenCalledTimes(1);
+    expect(deps.toastSuccess).toHaveBeenCalledWith('Profile "Work" deleted');
+    expect(deps.toastError).not.toHaveBeenCalled();
+  });
+
+  it('toasts an error and does NOT clear selection when DELETE rejects', async () => {
+    const deps = makeDeps({
+      deleteProfile: vi.fn(async () => {
+        throw new Error('HTTP 500: internal error');
+      }),
+    });
+    await runDeleteProfile(deps);
+    expect(deps.toastError).toHaveBeenCalledWith('Failed to delete "Work"');
+    expect(deps.toastSuccess).not.toHaveBeenCalled();
+    expect(deps.clearSelection).not.toHaveBeenCalled();
+    expect(deps.listProfiles).not.toHaveBeenCalled();
+    expect(deps.setProfiles).not.toHaveBeenCalled();
+  });
+
+  it('post-DELETE refresh failure stays silent and still toasts success', async () => {
+    const deps = makeDeps({
+      listProfiles: vi.fn(async () => {
+        throw new Error('HTTP 500: refresh failed');
+      }),
+    });
+    await runDeleteProfile(deps);
+    expect(deps.toastSuccess).toHaveBeenCalledWith('Profile "Work" deleted');
+    expect(deps.toastError).not.toHaveBeenCalled();
+    expect(deps.clearSelection).toHaveBeenCalledTimes(1);
+    expect(deps.setProfiles).not.toHaveBeenCalled();
+  });
+});
+
+// ── Source-level assertion that the detail panel mounts a ConfirmModal for
+// delete (test matrix row #5: "Confirmation modal, then DELETE"). Mirrors the
+// detail-panel-helpers.test.ts pattern of scanning the .svelte source string
+// via Vite's `?raw` query so the test stays runtime-agnostic.
+describe('ProfileDetail delete confirmation (matrix row #5 — modal gate)', () => {
+  it('renders a ConfirmModal under a showDeleteConfirm guard', () => {
+    expect(profileDetailSource).toMatch(/\{#if\s+showDeleteConfirm\}/);
+    expect(profileDetailSource).toMatch(/<ConfirmModal[\s\S]*?confirmLabel="Delete"/);
+  });
+
+  it("delete button opens the modal instead of calling DELETE directly", () => {
+    expect(profileDetailSource).toMatch(
+      /onclick=\{\(\)\s*=>\s*\(?\s*showDeleteConfirm\s*=\s*true/,
+    );
+  });
+});
+
+// ── D3.B — empty state + toast notifications ────────────────────────────────
+//
+// The tab-level empty state lives in `Profiles.svelte` and is gated on
+// `!loading && profiles.length === 0` so the loading skeleton and a populated
+// list both keep the two-panel layout. The CTA opens the existing
+// `CreateProfileModal` from the same component.
+
+describe('Profiles.svelte empty state (D3.B)', () => {
+  it('renders the empty-state branch only when no profiles exist and not loading', () => {
+    expect(profilesSource).toMatch(
+      /\{:else if\s+!loading\s+&&\s+profiles\.length\s*===\s*0\}/,
+    );
+    expect(profilesSource).toMatch(/data-testid="profiles-empty-state"/);
+  });
+
+  it('shows the spec copy and a Create Profile CTA inside the empty state', () => {
+    expect(profilesSource).toMatch(/No profiles yet/);
+    expect(profilesSource).toMatch(/namespace your servers by project/);
+    expect(profilesSource).toMatch(/>\s*Create Profile\s*<\/span>/);
+  });
+
+  it('mounts CreateProfileModal from the empty state CTA', () => {
+    expect(profilesSource).toMatch(
+      /onclick=\{\(\)\s*=>\s*\(?\s*showCreateModal\s*=\s*true/,
+    );
+    expect(profilesSource).toMatch(/<CreateProfileModal/);
+  });
+});
+
+describe('CreateProfileModal toast coverage (D3.B)', () => {
+  it('toasts success on create', () => {
+    expect(createProfileModalSource).toMatch(
+      /toast\.success\(`Profile "\$\{created\.name\}" created`\)/,
+    );
+  });
+
+  it('toasts error on create failure (keeps inline submitError for the relay message)', () => {
+    expect(createProfileModalSource).toMatch(
+      /toast\.error\(`Failed to create "\$\{name\.trim\(\)\}"`\)/,
+    );
+    expect(createProfileModalSource).toMatch(/submitError\s*=\s*e instanceof Error/);
+  });
+});

--- a/src/lib/components/profile-detail-helpers.test.ts
+++ b/src/lib/components/profile-detail-helpers.test.ts
@@ -27,19 +27,13 @@ function makeDetail(overrides: Partial<ProfileDetail> = {}): ProfileDetail {
   };
 }
 
-// Default globals snapshot used by the form-loading copy-on-write contract.
-// Matches the production defaults in `stores.ts` so values feel realistic
-// when reading the tests, but the specific booleans are only meaningful in
-// tests that explicitly exercise the null→default resolution.
-const DEFAULTS = { jsExecution: false, toonOutput: true };
-
 describe('sortProfilesByName', () => {
   it('sorts by friendly name with path tiebreak', () => {
     const profiles: ProfileSummary[] = [
-      { name: 'Personal', path: 'personal', endpoints: [], js_execution: null, toon_output: null, endpoint_count: 0, tool_count: 0 },
-      { name: 'Work', path: 'work-a', endpoints: [], js_execution: null, toon_output: null, endpoint_count: 0, tool_count: 0 },
-      { name: 'Work', path: 'work-b', endpoints: [], js_execution: null, toon_output: null, endpoint_count: 0, tool_count: 0 },
-      { name: 'Apex', path: 'apex', endpoints: [], js_execution: null, toon_output: null, endpoint_count: 0, tool_count: 0 },
+      { name: 'Personal', path: 'personal', endpoints: [], js_execution: false, toon_output: true, endpoint_count: 0, tool_count: 0 },
+      { name: 'Work', path: 'work-a', endpoints: [], js_execution: false, toon_output: true, endpoint_count: 0, tool_count: 0 },
+      { name: 'Work', path: 'work-b', endpoints: [], js_execution: false, toon_output: true, endpoint_count: 0, tool_count: 0 },
+      { name: 'Apex', path: 'apex', endpoints: [], js_execution: false, toon_output: true, endpoint_count: 0, tool_count: 0 },
     ];
     expect(sortProfilesByName(profiles).map((p) => p.path)).toEqual([
       'apex',
@@ -51,8 +45,8 @@ describe('sortProfilesByName', () => {
 
   it('does not mutate the input array', () => {
     const profiles: ProfileSummary[] = [
-      { name: 'B', path: 'b', endpoints: [], js_execution: null, toon_output: null, endpoint_count: 0, tool_count: 0 },
-      { name: 'A', path: 'a', endpoints: [], js_execution: null, toon_output: null, endpoint_count: 0, tool_count: 0 },
+      { name: 'B', path: 'b', endpoints: [], js_execution: false, toon_output: true, endpoint_count: 0, tool_count: 0 },
+      { name: 'A', path: 'a', endpoints: [], js_execution: false, toon_output: true, endpoint_count: 0, tool_count: 0 },
     ];
     const before = profiles.map((p) => p.path);
     sortProfilesByName(profiles);
@@ -89,80 +83,78 @@ describe('toggleStagedEndpoint (matrix row #6 — checklist staging)', () => {
   });
 });
 
-describe('formFromDetail (copy-on-write from globals)', () => {
-  it('resolves stored null to the provided default for both toggles', () => {
-    const detail = makeDetail({ js_execution: null, toon_output: null });
-    const form = formFromDetail(detail, { jsExecution: true, toonOutput: false });
-    expect(form.jsExecution).toBe(true);
-    expect(form.toonOutput).toBe(false);
-  });
-
-  it('preserves stored true/false even when defaults differ', () => {
+describe('formFromDetail', () => {
+  it('copies the stored booleans verbatim', () => {
     const detail = makeDetail({ js_execution: false, toon_output: true });
-    const form = formFromDetail(detail, { jsExecution: true, toonOutput: false });
+    const form = formFromDetail(detail);
     expect(form.jsExecution).toBe(false);
     expect(form.toonOutput).toBe(true);
+  });
+
+  it('round-trips true/true', () => {
+    const detail = makeDetail({ js_execution: true, toon_output: true });
+    const form = formFromDetail(detail);
+    expect(form.jsExecution).toBe(true);
+    expect(form.toonOutput).toBe(true);
+  });
+
+  it('round-trips false/false', () => {
+    const detail = makeDetail({ js_execution: false, toon_output: false });
+    const form = formFromDetail(detail);
+    expect(form.jsExecution).toBe(false);
+    expect(form.toonOutput).toBe(false);
   });
 });
 
 describe('computeProfileIsDirty', () => {
   it('returns false when form is unchanged from detail', () => {
     const detail = makeDetail();
-    expect(computeProfileIsDirty(detail, formFromDetail(detail, DEFAULTS), DEFAULTS)).toBe(false);
+    expect(computeProfileIsDirty(detail, formFromDetail(detail))).toBe(false);
   });
 
   it('returns true when the name changes', () => {
     const detail = makeDetail();
-    const form = { ...formFromDetail(detail, DEFAULTS), name: 'Work Updated' };
-    expect(computeProfileIsDirty(detail, form, DEFAULTS)).toBe(true);
+    const form = { ...formFromDetail(detail), name: 'Work Updated' };
+    expect(computeProfileIsDirty(detail, form)).toBe(true);
   });
 
   it('returns true when the path changes', () => {
     const detail = makeDetail();
-    const form = { ...formFromDetail(detail, DEFAULTS), path: 'work-2' };
-    expect(computeProfileIsDirty(detail, form, DEFAULTS)).toBe(true);
+    const form = { ...formFromDetail(detail), path: 'work-2' };
+    expect(computeProfileIsDirty(detail, form)).toBe(true);
   });
 
   it('returns true when js_execution flips between booleans', () => {
     const detail = makeDetail({ js_execution: true });
-    const form = { ...formFromDetail(detail, DEFAULTS), jsExecution: false };
-    expect(computeProfileIsDirty(detail, form, DEFAULTS)).toBe(true);
+    const form = { ...formFromDetail(detail), jsExecution: false };
+    expect(computeProfileIsDirty(detail, form)).toBe(true);
   });
 
-  it('stored null + form matching default is NOT dirty (copy-on-write baseline)', () => {
-    const detail = makeDetail({ js_execution: null, toon_output: null });
-    const form = formFromDetail(detail, { jsExecution: true, toonOutput: false });
-    expect(
-      computeProfileIsDirty(detail, form, { jsExecution: true, toonOutput: false }),
-    ).toBe(false);
-  });
-
-  it('stored null + user toggles opposite of default IS dirty', () => {
-    const detail = makeDetail({ js_execution: null, toon_output: null });
-    const defaults = { jsExecution: true, toonOutput: false };
-    const form = { ...formFromDetail(detail, defaults), toonOutput: true };
-    expect(computeProfileIsDirty(detail, form, defaults)).toBe(true);
+  it('returns true when toon_output flips between booleans', () => {
+    const detail = makeDetail({ toon_output: true });
+    const form = { ...formFromDetail(detail), toonOutput: false };
+    expect(computeProfileIsDirty(detail, form)).toBe(true);
   });
 
   it('returns true when an endpoint is staged on', () => {
     const detail = makeDetail();
-    const form = formFromDetail(detail, DEFAULTS);
+    const form = formFromDetail(detail);
     form.endpoints = toggleStagedEndpoint(form.endpoints, 'Todoist');
-    expect(computeProfileIsDirty(detail, form, DEFAULTS)).toBe(true);
+    expect(computeProfileIsDirty(detail, form)).toBe(true);
   });
 
   it('returns true when an endpoint is staged off', () => {
     const detail = makeDetail();
-    const form = formFromDetail(detail, DEFAULTS);
+    const form = formFromDetail(detail);
     form.endpoints = toggleStagedEndpoint(form.endpoints, 'Gmail');
-    expect(computeProfileIsDirty(detail, form, DEFAULTS)).toBe(true);
+    expect(computeProfileIsDirty(detail, form)).toBe(true);
   });
 
   it('returns false when the endpoint set has the same members in different order', () => {
     const detail = makeDetail({ endpoints: ['Gmail', 'Linear'] });
-    const form = formFromDetail(detail, DEFAULTS);
+    const form = formFromDetail(detail);
     form.endpoints = new Set(['Linear', 'Gmail']);
-    expect(computeProfileIsDirty(detail, form, DEFAULTS)).toBe(false);
+    expect(computeProfileIsDirty(detail, form)).toBe(false);
   });
 });
 
@@ -170,7 +162,7 @@ describe('computeProfileIsDirty', () => {
 describe('buildUpdateProfileParams (matrix row #4 — save payload shape)', () => {
   it('emits the staged form as a UpdateProfileParams body', () => {
     const detail = makeDetail();
-    const form = formFromDetail(detail, DEFAULTS);
+    const form = formFromDetail(detail);
     form.name = 'Work Updated';
     form.endpoints = toggleStagedEndpoint(form.endpoints, 'Todoist');
     const params = buildUpdateProfileParams(form);
@@ -185,15 +177,13 @@ describe('buildUpdateProfileParams (matrix row #4 — save payload shape)', () =
 
   it('trims surrounding whitespace from the friendly name', () => {
     const detail = makeDetail();
-    const form = { ...formFromDetail(detail, DEFAULTS), name: '  Work  ' };
+    const form = { ...formFromDetail(detail), name: '  Work  ' };
     expect(buildUpdateProfileParams(form).name).toBe('Work');
   });
 
-  it('never emits null on js_execution / toon_output (copy-on-write resolves at load)', () => {
-    const detail = makeDetail({ js_execution: null, toon_output: null });
-    const params = buildUpdateProfileParams(
-      formFromDetail(detail, { jsExecution: false, toonOutput: true }),
-    );
+  it('always emits concrete booleans on js_execution / toon_output', () => {
+    const detail = makeDetail({ js_execution: false, toon_output: true });
+    const params = buildUpdateProfileParams(formFromDetail(detail));
     expect(typeof params.js_execution).toBe('boolean');
     expect(typeof params.toon_output).toBe('boolean');
     expect(params.js_execution).toBe(false);
@@ -293,7 +283,7 @@ describe('runSaveProfile (matrix row #4 — Save calls PUT /api/profiles/{path})
 describe('checklist staging + save (matrix row #6 — staged, then committed)', () => {
   it('toggling does not call updateProfile; only Save does', async () => {
     const detail = makeDetail({ endpoints: ['Gmail', 'Linear'] });
-    let form = formFromDetail(detail, DEFAULTS);
+    let form = formFromDetail(detail);
 
     const updateProfile = vi.fn(async () => ({
       ...detail,

--- a/src/lib/components/profile-detail-helpers.ts
+++ b/src/lib/components/profile-detail-helpers.ts
@@ -21,23 +21,17 @@ export interface ProfileEditForm {
  * built from the relay's `endpoints` array so server-side ordering doesn't
  * leak into the form's identity. Used both on initial load and on revert.
  *
- * `defaults` provides the current global `jsExecution` / `toonOutput` values
- * (typically read once from the `jsExecutionMode` / `toonOutput` stores). When
- * the stored detail value is `null` — the legacy "inherit from global" marker
- * the relay still emits on the wire — the form resolves to the matching
- * default. This is a one-way copy-on-write: the next save persists a concrete
- * boolean, so the `null` disappears on first edit-save.
+ * `js_execution` and `toon_output` are concrete booleans end-to-end: the
+ * relay rejects configs/requests that omit them, so the form copies them
+ * verbatim with no global-default fallback.
  */
-export function formFromDetail(
-  detail: ProfileDetail,
-  defaults: { jsExecution: boolean; toonOutput: boolean },
-): ProfileEditForm {
+export function formFromDetail(detail: ProfileDetail): ProfileEditForm {
   return {
     name: detail.name,
     path: detail.path,
     endpoints: new Set(detail.endpoints),
-    jsExecution: detail.js_execution ?? defaults.jsExecution,
-    toonOutput: detail.toon_output ?? defaults.toonOutput,
+    jsExecution: detail.js_execution,
+    toonOutput: detail.toon_output,
   };
 }
 
@@ -60,24 +54,15 @@ export function toggleStagedEndpoint(staged: Set<string>, name: string): Set<str
  * Whether the form has uncommitted edits relative to the loaded detail.
  * Compares all four user-editable fields plus membership-as-a-set so order
  * differences in the underlying array don't register as dirty.
- *
- * `defaults` are the same global values used to seed the form in
- * {@link formFromDetail} so we can recognise "user did nothing" on a profile
- * that was loaded with stored `null`. The comparison is therefore against
- * `detail.js_execution ?? defaults.jsExecution` (and same for toon): a
- * profile loaded with stored `null` is dirty IFF the user toggles to the
- * opposite of the global default. The first save then persists a concrete
- * boolean and the `null` disappears from the stored config.
  */
 export function computeProfileIsDirty(
   detail: ProfileDetail,
   form: ProfileEditForm,
-  defaults: { jsExecution: boolean; toonOutput: boolean },
 ): boolean {
   if (form.name !== detail.name) return true;
   if (form.path !== detail.path) return true;
-  if (form.jsExecution !== (detail.js_execution ?? defaults.jsExecution)) return true;
-  if (form.toonOutput !== (detail.toon_output ?? defaults.toonOutput)) return true;
+  if (form.jsExecution !== detail.js_execution) return true;
+  if (form.toonOutput !== detail.toon_output) return true;
   const original = new Set(detail.endpoints);
   if (original.size !== form.endpoints.size) return true;
   for (const n of form.endpoints) {
@@ -91,8 +76,7 @@ export function computeProfileIsDirty(
  * `name` is trimmed (matches the create-profile modal) and `endpoints` is
  * emitted in stable alphabetical order so two semantically-equal saves
  * produce byte-identical bodies. `js_execution` and `toon_output` are always
- * emitted as concrete booleans — the relay still accepts `null` on the wire
- * for backward compat but the desktop never produces it.
+ * emitted as concrete booleans — the relay rejects requests that omit them.
  */
 export function buildUpdateProfileParams(form: ProfileEditForm): UpdateProfileParams {
   return {

--- a/src/lib/components/profile-detail-helpers.ts
+++ b/src/lib/components/profile-detail-helpers.ts
@@ -12,22 +12,32 @@ export interface ProfileEditForm {
   name: string;
   path: string;
   endpoints: Set<string>;
-  jsExecution: boolean | null;
-  toonOutput: boolean | null;
+  jsExecution: boolean;
+  toonOutput: boolean;
 }
 
 /**
  * Seed the form from a freshly-loaded `ProfileDetail`. The membership set is
  * built from the relay's `endpoints` array so server-side ordering doesn't
  * leak into the form's identity. Used both on initial load and on revert.
+ *
+ * `defaults` provides the current global `jsExecution` / `toonOutput` values
+ * (typically read once from the `jsExecutionMode` / `toonOutput` stores). When
+ * the stored detail value is `null` — the legacy "inherit from global" marker
+ * the relay still emits on the wire — the form resolves to the matching
+ * default. This is a one-way copy-on-write: the next save persists a concrete
+ * boolean, so the `null` disappears on first edit-save.
  */
-export function formFromDetail(detail: ProfileDetail): ProfileEditForm {
+export function formFromDetail(
+  detail: ProfileDetail,
+  defaults: { jsExecution: boolean; toonOutput: boolean },
+): ProfileEditForm {
   return {
     name: detail.name,
     path: detail.path,
     endpoints: new Set(detail.endpoints),
-    jsExecution: detail.js_execution,
-    toonOutput: detail.toon_output,
+    jsExecution: detail.js_execution ?? defaults.jsExecution,
+    toonOutput: detail.toon_output ?? defaults.toonOutput,
   };
 }
 
@@ -50,12 +60,24 @@ export function toggleStagedEndpoint(staged: Set<string>, name: string): Set<str
  * Whether the form has uncommitted edits relative to the loaded detail.
  * Compares all four user-editable fields plus membership-as-a-set so order
  * differences in the underlying array don't register as dirty.
+ *
+ * `defaults` are the same global values used to seed the form in
+ * {@link formFromDetail} so we can recognise "user did nothing" on a profile
+ * that was loaded with stored `null`. The comparison is therefore against
+ * `detail.js_execution ?? defaults.jsExecution` (and same for toon): a
+ * profile loaded with stored `null` is dirty IFF the user toggles to the
+ * opposite of the global default. The first save then persists a concrete
+ * boolean and the `null` disappears from the stored config.
  */
-export function computeProfileIsDirty(detail: ProfileDetail, form: ProfileEditForm): boolean {
+export function computeProfileIsDirty(
+  detail: ProfileDetail,
+  form: ProfileEditForm,
+  defaults: { jsExecution: boolean; toonOutput: boolean },
+): boolean {
   if (form.name !== detail.name) return true;
   if (form.path !== detail.path) return true;
-  if (form.jsExecution !== detail.js_execution) return true;
-  if (form.toonOutput !== detail.toon_output) return true;
+  if (form.jsExecution !== (detail.js_execution ?? defaults.jsExecution)) return true;
+  if (form.toonOutput !== (detail.toon_output ?? defaults.toonOutput)) return true;
   const original = new Set(detail.endpoints);
   if (original.size !== form.endpoints.size) return true;
   for (const n of form.endpoints) {
@@ -68,7 +90,9 @@ export function computeProfileIsDirty(detail: ProfileDetail, form: ProfileEditFo
  * Build the `PUT /api/profiles/{path}` body from the current form snapshot.
  * `name` is trimmed (matches the create-profile modal) and `endpoints` is
  * emitted in stable alphabetical order so two semantically-equal saves
- * produce byte-identical bodies.
+ * produce byte-identical bodies. `js_execution` and `toon_output` are always
+ * emitted as concrete booleans — the relay still accepts `null` on the wire
+ * for backward compat but the desktop never produces it.
  */
 export function buildUpdateProfileParams(form: ProfileEditForm): UpdateProfileParams {
   return {

--- a/src/lib/components/profile-detail-helpers.ts
+++ b/src/lib/components/profile-detail-helpers.ts
@@ -1,0 +1,168 @@
+import type { ProfileDetail, ProfileSummary, UpdateProfileParams } from '$lib/api';
+
+/**
+ * The "edited" snapshot of the right-pane form. Held in `$state` while the
+ * user types/toggles; committed to the relay on Save via {@link runSaveProfile}.
+ *
+ * `endpoints` is a `Set<string>` so the checklist UI can flip membership in
+ * O(1). The set is converted back to a deterministic array (alphabetical) when
+ * we build the PUT body.
+ */
+export interface ProfileEditForm {
+  name: string;
+  path: string;
+  endpoints: Set<string>;
+  jsExecution: boolean | null;
+  toonOutput: boolean | null;
+}
+
+/**
+ * Seed the form from a freshly-loaded `ProfileDetail`. The membership set is
+ * built from the relay's `endpoints` array so server-side ordering doesn't
+ * leak into the form's identity. Used both on initial load and on revert.
+ */
+export function formFromDetail(detail: ProfileDetail): ProfileEditForm {
+  return {
+    name: detail.name,
+    path: detail.path,
+    endpoints: new Set(detail.endpoints),
+    jsExecution: detail.js_execution,
+    toonOutput: detail.toon_output,
+  };
+}
+
+/**
+ * Toggle one endpoint name in the staged membership set. Returns a new `Set`
+ * so Svelte reactivity sees the change. The check-then-mutate-then-clone shape
+ * keeps the helper pure (no aliasing of the caller's set).
+ */
+export function toggleStagedEndpoint(staged: Set<string>, name: string): Set<string> {
+  const next = new Set(staged);
+  if (next.has(name)) {
+    next.delete(name);
+  } else {
+    next.add(name);
+  }
+  return next;
+}
+
+/**
+ * Whether the form has uncommitted edits relative to the loaded detail.
+ * Compares all four user-editable fields plus membership-as-a-set so order
+ * differences in the underlying array don't register as dirty.
+ */
+export function computeProfileIsDirty(detail: ProfileDetail, form: ProfileEditForm): boolean {
+  if (form.name !== detail.name) return true;
+  if (form.path !== detail.path) return true;
+  if (form.jsExecution !== detail.js_execution) return true;
+  if (form.toonOutput !== detail.toon_output) return true;
+  const original = new Set(detail.endpoints);
+  if (original.size !== form.endpoints.size) return true;
+  for (const n of form.endpoints) {
+    if (!original.has(n)) return true;
+  }
+  return false;
+}
+
+/**
+ * Build the `PUT /api/profiles/{path}` body from the current form snapshot.
+ * `name` is trimmed (matches the create-profile modal) and `endpoints` is
+ * emitted in stable alphabetical order so two semantically-equal saves
+ * produce byte-identical bodies.
+ */
+export function buildUpdateProfileParams(form: ProfileEditForm): UpdateProfileParams {
+  return {
+    name: form.name.trim(),
+    path: form.path,
+    endpoints: Array.from(form.endpoints).sort(),
+    js_execution: form.jsExecution,
+    toon_output: form.toonOutput,
+  };
+}
+
+/**
+ * Sort summaries for the left-rail sidebar. Engineering Spec §9.2 specifies
+ * "List of profiles, sorted by name"; ties break on path so the order is
+ * deterministic even when two profiles share a friendly name.
+ */
+export function sortProfilesByName(profiles: ReadonlyArray<ProfileSummary>): ProfileSummary[] {
+  return [...profiles].sort((a, b) => {
+    const byName = a.name.localeCompare(b.name);
+    if (byName !== 0) return byName;
+    return a.path.localeCompare(b.path);
+  });
+}
+
+// ── Save/delete handlers (extracted for testability) ─────────────────────────
+//
+// These mirror the dependency-injection pattern used by
+// `detail-panel-helpers.test.ts::runHandleDelete` so we can cover the toast +
+// state-refresh contract for profile mutations without mounting Svelte.
+
+export interface SaveProfileDeps {
+  originalPath: string;
+  params: UpdateProfileParams;
+  updateProfile: (path: string, params: UpdateProfileParams) => Promise<ProfileSummary>;
+  listProfiles: () => Promise<ProfileSummary[]>;
+  setProfiles: (data: ProfileSummary[]) => void;
+  setSelectedPath: (path: string) => void;
+  applyDetail: (summary: ProfileSummary) => void;
+  toastSuccess: (msg: string) => void;
+  toastError: (msg: string) => void;
+}
+
+/**
+ * Run the Save flow: PUT the params, then best-effort refresh the sidebar list
+ * and rebase the right-pane selection on the (possibly renamed) path. Errors
+ * from the refresh step are swallowed because the mutation already succeeded
+ * and the parent's poll will reconcile; only PUT failures surface as toasts.
+ */
+export async function runSaveProfile(deps: SaveProfileDeps): Promise<void> {
+  try {
+    const updated = await deps.updateProfile(deps.originalPath, deps.params);
+    deps.applyDetail(updated);
+    deps.setSelectedPath(updated.path);
+    try {
+      const data = await deps.listProfiles();
+      deps.setProfiles(data);
+    } catch {
+      // Mutation already succeeded — silent on purpose; the sidebar will
+      // reconcile on the next outer refresh.
+    }
+    deps.toastSuccess(`Profile "${updated.name}" saved`);
+  } catch {
+    deps.toastError(`Failed to save "${deps.params.name}"`);
+  }
+}
+
+export interface DeleteProfileDeps {
+  path: string;
+  name: string;
+  deleteProfile: (path: string) => Promise<void>;
+  listProfiles: () => Promise<ProfileSummary[]>;
+  setProfiles: (data: ProfileSummary[]) => void;
+  clearSelection: () => void;
+  toastSuccess: (msg: string) => void;
+  toastError: (msg: string) => void;
+}
+
+/**
+ * Run the Delete flow: DELETE the profile, clear the right-pane selection,
+ * best-effort refresh the sidebar list, and toast success/error. Mirrors the
+ * `handleDelete` shape from `DetailPanel.svelte`.
+ */
+export async function runDeleteProfile(deps: DeleteProfileDeps): Promise<void> {
+  try {
+    await deps.deleteProfile(deps.path);
+    deps.clearSelection();
+    try {
+      const data = await deps.listProfiles();
+      deps.setProfiles(data);
+    } catch {
+      // Mutation already succeeded — silent on purpose.
+    }
+    deps.toastSuccess(`Profile "${deps.name}" deleted`);
+  } catch {
+    deps.toastError(`Failed to delete "${deps.name}"`);
+  }
+}

--- a/src/lib/logParser.test.ts
+++ b/src/lib/logParser.test.ts
@@ -111,6 +111,54 @@ describe('parseLogLine', () => {
   });
 });
 
+describe('parseLogLine — profile field (matrix row #7)', () => {
+  it('extracts profile from the mcp_request span', () => {
+    // Engineering Spec §7.1: the relay emits
+    // tracing::info_span!("mcp_request", profile = %profile_path).
+    const parsed = parseLogLine(
+      'info',
+      '2026-05-25T10:30:15Z INFO mcp_request{profile="work"} endpoint{endpoint="gmail"}: Tool call completed tool=send_email status=ok duration_ms=234',
+    );
+    expect(parsed.profile).toBe('work');
+    expect(parsed.endpoint).toBe('gmail');
+    expect(parsed.tool).toBe('send_email');
+    expect(parsed.durationMs).toBe(234);
+  });
+
+  it('extracts profile from an unquoted span value', () => {
+    // The Compact tracing formatter omits the quotes around span values.
+    // The parser must handle both shapes per the recon §5 note.
+    const parsed = parseLogLine(
+      'info',
+      '2026-05-25T10:30:15 INFO mcp_request{profile=work endpoint=gmail tool=send_email} completed duration_ms=234',
+    );
+    expect(parsed.profile).toBe('work');
+  });
+
+  it('falls back to any span carrying a profile field when mcp_request is absent', () => {
+    // Robustness to R3.E's exact span name: if the field shows up on a
+    // different span (e.g. `request{profile=work id=42}`), we still surface it.
+    const parsed = parseLogLine(
+      'info',
+      'request{method="tools/call" id=42 profile="personal"} endpoint{endpoint="slack"}: hello',
+    );
+    expect(parsed.profile).toBe('personal');
+  });
+
+  it('leaves profile undefined when no span carries the field', () => {
+    const parsed = parseLogLine(
+      'info',
+      'endpoint{endpoint="github" transport="stdio"}: Initialize handshake complete',
+    );
+    expect(parsed.profile).toBeUndefined();
+  });
+
+  it('leaves profile undefined for lines with no span context', () => {
+    const parsed = parseLogLine('info', 'Relay listening on 127.0.0.1:47107');
+    expect(parsed.profile).toBeUndefined();
+  });
+});
+
 describe('parseLogLine — endpointOverride (Slice D.2)', () => {
   it('uses the override when provided, ignoring the parsed span value', () => {
     const parsed = parseLogLine(

--- a/src/lib/logParser.ts
+++ b/src/lib/logParser.ts
@@ -20,6 +20,7 @@ export interface ParsedLogLine {
   tool?: string;
   status?: string;
   durationMs?: number;
+  profile?: string;
   message: string;
   raw: string;
   isToolCall: boolean;
@@ -123,6 +124,15 @@ export function parseLogLine(
       ? options.endpointOverride
       : parsedEndpoint;
 
+  // Per Engineering Spec §7.1 the relay emits `tracing::info_span!("mcp_request",
+  // profile = %profile_path)`, so the canonical span name is `mcp_request`.
+  // Fall back to scanning every captured span for a `profile` field so the
+  // parser stays robust to the exact span name R3.E ends up emitting (see
+  // Desktop recon §5 and the spec's "Recon findings — locked decisions"
+  // Desktop #6).
+  const profile =
+    spans.mcp_request?.profile ?? Object.values(spans).find((s) => s.profile)?.profile;
+
   return {
     timestamp,
     level: normalizeLevel(extractedLevel ?? level),
@@ -134,6 +144,7 @@ export function parseLogLine(
     tool,
     status,
     durationMs: durationMs !== undefined && !Number.isNaN(durationMs) ? durationMs : undefined,
+    profile,
     message: cleanedMessage,
     raw: message,
     isToolCall,

--- a/src/lib/relaySidecarUi.test.ts
+++ b/src/lib/relaySidecarUi.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import {
+  allTopLevelTabs,
+  getVisibleTopLevelTabs,
+  getActiveTopLevelTab,
+  relayTabsRestricted,
+} from './relaySidecarUi';
+import type { RelaySidecarStatusType } from './stores';
+
+describe('allTopLevelTabs', () => {
+  it("includes 'profiles' between 'unified-catalog' and 'relay-logs'", () => {
+    const ids = allTopLevelTabs.map((tab) => tab.id);
+    const catalogIdx = ids.indexOf('unified-catalog');
+    const profilesIdx = ids.indexOf('profiles');
+    const logsIdx = ids.indexOf('relay-logs');
+    expect(catalogIdx).toBeGreaterThanOrEqual(0);
+    expect(profilesIdx).toBe(catalogIdx + 1);
+    expect(logsIdx).toBe(profilesIdx + 1);
+  });
+
+  it("labels the profiles tab 'Profiles'", () => {
+    const tab = allTopLevelTabs.find((t) => t.id === 'profiles');
+    expect(tab?.label).toBe('Profiles');
+  });
+});
+
+describe('getVisibleTopLevelTabs — profiles visibility (test matrix #9)', () => {
+  const visibleStatuses: RelaySidecarStatusType[] = ['running', 'starting', 'unknown', 'restarting'];
+  const restrictedStatuses: RelaySidecarStatusType[] = ['failed', 'stopped'];
+
+  for (const status of visibleStatuses) {
+    it(`shows 'profiles' when relay status is '${status}'`, () => {
+      const ids = getVisibleTopLevelTabs(status).map((tab) => tab.id);
+      expect(ids).toContain('profiles');
+    });
+  }
+
+  for (const status of restrictedStatuses) {
+    it(`hides 'profiles' when relay status is '${status}'`, () => {
+      const ids = getVisibleTopLevelTabs(status).map((tab) => tab.id);
+      expect(ids).not.toContain('profiles');
+      expect(relayTabsRestricted(status)).toBe(true);
+    });
+
+    it(`hides 'profiles' alongside 'servers' and 'unified-catalog' when relay status is '${status}'`, () => {
+      const ids = getVisibleTopLevelTabs(status).map((tab) => tab.id);
+      expect(ids).not.toContain('servers');
+      expect(ids).not.toContain('unified-catalog');
+      expect(ids).not.toContain('profiles');
+      expect(ids).toEqual(['relay-logs', 'settings']);
+    });
+  }
+});
+
+describe("getActiveTopLevelTab — 'profiles' selection", () => {
+  it("keeps 'profiles' active when relay is running", () => {
+    expect(getActiveTopLevelTab('profiles', 'running')).toBe('profiles');
+  });
+
+  it("falls back to 'settings' when 'profiles' is the active tab but relay is failed", () => {
+    expect(getActiveTopLevelTab('profiles', 'failed')).toBe('settings');
+  });
+
+  it("falls back to 'settings' when 'profiles' is the active tab but relay is stopped", () => {
+    expect(getActiveTopLevelTab('profiles', 'stopped')).toBe('settings');
+  });
+});

--- a/src/lib/relaySidecarUi.ts
+++ b/src/lib/relaySidecarUi.ts
@@ -1,10 +1,11 @@
 import type { RelaySidecarStatusType } from './stores';
 
-export type TopLevelTabId = 'servers' | 'unified-catalog' | 'relay-logs' | 'settings';
+export type TopLevelTabId = 'servers' | 'unified-catalog' | 'profiles' | 'relay-logs' | 'settings';
 
 export const allTopLevelTabs = [
   { id: 'servers' as const, label: 'Servers' },
   { id: 'unified-catalog' as const, label: 'Catalog' },
+  { id: 'profiles' as const, label: 'Profiles' },
   { id: 'relay-logs' as const, label: 'Logs' },
   { id: 'settings' as const, label: 'Settings' },
 ];

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -53,9 +53,9 @@ function createThemeStore() {
 
 export const theme = createThemeStore();
 export const searchQuery = writable<string>('');
-export const activeTab = writable<'tools' | 'logs' | 'config' | 'auth'>('tools');
+export const activeTab = writable<'tools' | 'logs' | 'config' | 'auth' | 'profiles'>('tools');
 export const oauthStatuses = writable<Map<string, OAuthStatus>>(new Map());
-export const activeTopLevelTab = writable<'servers' | 'unified-catalog' | 'relay-logs' | 'settings'>('servers');
+export const activeTopLevelTab = writable<'servers' | 'unified-catalog' | 'profiles' | 'relay-logs' | 'settings'>('servers');
 
 export const relayLogLines = writable<ParsedLogLine[]>([]);
 export const miniPlayerMode = writable<boolean>(false);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,6 +6,7 @@
   import Settings from '$lib/components/Settings.svelte';
   import RelayLogs from '$lib/components/RelayLogs.svelte';
   import UnifiedCatalog from '$lib/components/UnifiedCatalog.svelte';
+  import Profiles from '$lib/components/Profiles.svelte';
   import Onboarding from '$lib/components/Onboarding.svelte';
   import ConfirmModal from '$lib/components/ConfirmModal.svelte';
   import { endpoints, activeTopLevelTab, miniPlayerMode, relayConnected, showOnboarding, relayPort, relaySidecarStatus, relaySidecarError, initialLoadComplete, oauthStatuses } from '$lib/stores';
@@ -291,6 +292,9 @@
       </div>
       <div class="h-full" style:display={$activeTopLevelTab === 'unified-catalog' ? 'block' : 'none'}>
         <UnifiedCatalog />
+      </div>
+      <div class="h-full" style:display={$activeTopLevelTab === 'profiles' ? 'block' : 'none'}>
+        <Profiles />
       </div>
       <div class="h-full" style:display={$activeTopLevelTab === 'relay-logs' ? 'block' : 'none'}>
         <RelayLogs ongotoendpoint={handleGoToEndpoint} />

--- a/src/routes/page-tabs.test.ts
+++ b/src/routes/page-tabs.test.ts
@@ -15,6 +15,7 @@ describe('+page relay tab logic', () => {
     expect(getVisibleTopLevelTabs('running').map((tab) => tab.id)).toEqual([
       'servers',
       'unified-catalog',
+      'profiles',
       'relay-logs',
       'settings',
     ]);
@@ -28,6 +29,7 @@ describe('+page relay tab logic', () => {
     expect(getVisibleTopLevelTabs('restarting').map((tab) => tab.id)).toEqual([
       'servers',
       'unified-catalog',
+      'profiles',
       'relay-logs',
       'settings',
     ]);


### PR DESCRIPTION
## Summary

Implements the **desktop UI** for the new endpoint-profiles feature (Issue [endara-ai/endara-relay#77](https://github.com/endara-ai/endara-relay/issues/77)) — lets users manage profiles that namespace MCP servers by project, browse them in a dedicated `Profiles` top-level tab, toggle per-endpoint membership inline from the Servers detail, and filter the Logs view by profile.

Engineering Spec **§9 (Desktop UI)** covers the surface: new top-level tab, two-panel Profiles layout, CreateProfileModal, per-endpoint Profiles sub-tab, RelayLogs profile filter, unsaved-changes guard, empty state + toasts.

## Pairs with

- Relay PR: [endara-ai/endara-relay#83](https://github.com/endara-ai/endara-relay/pull/83) — `feat: endpoint profiles (/mcp/{profile})` (§1–§8). The two PRs ship in lockstep on the same `vX.Y.Z-rc.N` cycle; the desktop UI talks to the relay management API + `profile=<path>` log spans added in #83.

## Changes (14 commits, in topological order)

1. `feat(profiles): add profile API client functions` (D1.A) — `src/lib/api.ts` adds list/get/create/update/delete profile calls + endpoint-profile membership against the relay management API (mirrors `enableEndpoint`/`disableTool`, not Tauri `invoke`).
2. `feat(logs): parse profile field from tracing spans` (D1.B) — `src/lib/logParser.ts` extracts the immutable cross-stack `profile=<path>` field from any span, with `mcp_request` as the preferred source.
3. `feat(logs): add profile filter dropdown to RelayLogs` (D2.D) — `LogFilterBar` gets a multi-select profile dropdown (empty set = All), mirroring the existing endpoint dropdown.
4. `feat(profiles): register Profiles top-level tab` (D1.C) — `TopLevelTabId` adds `'profiles'`; `+page.svelte` mounts the panel; tab visibility hides it when relay is in a restricted state, matching Servers/Catalog.
5. `feat(profiles): CreateProfileModal with name/path validation` (D2.A) — name + path validation (regex + reserved-paths), submit payload helper, success/failure toasts. Server assignment is intentionally **post-create** per Spec §9.3.
6. `feat(profiles): two-panel Profiles layout with save/delete` (D2.B) — `Profiles.svelte` + `ProfileSidebar` + `ProfileDetail`; PUT with path-rename rebase, DELETE with `ConfirmModal` gate, dirty-checking with 8 `computeProfileIsDirty` cases.
7. `feat(profiles): per-endpoint Profiles sub-tab (D2.C)` — `DetailPanel` gains a `Profiles` sub-tab on stdio/http/oauth endpoints showing membership rows + toggle + PUT round-trip + error toast.
8. `feat(profiles): unsaved-changes guard on profile detail (D3.A)` — wires `registerDirtyChecker` + `requestNavigation`, gates post-create selection, mirrors `ConfigTab.svelte` pattern.
9. `chore(deps): refresh pnpm lockfile` — `pnpm-lock.yaml` regenerated; no production-dep adds.
10. `fix(profiles): disable autocapitalize/autocorrect on profile path inputs` — keep profile paths predictable on mobile keyboards.
11. `feat(profiles): add connect-client snippet to profile detail view` — copyable `mcp.json` snippet pointed at `/mcp/{path}`.
12. `feat(profiles): describe profile-membership toggle on endpoint sub-tab` — clarifying copy.
13. `refactor(profiles): remove inherit; copy-on-write JS/TOON toggles` — locks the per-profile booleans to strict `true`/`false`, matching the relay-side locked decision.
14. `refactor(profiles): drop null from JS/TOON types and form helpers` — type-level cleanup of `js_execution` / `toon_output` (strictly `boolean`).

## Test plan

Full verification report on the D4.A task note. Headline gates (committed-tree run):

| Gate | Cmd | Result |
| --- | --- | --- |
| Typecheck (svelte-check) | `pnpm check` | ✅ 0 errors, 1 pre-existing tsconfig warning |
| Lint | `pnpm lint` | ⚠️ stub echo (pre-existing repo state; not a regression) |
| Unit tests | `pnpm test` | ✅ **553 passed / 24 skipped (577 total)** in ~8s |

### Spec §11 desktop test-matrix coverage (#1–#10, all ✅)

| # | Spec row | Proving test |
| --- | --- | --- |
| 1 | Path validation — valid | `validateProfilePath — matrix #1` (CreateProfileModal.test.ts) |
| 2 | Path validation — invalid | `validateProfilePath — matrix #2` (CreateProfileModal.test.ts) |
| 3 | Create profile modal — submit | `buildCreateProfilePayload — matrix #3` (CreateProfileModal.test.ts) |
| 4 | Profile detail — save | `buildUpdateProfileParams` + `runSaveProfile` (profile-detail-helpers.test.ts) |
| 5 | Profile detail — delete | `runDeleteProfile` + `ProfileDetail delete confirmation` (profile-detail-helpers.test.ts) |
| 6 | Server checklist — toggle | `toggleStagedEndpoint` + `checklist staging + save` (profile-detail-helpers.test.ts) |
| 7 | Log parser — profile field | `parseLogLine — profile field (matrix row #7)` (logParser.test.ts) |
| 8 | Log filter — profile | `restricts to the selected profiles (empty set = All)` (LogFilterBar.test.ts) |
| 9 | Profiles tab visibility | `getVisibleTopLevelTabs — profiles visibility (test matrix #9)` (relaySidecarUi.test.ts) |
| 10 | Per-endpoint profiles tab | `visibleTabs` across transports + enabled/disabled (detail-panel-helpers.test.ts) |

### Cross-stack contract

`packages/desktop/src/lib/logParser.ts:133–134` reads the `profile` field exactly as relay #83's `R3.E` emits it:

`spans.mcp_request?.profile ?? Object.values(spans).find((s) => s.profile)?.profile`

The field key is hard-coded as the literal `profile` per Engineering Spec §7.1 / Desktop locked decision #6.

## Non-goals

- Disabling `/mcp` (the everything endpoint) — Spec §12.
- Per-profile health/lifecycle tracking, OAuth flows, profile ordering, last-used timestamps — Spec §12.
- Migrating endpoint creation from `config.toml` to the management API — separate issue.

## Risk / rollback

- All new UI lives in dedicated routes/components; the Profiles tab is gated by the same relay-state visibility logic as Servers/Catalog.
- Rollback is a single revert of the merge commit; no schema/state migrations on the desktop side.

Closes [endara-ai/endara-relay#77](https://github.com/endara-ai/endara-relay/issues/77) (once both this PR and endara-ai/endara-relay#83 merge and ship in matching rc tags).
