### PR TITLE
fix: handle endpoint names with spaces in log parser

### DIFF
--- a/src/lib/logParser.test.ts
+++ b/src/lib/logParser.test.ts
@@ -13,6 +13,34 @@ describe('parseLogLine', () => {
     expect(parsed.level).toBe('info');
   });
 
+  it('extracts a quoted span value containing whitespace without stray quotes', () => {
+    // Regression: the previous alternation tried the unquoted branch first
+    // and would capture `"Clement` (stopping at the inner space), leaking a
+    // leading quote into the endpoint dropdown.
+    const parsed = parseLogLine(
+      'info',
+      'endpoint{endpoint="Clement Whatsapp" transport="stdio"}: Initialize handshake complete',
+    );
+    expect(parsed.endpoint).toBe('Clement Whatsapp');
+    expect(parsed.transport).toBe('stdio');
+  });
+
+  it('extracts a quoted endpoint name with a space from a full relay log line', () => {
+    // Mirrors the Rust-side fixture in src-tauri/src/lib.rs
+    // (`parse_endpoint_from_span_tests::endpoint_present_in_span_returns_some`)
+    // so the JS parser stays in lockstep with the authoritative parser on the
+    // real Full-format wire shape — timestamp + level + quoted span fields.
+    const parsed = parseLogLine(
+      'info',
+      '2026-05-20T10:00:00.000Z  INFO endpoint{endpoint="Clement Whatsapp" transport="stdio"}: Initialize handshake complete',
+    );
+    expect(parsed.endpoint).toBe('Clement Whatsapp');
+    expect(parsed.transport).toBe('stdio');
+    expect(parsed.timestamp.toISOString()).toBe('2026-05-20T10:00:00.000Z');
+    expect(parsed.level).toBe('info');
+    expect(parsed.message).toBe('Initialize handshake complete');
+  });
+
   it('extracts multiple span fields (endpoint, transport, server_type)', () => {
     const parsed = parseLogLine(
       'info',

--- a/src/lib/logParser.ts
+++ b/src/lib/logParser.ts
@@ -27,7 +27,13 @@ export interface ParsedLogLine {
 }
 
 const SPAN_RE = /(\w+)\{([^}]+)\}/g;
-const FIELD_RE = /(\w+)=([^\s,}]+|"[^"]*")/g;
+// The quoted alternative must come first: regex alternation is leftmost-first,
+// not longest-match, so trying `[^\s,}]+` ahead of `"[^"]*"` would greedily
+// match `"Clement` and stop at the space inside `endpoint="Clement Whatsapp"`,
+// leaving a stray leading quote in the captured value.
+// Capture groups: 1 = field name, 2 = full value, 3 = inside-quotes (when
+// quoted), 4 = unquoted value.
+const FIELD_RE = /(\w+)=("([^"]*)"|([^\s,}]+))/g;
 const TIMESTAMP_RE = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z?)\s+/;
 // Whole-word level token that the relay emits right after the timestamp. The
 // regex is case-sensitive because the relay always emits these upper-case;
@@ -88,7 +94,7 @@ export function parseLogLine(
     const [full, spanName, spanFields] = match;
     spans[spanName] = {};
     for (const fm of spanFields.matchAll(FIELD_RE)) {
-      spans[spanName][fm[1]] = fm[2].replace(/^"|"$/g, '');
+      spans[spanName][fm[1]] = fm[3] !== undefined ? fm[3] : fm[4];
     }
     cleanMessage = cleanMessage.replace(full, '');
   }


### PR DESCRIPTION
Fixes the bug where endpoint names containing spaces (e.g., `"Clement Whatsapp"`) were truncated to the first word in the desktop logs view.

## Root Cause

The JavaScript parser's `FIELD_RE` regex used leftmost-first alternation with the unquoted pattern before the quoted pattern, causing it to greedily match `"Clement` and stop at the space inside quoted values like `endpoint="Clement Whatsapp"`.

## Solution

- Reordered `FIELD_RE` regex in `src/lib/logParser.ts` to try the quoted pattern FIRST
- Updated field extraction to use capture group 3 (inside quotes) or 4 (unquoted)
- Added 2 regression tests in `src/lib/logParser.test.ts` covering quoted endpoint names with spaces

## Testing

- All 31 tests in `logParser.test.ts` pass (29 existing + 2 new)
- Full desktop test suite: 558 passed / 24 skipped / 0 failed
- No regressions detected

## Files Changed

- `src/lib/logParser.ts` — Regex fix + extraction logic
- `src/lib/logParser.test.ts` — 2 new regression tests
