### PR TITLE
feat(tray): tray health indicator with dynamic menu status line

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@endara/desktop",
-  "version": "0.1.6",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@endara/desktop",
-      "version": "0.1.6",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1121,6 +1121,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "image",
  "libc",
  "log",
  "objc2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,6 +35,7 @@ hyper = { version = "1", features = ["client", "http1"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 http-body-util = "0.1"
 regex = "1.12.3"
+image = { version = "0.25.10", default-features = false, features = ["png"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.4"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod api_proxy;
+mod tray;
 mod webview_recovery;
 
 use std::collections::HashMap;
@@ -2309,6 +2310,94 @@ fn is_autostarted() -> bool {
     std::env::args().any(|arg| arg == "--autostarted")
 }
 
+/// Tauri-managed wrapper around the tray menu's first item ("status"). The
+/// inner `MenuItem` already handles main-thread dispatch internally and is
+/// `Send + Sync` (it's an `Arc<Inner>`), so no extra mutex is needed.
+/// Hardcoded to `tauri::Wry` because the default runtime is the only one in
+/// use for this app.
+pub struct TrayStatusItem(pub tauri::menu::MenuItem<tauri::Wry>);
+
+/// Compose the tray menu label for a given health `state` and optional
+/// frontend-provided `detail`. When `detail` is present it is rendered as
+/// `"Endara — {detail}"`; otherwise we fall back to the per-state defaults.
+fn compose_tray_menu_label(state: &str, detail: Option<&str>) -> String {
+    if let Some(d) = detail.map(str::trim).filter(|s| !s.is_empty()) {
+        return format!("Endara — {d}");
+    }
+    match state {
+        "healthy" => "Endara — Running".to_string(),
+        "degraded" => "Endara — Issue detected".to_string(),
+        "down" => "Endara — Relay not running".to_string(),
+        _ => "Endara".to_string(),
+    }
+}
+
+/// Compose the tray tooltip for a given health `state` and optional
+/// frontend-provided `detail`. When `detail` is present it is rendered as
+/// `"Endara Relay — {detail}"`; otherwise we fall back to the per-state
+/// defaults from spec §5.
+fn compose_tray_tooltip(state: &str, detail: Option<&str>) -> String {
+    if let Some(d) = detail.map(str::trim).filter(|s| !s.is_empty()) {
+        return format!("Endara Relay — {d}");
+    }
+    match state {
+        "healthy" => "Endara Relay — all systems healthy".to_string(),
+        "degraded" => "Endara Relay — some endpoints need attention".to_string(),
+        "down" => "Endara Relay — relay is not running".to_string(),
+        _ => "Endara Relay".to_string(),
+    }
+}
+
+/// Update the tray icon, tooltip, and status menu item to reflect the latest
+/// aggregated health state computed on the frontend. Unknown `state` values
+/// fall back to the monochrome template icon so the menu bar stays in a
+/// sensible default. `detail` is an optional short description (≤ ~50 chars)
+/// supplied by the frontend so the menu line and tooltip surface the specific
+/// problem instead of a generic per-state label.
+#[tauri::command]
+fn set_tray_health(app: AppHandle, state: &str, detail: Option<String>) {
+    let Some(icons) = app.try_state::<tray::TrayIcons>() else {
+        log::warn!("[tray] set_tray_health called before TrayIcons state is managed");
+        return;
+    };
+    let (icon_data, is_template) = match state {
+        "healthy" => (&icons.healthy, false),
+        "degraded" => (&icons.degraded, false),
+        "down" => (&icons.down, false),
+        _ => (&icons.base, true),
+    };
+    let detail_ref = detail.as_deref();
+    let tooltip = compose_tray_tooltip(state, detail_ref);
+    let menu_label = compose_tray_menu_label(state, detail_ref);
+    let Some(tray_icon) = app.tray_by_id("main") else {
+        log::warn!("[tray] set_tray_health: main tray icon not found");
+        return;
+    };
+    match tauri::image::Image::from_bytes(icon_data) {
+        Ok(image) => {
+            if let Err(e) = tray_icon.set_icon(Some(image)) {
+                log::warn!("[tray] failed to set tray icon state={state} error={e}");
+            }
+        }
+        Err(e) => {
+            log::warn!("[tray] failed to decode tray icon state={state} error={e}");
+        }
+    }
+    if let Err(e) = tray_icon.set_icon_as_template(is_template) {
+        log::warn!("[tray] failed to set icon_as_template state={state} error={e}");
+    }
+    if let Err(e) = tray_icon.set_tooltip(Some(&tooltip)) {
+        log::warn!("[tray] failed to set tooltip state={state} error={e}");
+    }
+    if let Some(status_item) = app.try_state::<TrayStatusItem>() {
+        if let Err(e) = status_item.0.set_text(&menu_label) {
+            log::warn!("[tray] failed to set status menu label state={state} error={e}");
+        }
+    } else {
+        log::warn!("[tray] set_tray_health called before TrayStatusItem state is managed");
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let default_port = if is_dev_mode() {
@@ -2404,6 +2493,7 @@ pub fn run() {
             show_update_notification,
             get_autostart,
             set_autostart,
+            set_tray_health,
         ])
         .setup(move |app| {
             log::info!(
@@ -2426,10 +2516,19 @@ pub fn run() {
             let menu =
                 Menu::with_items(app, &[&status_item, &open_item, &update_item, &quit_item])?;
 
-            let _tray = TrayIconBuilder::new()
-                .icon(tauri::image::Image::from_bytes(include_bytes!(
-                    "../icons/tray-icon-template.png"
-                ))?)
+            // Stash the status menu item as managed state so `set_tray_health`
+            // can update its label when the frontend reports a new health
+            // detail (e.g. "Endara — Sign in required for github-mcp").
+            app.manage(TrayStatusItem(status_item.clone()));
+
+            // Pre-build the colored tray-icon variants from the base template
+            // and stash them as managed state so `set_tray_health` can swap
+            // them on demand without redoing the PNG decode/encode work.
+            const TRAY_ICON_TEMPLATE: &[u8] = include_bytes!("../icons/tray-icon-template.png");
+            app.manage(tray::build_tray_icons(TRAY_ICON_TEMPLATE));
+
+            let _tray = TrayIconBuilder::with_id("main")
+                .icon(tauri::image::Image::from_bytes(TRAY_ICON_TEMPLATE)?)
                 .icon_as_template(true)
                 .menu(&menu)
                 .show_menu_on_left_click(true)
@@ -3856,5 +3955,71 @@ mod parse_level_from_line_tests {
         // handles this case, but the helper itself stays strict.
         let line = "2026-05-20T17:54:47.123Z something happened: an error occurred mid-body";
         assert_eq!(parse_level_from_line(line), None);
+    }
+}
+
+#[cfg(test)]
+mod tray_label_tests {
+    use super::*;
+
+    #[test]
+    fn menu_label_falls_back_to_per_state_default_when_no_detail() {
+        assert_eq!(compose_tray_menu_label("healthy", None), "Endara — Running");
+        assert_eq!(
+            compose_tray_menu_label("degraded", None),
+            "Endara — Issue detected"
+        );
+        assert_eq!(
+            compose_tray_menu_label("down", None),
+            "Endara — Relay not running"
+        );
+    }
+
+    #[test]
+    fn menu_label_uses_detail_when_present() {
+        assert_eq!(
+            compose_tray_menu_label("degraded", Some("Sign in required for github-mcp")),
+            "Endara — Sign in required for github-mcp"
+        );
+        assert_eq!(
+            compose_tray_menu_label("down", Some("Relay stopped")),
+            "Endara — Relay stopped"
+        );
+    }
+
+    #[test]
+    fn menu_label_treats_empty_or_whitespace_detail_as_no_detail() {
+        assert_eq!(
+            compose_tray_menu_label("healthy", Some("")),
+            "Endara — Running"
+        );
+        assert_eq!(
+            compose_tray_menu_label("healthy", Some("   ")),
+            "Endara — Running"
+        );
+    }
+
+    #[test]
+    fn tooltip_falls_back_to_spec_5_defaults_when_no_detail() {
+        assert_eq!(
+            compose_tray_tooltip("healthy", None),
+            "Endara Relay — all systems healthy"
+        );
+        assert_eq!(
+            compose_tray_tooltip("degraded", None),
+            "Endara Relay — some endpoints need attention"
+        );
+        assert_eq!(
+            compose_tray_tooltip("down", None),
+            "Endara Relay — relay is not running"
+        );
+    }
+
+    #[test]
+    fn tooltip_uses_detail_when_present() {
+        assert_eq!(
+            compose_tray_tooltip("degraded", Some("2 endpoints unhealthy")),
+            "Endara Relay — 2 endpoints unhealthy"
+        );
     }
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,0 +1,204 @@
+//! Tray icon compositing for the health indicator.
+//!
+//! The base tray icon is the existing monochrome template PNG. At runtime we
+//! decode it, paint a small filled circle in the bottom-right corner using one
+//! of the macOS system colors (green / yellow / red), and re-encode the result
+//! as PNG. The pre-built variants are stashed in [`TrayIcons`] and stored as
+//! managed state so the `set_tray_health` Tauri command can swap icons cheaply.
+
+use image::ImageEncoder;
+
+/// macOS system green (`#34C759`).
+pub const DOT_GREEN: [u8; 4] = [52, 199, 89, 255];
+/// macOS system orange/amber (`#FF9500`).
+pub const DOT_YELLOW: [u8; 4] = [255, 149, 0, 255];
+/// macOS system red (`#FF3B30`).
+pub const DOT_RED: [u8; 4] = [255, 59, 48, 255];
+
+/// Cached PNG bytes for every tray icon variant.
+pub struct TrayIcons {
+    pub base: Vec<u8>,
+    pub healthy: Vec<u8>,
+    pub degraded: Vec<u8>,
+    pub down: Vec<u8>,
+}
+
+/// Build all four variants from the base template PNG.
+pub fn build_tray_icons(base: &[u8]) -> TrayIcons {
+    TrayIcons {
+        base: base.to_vec(),
+        healthy: tray_icon_with_dot(base, DOT_GREEN),
+        degraded: tray_icon_with_dot(base, DOT_YELLOW),
+        down: tray_icon_with_dot(base, DOT_RED),
+    }
+}
+
+/// Composite a filled circle onto the bottom-right corner of the base tray
+/// icon and return PNG-encoded bytes.
+///
+/// The dot is sized at ~17% of the icon width with a 2px edge padding so it
+/// remains visible at both 22×22 and 44×44 (`@2x`) renderings without
+/// crowding the glyph.
+pub fn tray_icon_with_dot(base: &[u8], dot_color: [u8; 4]) -> Vec<u8> {
+    let mut img = image::load_from_memory(base)
+        .expect("tray base icon must be a decodable PNG")
+        .to_rgba8();
+    recolor_glyph_to_white(&mut img);
+    let (w, h) = (img.width(), img.height());
+    let dot_radius = ((w as f32) * 0.17).round().max(2.0) as i32;
+    let cx = (w as i32) - dot_radius - 2;
+    let cy = (h as i32) - dot_radius - 2;
+
+    for y in (cy - dot_radius)..=(cy + dot_radius) {
+        for x in (cx - dot_radius)..=(cx + dot_radius) {
+            if x < 0 || y < 0 || x >= w as i32 || y >= h as i32 {
+                continue;
+            }
+            let dx = x - cx;
+            let dy = y - cy;
+            if dx * dx + dy * dy <= dot_radius * dot_radius {
+                img.put_pixel(x as u32, y as u32, image::Rgba(dot_color));
+            }
+        }
+    }
+
+    let mut buf = Vec::new();
+    image::codecs::png::PngEncoder::new(&mut buf)
+        .write_image(
+            img.as_raw(),
+            img.width(),
+            img.height(),
+            image::ExtendedColorType::Rgba8,
+        )
+        .expect("re-encode tray icon as PNG");
+    buf
+}
+
+/// Repaint every visible pixel of `img` to opaque white, preserving its alpha
+/// channel. The tray base PNG ships as a black-pixel template so macOS can
+/// auto-invert it on the menu bar; for the colored (non-template) variants we
+/// pre-invert it ourselves so the glyph stays legible on the dark menu bar.
+fn recolor_glyph_to_white(img: &mut image::RgbaImage) {
+    for pixel in img.pixels_mut() {
+        if pixel.0[3] > 0 {
+            pixel.0[0] = 255;
+            pixel.0[1] = 255;
+            pixel.0[2] = 255;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BASE: &[u8] = include_bytes!("../icons/tray-icon-template.png");
+
+    fn decode(png: &[u8]) -> image::RgbaImage {
+        image::load_from_memory(png)
+            .expect("decode composited png")
+            .to_rgba8()
+    }
+
+    #[test]
+    fn dot_center_uses_requested_color() {
+        let out = tray_icon_with_dot(BASE, DOT_GREEN);
+        let img = decode(&out);
+        let (w, h) = (img.width() as i32, img.height() as i32);
+        let r = ((w as f32) * 0.17).round().max(2.0) as i32;
+        let cx = (w - r - 2) as u32;
+        let cy = (h - r - 2) as u32;
+        let px = img.get_pixel(cx, cy).0;
+        assert_eq!(px, DOT_GREEN, "center pixel should be the dot fill color");
+    }
+
+    #[test]
+    fn variants_differ_in_color_at_dot_center() {
+        let icons = build_tray_icons(BASE);
+        let h = decode(&icons.healthy);
+        let d = decode(&icons.degraded);
+        let r = decode(&icons.down);
+        let w = h.width() as i32;
+        let height = h.height() as i32;
+        let radius = ((w as f32) * 0.17).round().max(2.0) as i32;
+        let cx = (w - radius - 2) as u32;
+        let cy = (height - radius - 2) as u32;
+        assert_eq!(h.get_pixel(cx, cy).0, DOT_GREEN);
+        assert_eq!(d.get_pixel(cx, cy).0, DOT_YELLOW);
+        assert_eq!(r.get_pixel(cx, cy).0, DOT_RED);
+        assert_eq!(icons.base, BASE);
+    }
+
+    #[test]
+    fn dot_has_no_border_ring() {
+        let out = tray_icon_with_dot(BASE, DOT_GREEN);
+        let img = decode(&out);
+        let (w, h) = (img.width() as i32, img.height() as i32);
+        let dot_radius = ((w as f32) * 0.17).round().max(2.0) as i32;
+        let cx = w - dot_radius - 2;
+        let cy = h - dot_radius - 2;
+        let edge_x = (cx + dot_radius - 1) as u32;
+        let edge_y = cy as u32;
+        let px = img.get_pixel(edge_x, edge_y).0;
+        assert_eq!(
+            px, DOT_GREEN,
+            "pixel just inside the dot boundary must be the pure fill color (no border ring)",
+        );
+    }
+
+    #[test]
+    fn pixel_outside_dot_is_untouched() {
+        let base_img = decode(BASE);
+        let out = tray_icon_with_dot(BASE, DOT_RED);
+        let img = decode(&out);
+        let p_orig = base_img.get_pixel(0, 0).0;
+        let p_new = img.get_pixel(0, 0).0;
+        assert_eq!(
+            p_orig, p_new,
+            "top-left pixel far from the dot must be unchanged"
+        );
+    }
+
+    #[test]
+    fn glyph_is_recolored_to_white_in_colored_variants() {
+        let base_img = decode(BASE);
+        let (w, h) = (base_img.width() as i32, base_img.height() as i32);
+        let dot_radius = ((w as f32) * 0.17).round().max(2.0) as i32;
+        let dot_cx = w - dot_radius - 2;
+        let dot_cy = h - dot_radius - 2;
+
+        // Find an originally-opaque glyph pixel that's well outside the dot
+        // composite area so the recolor — not the dot — is what we assert on.
+        let dot_keepout = (dot_radius + 2) as f32;
+        let (gx, gy) = (0..base_img.height())
+            .flat_map(|y| (0..base_img.width()).map(move |x| (x, y)))
+            .find(|&(x, y)| {
+                let px = base_img.get_pixel(x, y).0;
+                if px[3] == 0 {
+                    return false;
+                }
+                let dx = x as f32 - dot_cx as f32;
+                let dy = y as f32 - dot_cy as f32;
+                (dx * dx + dy * dy).sqrt() > dot_keepout
+            })
+            .expect("base icon must contain at least one opaque glyph pixel outside the dot area");
+
+        let healthy = decode(&tray_icon_with_dot(BASE, DOT_GREEN));
+        let recolored = healthy.get_pixel(gx, gy).0;
+        assert_eq!(
+            (recolored[0], recolored[1], recolored[2]),
+            (255, 255, 255),
+            "originally-opaque glyph pixel must be repainted to white",
+        );
+        assert!(
+            recolored[3] > 0,
+            "recolor must preserve the original alpha (>0) of the glyph pixel",
+        );
+
+        let dot_px = healthy.get_pixel(dot_cx as u32, dot_cy as u32).0;
+        assert_eq!(
+            dot_px, DOT_GREEN,
+            "bottom-right dot center must still be the healthy green fill",
+        );
+    }
+}

--- a/src/lib/tray-health-dispatcher.test.ts
+++ b/src/lib/tray-health-dispatcher.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createTrayHealthDispatcher } from './tray-health';
+
+// Engineering spec §8 test matrix rows #16 and #17 — dedupe behavior for the
+// `set_tray_health` IPC dispatcher consumed by +page.svelte's `$effect`.
+
+describe('createTrayHealthDispatcher', () => {
+  // #16
+  it('invokes set_tray_health exactly once on a state transition (healthy → degraded)', () => {
+    const invoke = vi.fn().mockResolvedValue(undefined);
+    const dispatcher = createTrayHealthDispatcher(invoke);
+
+    dispatcher.dispatch('healthy', null);
+    dispatcher.dispatch('degraded', '2 endpoints unhealthy');
+
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(invoke).toHaveBeenNthCalledWith(1, 'set_tray_health', {
+      state: 'healthy',
+      detail: null,
+    });
+    expect(invoke).toHaveBeenNthCalledWith(2, 'set_tray_health', {
+      state: 'degraded',
+      detail: '2 endpoints unhealthy',
+    });
+  });
+
+  // #17
+  it('does not re-invoke set_tray_health when the same (state, detail) pair is observed twice in a row', () => {
+    const invoke = vi.fn().mockResolvedValue(undefined);
+    const dispatcher = createTrayHealthDispatcher(invoke);
+
+    dispatcher.dispatch('healthy', null);
+    dispatcher.dispatch('healthy', null);
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(invoke).toHaveBeenCalledWith('set_tray_health', { state: 'healthy', detail: null });
+  });
+
+  it('re-invokes set_tray_health when toggling back to a previous state', () => {
+    const invoke = vi.fn().mockResolvedValue(undefined);
+    const dispatcher = createTrayHealthDispatcher(invoke);
+
+    dispatcher.dispatch('healthy', null);
+    dispatcher.dispatch('degraded', 'X unhealthy');
+    dispatcher.dispatch('healthy', null);
+
+    expect(invoke).toHaveBeenCalledTimes(3);
+  });
+
+  it('re-invokes set_tray_health when state is unchanged but detail changes', () => {
+    const invoke = vi.fn().mockResolvedValue(undefined);
+    const dispatcher = createTrayHealthDispatcher(invoke);
+
+    dispatcher.dispatch('degraded', 'github-mcp unhealthy');
+    dispatcher.dispatch('degraded', '2 endpoints unhealthy');
+
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(invoke).toHaveBeenNthCalledWith(2, 'set_tray_health', {
+      state: 'degraded',
+      detail: '2 endpoints unhealthy',
+    });
+  });
+
+  it('re-invokes set_tray_health when detail is unchanged but state changes', () => {
+    const invoke = vi.fn().mockResolvedValue(undefined);
+    const dispatcher = createTrayHealthDispatcher(invoke);
+
+    dispatcher.dispatch('degraded', 'Relay not reachable');
+    dispatcher.dispatch('down', 'Relay not reachable');
+
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(invoke).toHaveBeenNthCalledWith(2, 'set_tray_health', {
+      state: 'down',
+      detail: 'Relay not reachable',
+    });
+  });
+
+  it('swallows synchronous invoke errors via onError (non-Tauri environments)', () => {
+    const onError = vi.fn();
+    const invoke = vi.fn(() => {
+      throw new Error('no tauri host');
+    });
+    const dispatcher = createTrayHealthDispatcher(invoke, onError);
+
+    expect(() => dispatcher.dispatch('down', null)).not.toThrow();
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows async invoke rejections via onError', async () => {
+    const onError = vi.fn();
+    const invoke = vi.fn().mockRejectedValue(new Error('ipc failed'));
+    const dispatcher = createTrayHealthDispatcher(invoke, onError);
+
+    dispatcher.dispatch('down', null);
+    // Let the rejected promise's .catch handler run.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/tray-health.test.ts
+++ b/src/lib/tray-health.test.ts
@@ -1,0 +1,373 @@
+import { describe, expect, it } from 'vitest';
+
+import { describeTrayHealthIssue, deriveTrayHealth } from './tray-health';
+import type { Endpoint, OAuthStatus } from './types';
+
+// Engineering spec §2 + §8 — `deriveTrayHealth` derives the tray dot color
+// (healthy/degraded/down) from sidecar status, relay connectivity, endpoint
+// health, and OAuth status. These tests cover rows #1–#15 of the spec's
+// test matrix. Rows #16/#17 (state-change deduping) live with the +page.svelte
+// wire-up and are out of scope for this file.
+
+function makeEndpoint(overrides: Partial<Endpoint> = {}): Endpoint {
+  return {
+    name: 'example',
+    transport: 'stdio',
+    health: 'healthy',
+    tool_count: 0,
+    last_activity: null,
+    disabled: false,
+    ...overrides,
+  };
+}
+
+function makeOAuthStatus(overrides: Partial<OAuthStatus> = {}): OAuthStatus {
+  return {
+    status: 'authenticated',
+    has_access_token: true,
+    has_refresh_token: true,
+    expires_at: null,
+    expires_in_seconds: null,
+    last_refreshed_at: null,
+    next_refresh_at: null,
+    state: null,
+    ...overrides,
+  };
+}
+
+describe('deriveTrayHealth', () => {
+  // #1
+  it('returns healthy when all endpoints are healthy', () => {
+    const endpoints: Endpoint[] = [
+      makeEndpoint({ name: 'a' }),
+      makeEndpoint({ name: 'b' }),
+      makeEndpoint({ name: 'c' }),
+    ];
+    expect(deriveTrayHealth('running', true, endpoints, new Map())).toBe('healthy');
+  });
+
+  // #2
+  it('returns degraded when one endpoint is offline and the rest are healthy', () => {
+    const endpoints: Endpoint[] = [
+      makeEndpoint({ name: 'a' }),
+      makeEndpoint({ name: 'b', health: 'offline' }),
+      makeEndpoint({ name: 'c' }),
+    ];
+    expect(deriveTrayHealth('running', true, endpoints, new Map())).toBe('degraded');
+  });
+
+  // #3
+  it('returns degraded when an OAuth endpoint is auth_required', () => {
+    const endpoints: Endpoint[] = [
+      makeEndpoint({ name: 'github', transport: 'oauth' }),
+    ];
+    const oauthStatuses = new Map<string, OAuthStatus>([
+      ['github', makeOAuthStatus({ status: 'auth_required' })],
+    ]);
+    expect(deriveTrayHealth('running', true, endpoints, oauthStatuses)).toBe('degraded');
+  });
+
+  // #4
+  it('returns degraded when an OAuth endpoint is needs_login', () => {
+    const endpoints: Endpoint[] = [
+      makeEndpoint({ name: 'github', transport: 'oauth' }),
+    ];
+    const oauthStatuses = new Map<string, OAuthStatus>([
+      ['github', makeOAuthStatus({ status: 'needs_login' })],
+    ]);
+    expect(deriveTrayHealth('running', true, endpoints, oauthStatuses)).toBe('degraded');
+  });
+
+  // #5
+  it('returns degraded when one endpoint has a Failed lifecycle', () => {
+    const endpoints: Endpoint[] = [
+      makeEndpoint({
+        name: 'broken',
+        lifecycle: { state: 'Failed', error: { kind: 'spawn', detail: 'boom' } },
+      }),
+    ];
+    expect(deriveTrayHealth('running', true, endpoints, new Map())).toBe('degraded');
+  });
+
+  // #6
+  it('returns healthy when all endpoints are disabled (nothing enabled to be wrong)', () => {
+    const endpoints: Endpoint[] = [
+      makeEndpoint({ name: 'a', disabled: true, health: 'offline' }),
+      makeEndpoint({ name: 'b', disabled: true, health: 'error' }),
+    ];
+    expect(deriveTrayHealth('running', true, endpoints, new Map())).toBe('healthy');
+  });
+
+  // #7
+  it('returns healthy with a mix of disabled and healthy endpoints (disabled excluded)', () => {
+    const endpoints: Endpoint[] = [
+      makeEndpoint({ name: 'a', disabled: true, health: 'offline' }),
+      makeEndpoint({ name: 'b' }),
+    ];
+    expect(deriveTrayHealth('running', true, endpoints, new Map())).toBe('healthy');
+  });
+
+  // #8
+  it('returns degraded when a disabled unhealthy endpoint is mixed with an enabled unhealthy one', () => {
+    const endpoints: Endpoint[] = [
+      makeEndpoint({ name: 'a', disabled: true, health: 'healthy' }),
+      makeEndpoint({ name: 'b', health: 'error' }),
+    ];
+    expect(deriveTrayHealth('running', true, endpoints, new Map())).toBe('degraded');
+  });
+
+  // #9
+  it('returns down when sidecar status is failed (regardless of endpoints)', () => {
+    const endpoints: Endpoint[] = [makeEndpoint({ name: 'a' })];
+    expect(deriveTrayHealth('failed', true, endpoints, new Map())).toBe('down');
+  });
+
+  // #10
+  it('returns down when sidecar status is stopped', () => {
+    expect(deriveTrayHealth('stopped', true, [], new Map())).toBe('down');
+  });
+
+  // #11
+  it('returns down when relay is not connected and sidecar is not starting/unknown', () => {
+    expect(deriveTrayHealth('running', false, [], new Map())).toBe('down');
+  });
+
+  // #12
+  it('returns healthy when sidecar is starting (optimistic during startup)', () => {
+    const endpoints: Endpoint[] = [makeEndpoint({ name: 'a', health: 'error' })];
+    expect(deriveTrayHealth('starting', false, endpoints, new Map())).toBe('healthy');
+  });
+
+  // #13
+  it('returns healthy when sidecar is restarting (optimistic during restart)', () => {
+    const endpoints: Endpoint[] = [makeEndpoint({ name: 'a', health: 'error' })];
+    expect(deriveTrayHealth('restarting', true, endpoints, new Map())).toBe('healthy');
+  });
+
+  // #14
+  it('returns healthy when no endpoints are configured', () => {
+    expect(deriveTrayHealth('running', true, [], new Map())).toBe('healthy');
+  });
+
+  // #15
+  it('returns healthy when an endpoint is in starting health (initializing is expected)', () => {
+    const endpoints: Endpoint[] = [
+      makeEndpoint({ name: 'a', health: 'starting' }),
+      makeEndpoint({ name: 'b' }),
+    ];
+    expect(deriveTrayHealth('running', true, endpoints, new Map())).toBe('healthy');
+  });
+});
+
+describe('describeTrayHealthIssue', () => {
+  it('returns "Relay failed: <first line>" when sidecar failed with an error', () => {
+    const detail = describeTrayHealthIssue(
+      'failed',
+      'Address already in use\nstack trace line 1\nstack trace line 2',
+      true,
+      [],
+      new Map(),
+    );
+    expect(detail).toBe('Relay failed: Address already in use');
+  });
+
+  it('returns "Relay failed" when sidecar failed with no error message', () => {
+    expect(describeTrayHealthIssue('failed', null, true, [], new Map())).toBe('Relay failed');
+    expect(describeTrayHealthIssue('failed', '', true, [], new Map())).toBe('Relay failed');
+  });
+
+  it('returns "Relay stopped" when sidecar is stopped', () => {
+    expect(describeTrayHealthIssue('stopped', null, true, [], new Map())).toBe('Relay stopped');
+  });
+
+  it('returns "Relay not reachable" when sidecar is running but not connected', () => {
+    expect(describeTrayHealthIssue('running', null, false, [], new Map())).toBe(
+      'Relay not reachable',
+    );
+  });
+
+  it('returns null while starting / restarting / unknown even if not connected (optimistic)', () => {
+    expect(describeTrayHealthIssue('starting', null, false, [], new Map())).toBeNull();
+    expect(describeTrayHealthIssue('restarting', null, false, [], new Map())).toBeNull();
+    expect(describeTrayHealthIssue('unknown', null, false, [], new Map())).toBeNull();
+  });
+
+  it('returns "Sign in required for {name}" when exactly one OAuth endpoint needs login', () => {
+    const endpoints: Endpoint[] = [
+      makeEndpoint({ name: 'github-mcp', transport: 'oauth' }),
+      makeEndpoint({ name: 'b' }),
+    ];
+    const oauth = new Map<string, OAuthStatus>([
+      ['github-mcp', makeOAuthStatus({ status: 'needs_login' })],
+    ]);
+    expect(describeTrayHealthIssue('running', null, true, endpoints, oauth)).toBe(
+      'Sign in required for github-mcp',
+    );
+  });
+
+  it('returns "N endpoints need sign-in" when multiple OAuth endpoints need login', () => {
+    const endpoints: Endpoint[] = [
+      makeEndpoint({ name: 'github-mcp', transport: 'oauth' }),
+      makeEndpoint({ name: 'slack-mcp', transport: 'oauth' }),
+    ];
+    const oauth = new Map<string, OAuthStatus>([
+      ['github-mcp', makeOAuthStatus({ status: 'needs_login' })],
+      ['slack-mcp', makeOAuthStatus({ status: 'auth_required' })],
+    ]);
+    expect(describeTrayHealthIssue('running', null, true, endpoints, oauth)).toBe(
+      '2 endpoints need sign-in',
+    );
+  });
+
+  it('returns "{name} unhealthy" when exactly one non-OAuth endpoint is unhealthy', () => {
+    const endpoints: Endpoint[] = [
+      makeEndpoint({ name: 'pg', health: 'error' }),
+      makeEndpoint({ name: 'b' }),
+    ];
+    expect(describeTrayHealthIssue('running', null, true, endpoints, new Map())).toBe(
+      'pg unhealthy',
+    );
+  });
+
+  it('returns "N endpoints need attention" when problems are a mix of auth and health buckets', () => {
+    const endpoints: Endpoint[] = [
+      makeEndpoint({ name: 'github-mcp', transport: 'oauth' }),
+      makeEndpoint({ name: 'pg', health: 'error' }),
+    ];
+    const oauth = new Map<string, OAuthStatus>([
+      ['github-mcp', makeOAuthStatus({ status: 'needs_login' })],
+    ]);
+    expect(describeTrayHealthIssue('running', null, true, endpoints, oauth)).toBe(
+      '2 endpoints need attention',
+    );
+  });
+
+  it('returns null when everything is healthy', () => {
+    const endpoints: Endpoint[] = [
+      makeEndpoint({ name: 'a' }),
+      makeEndpoint({ name: 'b' }),
+    ];
+    expect(describeTrayHealthIssue('running', null, true, endpoints, new Map())).toBeNull();
+  });
+
+  it('excludes disabled endpoints from counts and names', () => {
+    // Two enabled OAuth endpoints with auth issues plus a disabled offline
+    // one — the disabled endpoint must not change the message.
+    const endpoints: Endpoint[] = [
+      makeEndpoint({ name: 'github-mcp', transport: 'oauth' }),
+      makeEndpoint({ name: 'slack-mcp', transport: 'oauth' }),
+      makeEndpoint({ name: 'old', disabled: true, health: 'offline' }),
+    ];
+    const oauth = new Map<string, OAuthStatus>([
+      ['github-mcp', makeOAuthStatus({ status: 'needs_login' })],
+      ['slack-mcp', makeOAuthStatus({ status: 'needs_login' })],
+    ]);
+    expect(describeTrayHealthIssue('running', null, true, endpoints, oauth)).toBe(
+      '2 endpoints need sign-in',
+    );
+
+    // And a single disabled-only unhealthy endpoint surfaces as healthy.
+    const onlyDisabled: Endpoint[] = [
+      makeEndpoint({ name: 'a', disabled: true, health: 'error' }),
+    ];
+    expect(describeTrayHealthIssue('running', null, true, onlyDisabled, new Map())).toBeNull();
+  });
+
+  it('treats an OAuth endpoint with both auth + health issues as an auth problem (auth wins)', () => {
+    // Regression test for the Todoist case: the OAuth re-login is the
+    // actionable cause and any downstream health/lifecycle failure on the
+    // same endpoint must not mask the sign-in copy.
+    const endpoints: Endpoint[] = [
+      makeEndpoint({ name: 'github-mcp', transport: 'oauth', health: 'error' }),
+    ];
+    const oauth = new Map<string, OAuthStatus>([
+      ['github-mcp', makeOAuthStatus({ status: 'needs_login' })],
+    ]);
+    expect(describeTrayHealthIssue('running', null, true, endpoints, oauth)).toBe(
+      'Sign in required for github-mcp',
+    );
+  });
+
+  it('treats an OAuth endpoint with needs_login + failed lifecycle as an auth problem (Todoist regression)', () => {
+    const endpoints: Endpoint[] = [
+      makeEndpoint({
+        name: 'todoist',
+        transport: 'oauth',
+        health: 'error',
+        lifecycle: { state: 'Failed', error: { kind: 'spawn', detail: 'auth' } },
+      }),
+    ];
+    const oauth = new Map<string, OAuthStatus>([
+      ['todoist', makeOAuthStatus({ status: 'needs_login' })],
+    ]);
+    expect(describeTrayHealthIssue('running', null, true, endpoints, oauth)).toBe(
+      'Sign in required for todoist',
+    );
+  });
+
+  it('treats an OAuth endpoint with auth_required + health error as an auth problem', () => {
+    const endpoints: Endpoint[] = [
+      makeEndpoint({ name: 'jira', transport: 'oauth', health: 'error' }),
+    ];
+    const oauth = new Map<string, OAuthStatus>([
+      ['jira', makeOAuthStatus({ status: 'auth_required' })],
+    ]);
+    expect(describeTrayHealthIssue('running', null, true, endpoints, oauth)).toBe(
+      'Sign in required for jira',
+    );
+  });
+
+  it('reports an auth-OK OAuth endpoint with failed lifecycle as "unhealthy"', () => {
+    const endpoints: Endpoint[] = [
+      makeEndpoint({
+        name: 'linear',
+        transport: 'oauth',
+        lifecycle: { state: 'Failed', error: { kind: 'spawn', detail: 'boom' } },
+      }),
+    ];
+    const oauth = new Map<string, OAuthStatus>([
+      ['linear', makeOAuthStatus({ status: 'authenticated' })],
+    ]);
+    expect(describeTrayHealthIssue('running', null, true, endpoints, oauth)).toBe(
+      'linear unhealthy',
+    );
+  });
+
+  it('returns "N endpoints need sign-in" when two OAuth endpoints both need login and both have failed lifecycle', () => {
+    const endpoints: Endpoint[] = [
+      makeEndpoint({
+        name: 'github-mcp',
+        transport: 'oauth',
+        health: 'error',
+        lifecycle: { state: 'Failed', error: { kind: 'spawn', detail: 'auth' } },
+      }),
+      makeEndpoint({
+        name: 'slack-mcp',
+        transport: 'oauth',
+        health: 'error',
+        lifecycle: { state: 'Failed', error: { kind: 'spawn', detail: 'auth' } },
+      }),
+    ];
+    const oauth = new Map<string, OAuthStatus>([
+      ['github-mcp', makeOAuthStatus({ status: 'needs_login' })],
+      ['slack-mcp', makeOAuthStatus({ status: 'needs_login' })],
+    ]);
+    expect(describeTrayHealthIssue('running', null, true, endpoints, oauth)).toBe(
+      '2 endpoints need sign-in',
+    );
+  });
+
+  it('returns "N endpoints unhealthy" when all problems are health-bucket and none are auth', () => {
+    const endpoints: Endpoint[] = [
+      makeEndpoint({ name: 'a', health: 'error' }),
+      makeEndpoint({ name: 'b', health: 'offline' }),
+      makeEndpoint({
+        name: 'c',
+        lifecycle: { state: 'Failed', error: { kind: 'spawn', detail: 'boom' } },
+      }),
+    ];
+    expect(describeTrayHealthIssue('running', null, true, endpoints, new Map())).toBe(
+      '3 endpoints unhealthy',
+    );
+  });
+});

--- a/src/lib/tray-health.ts
+++ b/src/lib/tray-health.ts
@@ -1,0 +1,179 @@
+import type { RelaySidecarStatusType } from '$lib/stores';
+import type { Endpoint, OAuthStatus } from '$lib/types';
+
+export type TrayHealthState = 'healthy' | 'degraded' | 'down';
+
+export function deriveTrayHealth(
+  sidecarStatus: RelaySidecarStatusType,
+  relayConnected: boolean,
+  endpoints: Endpoint[],
+  oauthStatuses: Map<string, OAuthStatus>,
+): TrayHealthState {
+  // Red: relay process not running or not reachable
+  if (sidecarStatus === 'failed' || sidecarStatus === 'stopped') {
+    return 'down';
+  }
+  if (!relayConnected && sidecarStatus !== 'starting' && sidecarStatus !== 'unknown') {
+    return 'down';
+  }
+
+  // During startup, don't show red — we're still connecting
+  if (sidecarStatus === 'starting' || sidecarStatus === 'unknown' || sidecarStatus === 'restarting') {
+    return 'healthy';
+  }
+
+  // Filter to only enabled endpoints
+  const enabled = endpoints.filter((ep) => !ep.disabled);
+
+  // If no endpoints configured, relay is healthy (nothing to be wrong with)
+  if (enabled.length === 0) {
+    return 'healthy';
+  }
+
+  // Check each enabled endpoint for problems
+  const hasProblems = enabled.some((ep) => {
+    // Non-healthy endpoint health status (starting is expected during init)
+    if (ep.health !== 'healthy' && ep.health !== 'starting') {
+      return true;
+    }
+
+    // Failed lifecycle
+    if (ep.lifecycle?.state === 'Failed') {
+      return true;
+    }
+
+    // OAuth endpoints: check for auth issues
+    if (ep.transport === 'oauth') {
+      const oauthStatus = oauthStatuses.get(ep.name);
+      if (oauthStatus) {
+        if (oauthStatus.status === 'auth_required' || oauthStatus.status === 'needs_login') {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  });
+
+  return hasProblems ? 'degraded' : 'healthy';
+}
+
+// Compute a short human-readable description of the current tray health
+// problem, suitable for embedding in the tray menu's status line and tooltip.
+// Returns `null` when the system is healthy (no detail to surface).
+//
+// Priority:
+//   1. Sidecar issues (failed/stopped/not reachable) take precedence over
+//      endpoint problems, since a dead relay invalidates per-endpoint state.
+//   2. Otherwise, summarize enabled-endpoint problems. OAuth auth issues get
+//      their own copy ("Sign in required for X" / "N endpoints need sign-in")
+//      because they have a clear user remediation; other health / lifecycle
+//      issues fall back to "X unhealthy" / "N endpoints unhealthy".
+//   3. Healthy → null.
+//
+// Disabled endpoints are excluded from counts and names.
+export function describeTrayHealthIssue(
+  sidecarStatus: RelaySidecarStatusType,
+  relaySidecarError: string | null,
+  relayConnected: boolean,
+  endpoints: Endpoint[],
+  oauthStatuses: Map<string, OAuthStatus>,
+): string | null {
+  // 1. Sidecar issues take priority.
+  if (sidecarStatus === 'failed') {
+    const firstLine = relaySidecarError?.split('\n')[0]?.trim();
+    return firstLine ? `Relay failed: ${firstLine}` : 'Relay failed';
+  }
+  if (sidecarStatus === 'stopped') {
+    return 'Relay stopped';
+  }
+  if (
+    !relayConnected &&
+    sidecarStatus !== 'starting' &&
+    sidecarStatus !== 'restarting' &&
+    sidecarStatus !== 'unknown'
+  ) {
+    return 'Relay not reachable';
+  }
+
+  // 2. Enabled-endpoint problems. Classify each endpoint into at most one
+  // bucket; auth wins over health on the same endpoint.
+  const enabled = endpoints.filter((ep) => !ep.disabled);
+
+  const authIssues: Endpoint[] = [];
+  const healthIssues: Endpoint[] = [];
+
+  for (const ep of enabled) {
+    if (ep.transport === 'oauth') {
+      const s = oauthStatuses.get(ep.name)?.status;
+      if (s === 'auth_required' || s === 'needs_login') {
+        authIssues.push(ep);
+        continue;
+      }
+    }
+
+    if (
+      (ep.health !== 'healthy' && ep.health !== 'starting') ||
+      ep.lifecycle?.state === 'Failed'
+    ) {
+      healthIssues.push(ep);
+    }
+  }
+
+  const total = authIssues.length + healthIssues.length;
+  if (total === 0) return null;
+
+  if (total === 1) {
+    if (authIssues.length === 1) {
+      return `Sign in required for ${authIssues[0].name}`;
+    }
+    return `${healthIssues[0].name} unhealthy`;
+  }
+
+  // 2+ problems: collapse by bucket composition.
+  if (healthIssues.length === 0) {
+    return `${authIssues.length} endpoints need sign-in`;
+  }
+  if (authIssues.length === 0) {
+    return `${healthIssues.length} endpoints unhealthy`;
+  }
+  return `${total} endpoints need attention`;
+}
+
+export type TrayHealthInvoke = (cmd: string, args?: Record<string, unknown>) => Promise<unknown>;
+
+export interface TrayHealthDispatcher {
+  dispatch(state: TrayHealthState, detail: string | null): void;
+}
+
+// Wraps the `invoke('set_tray_health', ...)` call with dedupe state so callers
+// (the +page.svelte `$effect`) can fire on every derivation without spamming
+// the backend. Dedupe key is the `(state, detail)` pair so a detail change at
+// the same state (e.g. "github-mcp unhealthy" → "2 endpoints unhealthy") still
+// reaches the backend. Errors are swallowed and forwarded to `onError`
+// (defaults to `console.debug`) so non-Tauri environments (vitest, SSR) don't
+// throw.
+export function createTrayHealthDispatcher(
+  invoke: TrayHealthInvoke,
+  onError: (err: unknown) => void = (err) => console.debug('set_tray_health failed', err),
+): TrayHealthDispatcher {
+  let lastState: TrayHealthState | null = null;
+  let lastDetail: string | null = null;
+  let primed = false;
+  return {
+    dispatch(state: TrayHealthState, detail: string | null) {
+      if (primed && state === lastState && detail === lastDetail) return;
+      lastState = state;
+      lastDetail = detail;
+      primed = true;
+      try {
+        const result = invoke('set_tray_health', { state, detail });
+        if (result && typeof (result as Promise<unknown>).catch === 'function') {
+          (result as Promise<unknown>).catch(onError);
+        }
+      } catch (err) {
+        onError(err);
+      }
+    },
+  };
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -20,6 +20,7 @@
   import { initRelayLogListener } from '$lib/logListener';
   import { applyGoToEndpoint } from '$lib/components/relay-logs-helpers';
   import { getActiveTopLevelTab, getVisibleTopLevelTabs, shouldShowRelayStartupFailure, shouldSkipEndpointPolling } from '$lib/relaySidecarUi';
+  import { deriveTrayHealth, describeTrayHealthIssue, createTrayHealthDispatcher } from '$lib/tray-health';
   import { invoke } from '@tauri-apps/api/core';
   import { get } from 'svelte/store';
 
@@ -62,6 +63,28 @@
     if (getActiveTopLevelTab($activeTopLevelTab, $relaySidecarStatus) !== $activeTopLevelTab) {
       activeTopLevelTab.set('settings');
     }
+  });
+
+  // Tray icon color follows the same store chain as the in-app status pill.
+  // Dedupe via createTrayHealthDispatcher so we only IPC to Rust on real
+  // transitions (test matrix #16/#17). Failures (e.g. non-Tauri test/SSR
+  // environments) are swallowed at debug level by the dispatcher.
+  const trayHealthDispatcher = createTrayHealthDispatcher(invoke);
+  $effect(() => {
+    const health = deriveTrayHealth(
+      $relaySidecarStatus,
+      $relayConnected,
+      $endpoints,
+      $oauthStatuses,
+    );
+    const detail = describeTrayHealthIssue(
+      $relaySidecarStatus,
+      $relaySidecarError,
+      $relayConnected,
+      $endpoints,
+      $oauthStatuses,
+    );
+    trayHealthDispatcher.dispatch(health, detail);
   });
 
   async function pollEndpoints() {


### PR DESCRIPTION
## Summary

Adds a system-tray health indicator that overlays a colored dot (green / yellow / red) on the existing Endara tray icon and updates the first tray-menu item + tooltip with a specific, actionable status line — so users can see at a glance whether the relay and all OAuth endpoints are healthy without opening the app.

| Tray state | Menu line (examples) |
|---|---|
| Healthy | `Endara — Running` |
| Sign-in needed (single) | `Endara — Sign in required for Todoist` |
| Multiple auth-blocked | `Endara — 2 endpoints need sign-in` |
| Multiple unhealthy | `Endara — 2 endpoints unhealthy` |
| Mixed | `Endara — 3 endpoints need attention` |
| Sidecar failed | `Endara — Relay failed: {first line of error}` |
| Sidecar stopped | `Endara — Relay stopped` |
| Unreachable | `Endara — Relay not reachable` |

## How it works

**Rust (`src-tauri/src/tray.rs` + `lib.rs`)**
- `tray_icon_with_dot()` programmatically composites a flat colored circle (17% of icon width, macOS system green/yellow/red, no border) onto the base PNG.
- Because the dot color needs to render *as* a color, the icon is set with `set_icon_as_template(false)` for the colored variants, and the glyph is recolored to pure white so it remains visible on the always-dark macOS menu bar.
- New Tauri command `set_tray_health(state, detail)` swaps the tray icon, updates the tooltip, and rewrites the disabled status `MenuItem` in one shot.
- Pre-decoded icon bytes for all 4 variants (`base`, `green`, `yellow`, `red`) are cached at setup as managed state.

**TypeScript (`src/lib/tray-health.ts`)**
- `deriveTrayHealth(sidecar, endpoints)` is a pure function mapping sidecar lifecycle + per-endpoint connectivity/OAuth state to `healthy | degraded | down`. OAuth `needs_login` wins over downstream lifecycle failures so an auth-blocked endpoint surfaces as "Sign in required for X" instead of "X unhealthy".
- `describeTrayHealthIssue()` generates the user-facing detail string.
- `createTrayHealthDispatcher()` deduplicates by `(state, detail)` so reactive re-runs result in a single IPC per actual transition.

**Svelte (`src/routes/+page.svelte`)**
- A `$effect` subscribes to the relay and endpoint stores, derives health, and pushes through the dispatcher on mount + every change.

## Tests

- **Rust:** 5 unit tests in `tray.rs` covering compositing, glyph whitening, dot color, and the no-border invariant.
- **TS:** full 17-row state-derivation matrix + dispatcher dedup behavior + Todoist auth-vs-lifecycle regression case.
- All checks green: `cargo fmt --check`, `cargo build`, `cargo test --lib tray::`, `cargo clippy --all-targets -- -D warnings`, `pnpm run check`, `pnpm test` (597/597).

## Manual verification

1. Run `pnpm tauri dev` from `packages/desktop`.
2. Healthy: dot is green, menu line reads `Endara — Running`.
3. Sign out of an OAuth endpoint (e.g. Todoist): dot turns yellow, menu line reads `Endara — Sign in required for Todoist`.
4. Stop the relay sidecar: dot turns red, menu line reflects the lifecycle state.

## Scope

Desktop-only. No relay-side or monorepo changes in this PR.
