### PR TITLE
fix(logs): handle quoted multi-word event fields in log parser

### DIFF
--- a/src/lib/logParser.test.ts
+++ b/src/lib/logParser.test.ts
@@ -311,3 +311,82 @@ describe('parseLogLine — in-text level extraction (hotfix)', () => {
     expect(parsed.message).toBe('some error occurred');
   });
 });
+
+describe('parseLogLine — trailing event fields (defense-in-depth)', () => {
+  // Pairs with the watcher span migration: any `info!(endpoint = %name, …)`
+  // emitted outside an `endpoint{…}` span must still surface correctly and
+  // must not leak quoted multi-word values into the message body.
+  it('keeps quoted multi-word trailing event field intact and out of the message', () => {
+    const parsed = parseLogLine(
+      'info',
+      'Relay handling request endpoint="Collins Whatsapp"',
+    );
+    expect(parsed.endpoint).toBe('Collins Whatsapp');
+    expect(parsed.message).toBe('Relay handling request');
+    expect(parsed.message).not.toContain('Words');
+    expect(parsed.message).not.toContain('endpoint=');
+  });
+
+  it('surfaces an unquoted single-word trailing event field as the endpoint', () => {
+    const parsed = parseLogLine('info', 'Relay handling request endpoint=Drive');
+    expect(parsed.endpoint).toBe('Drive');
+    expect(parsed.message).toBe('Relay handling request');
+  });
+
+  it('silently drops an empty trailing event field (endpoint=) without leaking it', () => {
+    const parsed = parseLogLine('info', 'Relay handling request endpoint=');
+    expect(parsed.endpoint).toBeUndefined();
+    expect(parsed.message).toBe('Relay handling request');
+    expect(parsed.message).not.toContain('endpoint=');
+  });
+
+  it('does not let an empty trailing endpoint= override a real span endpoint', () => {
+    const parsed = parseLogLine(
+      'info',
+      'endpoint{endpoint="github"}: handled endpoint=',
+    );
+    expect(parsed.endpoint).toBe('github');
+    expect(parsed.message).toBe('handled');
+  });
+
+  it('does not let an empty trailing endpoint= override an endpointOverride', () => {
+    const parsed = parseLogLine(
+      'info',
+      'handled endpoint=',
+      { endpointOverride: 'gmail' },
+    );
+    expect(parsed.endpoint).toBe('gmail');
+    expect(parsed.message).toBe('handled');
+  });
+
+  it('parses multiple trailing event fields mixed with the message', () => {
+    const parsed = parseLogLine(
+      'info',
+      'Relay handling request endpoint="Collins Whatsapp" transport=stdio',
+    );
+    expect(parsed.endpoint).toBe('Collins Whatsapp');
+    expect(parsed.transport).toBe('stdio');
+    expect(parsed.message).toBe('Relay handling request');
+  });
+
+  it('surfaces event-level transport and server_type when no endpoint span is present', () => {
+    const parsed = parseLogLine(
+      'info',
+      'Relay handling request endpoint=gmail transport=stdio server_type=github',
+    );
+    expect(parsed.endpoint).toBe('gmail');
+    expect(parsed.transport).toBe('stdio');
+    expect(parsed.serverType).toBe('github');
+    expect(parsed.message).toBe('Relay handling request');
+  });
+
+  it('prefers the endpoint span over a trailing event-level endpoint field', () => {
+    const parsed = parseLogLine(
+      'info',
+      'endpoint{endpoint="github"}: handled endpoint="other"',
+    );
+    expect(parsed.endpoint).toBe('github');
+    expect(parsed.message).toBe('handled');
+  });
+});
+

--- a/src/lib/logParser.ts
+++ b/src/lib/logParser.ts
@@ -34,6 +34,11 @@ const SPAN_RE = /(\w+)\{([^}]+)\}/g;
 // Capture groups: 1 = field name, 2 = full value, 3 = inside-quotes (when
 // quoted), 4 = unquoted value.
 const FIELD_RE = /(\w+)=("([^"]*)"|([^\s,}]+))/g;
+// Event-level fields appended after the message text (outside any span). Same
+// shape as FIELD_RE but the unquoted alternative is `\S*` so a trailing
+// `endpoint=` with no value still matches and gets stripped from the message
+// instead of leaking as a stray token.
+const EVENT_FIELD_RE = /(\w+)=("([^"]*)"|(\S*))/g;
 const TIMESTAMP_RE = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z?)\s+/;
 // Whole-word level token that the relay emits right after the timestamp. The
 // regex is case-sensitive because the relay always emits these upper-case;
@@ -102,18 +107,21 @@ export function parseLogLine(
   // ": " separator that preceded the message text. Collapse both.
   cleanMessage = cleanMessage.replace(/^\s+/, '').replace(/^:\s*/, '').trim();
 
-  const msgParts = cleanMessage.length > 0 ? cleanMessage.split(/\s+/) : [];
-  const messageParts: string[] = [];
-  for (const part of msgParts) {
-    const fieldMatch = part.match(/^(\w+)=(.+)$/);
-    if (fieldMatch) {
-      fields[fieldMatch[1]] = fieldMatch[2].replace(/^"|"$/g, '');
-    } else {
-      messageParts.push(part);
+  // Scan with a regex (not split-on-whitespace) so quoted multi-word values
+  // such as `endpoint="Two Words"` stay intact instead of leaking the trailing
+  // word into the message. Empty values (`endpoint=`) are removed from the
+  // message but not stored, so they cannot overwrite a real endpoint from the
+  // span or from `endpointOverride`.
+  for (const fm of cleanMessage.matchAll(EVENT_FIELD_RE)) {
+    const value = fm[3] !== undefined ? fm[3] : fm[4];
+    if (value !== '') {
+      fields[fm[1]] = value;
     }
   }
-
-  const cleanedMessage = messageParts.join(' ').trim();
+  const cleanedMessage = cleanMessage
+    .replace(EVENT_FIELD_RE, '')
+    .replace(/\s+/g, ' ')
+    .trim();
   const tool = fields.tool;
   const status = fields.status;
   const durationMs = fields.duration_ms !== undefined ? parseInt(fields.duration_ms, 10) : undefined;
@@ -124,7 +132,10 @@ export function parseLogLine(
         cleanedMessage.includes('Tool call failed'))) ||
     (status !== undefined && durationMs !== undefined && !Number.isNaN(durationMs));
 
-  const parsedEndpoint = spans.endpoint?.endpoint;
+  // Fall back to event-level fields when no `endpoint` span is present, so
+  // `info!(endpoint = %name, …)` calls outside a span still render correctly.
+  // Empty values were skipped above, so `??` won't promote `""` over undefined.
+  const parsedEndpoint = spans.endpoint?.endpoint ?? fields.endpoint;
   const endpoint =
     options?.endpointOverride !== undefined && options.endpointOverride !== null
       ? options.endpointOverride
@@ -143,8 +154,8 @@ export function parseLogLine(
     timestamp,
     level: normalizeLevel(extractedLevel ?? level),
     endpoint,
-    transport: spans.endpoint?.transport,
-    serverType: spans.endpoint?.server_type,
+    transport: spans.endpoint?.transport ?? fields.transport,
+    serverType: spans.endpoint?.server_type ?? fields.server_type,
     method: spans.request?.method,
     requestId: spans.request?.id,
     tool,


### PR DESCRIPTION
## Problem
The Logs view's front-end parser splits trailing event fields per whitespace token, so quoted multi-word values (`endpoint="Collins Whatsapp"`) leak the second word back into the visible message. It also only reads `endpoint` from a span context, so single-word event-field values like `endpoint=Drive` get captured in `fields.endpoint` and silently dropped — the endpoint column then renders `──` instead of `Drive`.

## Fix
- New `EVENT_FIELD_RE` regex scans `cleanMessage` for `key="value with spaces"` or `key=value` as whole tokens, removing each match from the message and storing the unquoted value in `fields`.
- Empty-string values (`endpoint=`) are stripped from the message text but never written into `fields`, so they can't poison the column.
- `endpoint` / `transport` / `serverType` derivation now falls back to `fields.X` when no `endpoint{}` span is present.
- `endpointOverride` precedence preserved.

## Context
Pairs with a companion fix on `endara-ai/endara-relay` that migrates watcher reload logs to the canonical `endpoint` span. This PR is the defense-in-depth complement: the relay fix is the primary path; this PR keeps the Logs view honest for the four `create_adapter` call sites that still emit `endpoint` as an event field, and for any future regressions.

## Verification
- `pnpm test -- logParser` ✅ all logParser cases (including 7 new ones) pass
- `pnpm test` ✅ 762/762

## Test cases added
1. Trailing `endpoint="Two Words"` event-field on a relay-level line — endpoint surfaces, no fragment leaks.
2. Trailing unquoted `endpoint=Drive` event-field — endpoint surfaces, message is clean.
3. Trailing empty `endpoint=` event-field — endpoint stays undefined, no stray token in message.
4. Multiple trailing event fields (`endpoint="Collins Whatsapp" transport=stdio`) — all parsed correctly.
5–7. Span precedence over fields, endpointOverride precedence over both, no overwrite of real span values with empty fields.
