### PR TITLE
feat: add Atlassian to OAuth catalog

### DIFF
--- a/src/lib/data/oauth-catalog.test.ts
+++ b/src/lib/data/oauth-catalog.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { oauthCatalog } from './oauth-catalog';
 
 describe('oauthCatalog', () => {
-  it('should have exactly 9 entries', () => {
-    expect(oauthCatalog).toHaveLength(9);
+  it('should have exactly 10 entries', () => {
+    expect(oauthCatalog).toHaveLength(10);
   });
 
   it('should include the Gmail entry with curated scopes', () => {
@@ -110,6 +110,23 @@ describe('oauthCatalog', () => {
     expect(craft!.url).toBe('https://mcp.craft.do/my/mcp');
     expect(craft!.supportsDiscovery).toBe(true);
     expect(craft!.supportsDcr).toBe(true);
+  });
+
+  it('should have the correct Atlassian entry', () => {
+    const atlassian = oauthCatalog.find((entry) => entry.id === 'atlassian');
+    expect(atlassian).toBeDefined();
+    expect(atlassian!.url).toBe('https://mcp.atlassian.com/v1/mcp/authv2');
+    expect(atlassian!.supportsDiscovery).toBe(true);
+    expect(atlassian!.supportsDcr).toBe(true);
+    expect(atlassian!.defaultScopes).toEqual([
+      'offline_access',
+      'read:jira-work',
+      'write:jira-work',
+      'read:page:confluence',
+      'write:page:confluence',
+      'search:confluence',
+      'read:space:confluence',
+    ]);
   });
 });
 

--- a/src/lib/data/oauth-catalog.ts
+++ b/src/lib/data/oauth-catalog.ts
@@ -31,6 +31,27 @@ export interface OAuthCatalogEntry {
 
 export const oauthCatalog: OAuthCatalogEntry[] = [
   {
+    id: 'atlassian',
+    name: 'Atlassian',
+    description: 'Jira, Confluence, and Compass',
+    icon: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"><path d="M6.5 11.5L3 17h6l1.5-2.5M13.5 8.5L17 3h-6L3 17M13.5 8.5l3.5 8.5h-6l-1.5-3"/></svg>',
+    category: 'productivity',
+    url: 'https://mcp.atlassian.com/v1/mcp/authv2',
+    defaultScopes: [
+      'offline_access',
+      'read:jira-work',
+      'write:jira-work',
+      'read:page:confluence',
+      'write:page:confluence',
+      'search:confluence',
+      'read:space:confluence',
+    ],
+    supportsDiscovery: true,
+    supportsDcr: true,
+    notes:
+      'Jira, Confluence, and Compass via Atlassian Remote MCP — your org admin must have Rovo + Remote MCP enabled',
+  },
+  {
     id: 'linear',
     name: 'Linear',
     description: 'Issue tracking and project management',


### PR DESCRIPTION
## What

Adds a single new entry to `src/lib/data/oauth-catalog.ts` for **Atlassian** (Jira / Confluence / Compass).

## URL

`https://mcp.atlassian.com/v1/mcp/authv2` — the **only** Atlassian MCP endpoint that serves RFC 9728 OAuth Protected Resource Metadata. Verified by curl probe against `/.well-known/oauth-protected-resource/v1/mcp/authv2` (200). The other published endpoint `/v1/mcp` returns 404 on the same well-known path and cannot be auto-discovered.

## Capabilities

- `supportsDiscovery: true` — RFC 9728 protected-resource metadata works at the URL above.
- `supportsDcr: true` — Atlassian's authorization server advertises and accepts RFC 7591 Dynamic Client Registration.

## Default scopes

```
offline_access
read:jira-work
write:jira-work
read:page:confluence
write:page:confluence
search:confluence
read:space:confluence
```

Covers the common Jira + Confluence read/write surface plus refresh-token support. **Compass scopes are intentionally omitted from the defaults** — most users don't have Compass, and advanced users who do can add Compass scopes via the raw-scope edit field (DCR supports it).

## One entry, not three

Atlassian serves Jira, Confluence, and Compass through the same MCP endpoint with a single OAuth flow — so this is one catalog entry, not three.

## Tests

- Bumped `toHaveLength(9)` → `toHaveLength(10)` in the existing catalog count assertion.
- Added a new `it()` block asserting the Atlassian entry's `url`, `supportsDiscovery`, `supportsDcr`, and the exact `defaultScopes` array.

## Gates

- `pnpm test -- oauth-catalog` → **755 passed | 24 skipped**
- `pnpm check` → **0 errors**

## Companion

Pairs with a PR on `endara-ai/endara-relay` that captures and replays the `Mcp-Session-Id` header. Without that fix, Streamable HTTP servers like Atlassian Jira return 400 on the second request. That relay fix ships in its own PR.
