### PR TITLE
fix(oauth-catalog): clear Atlassian default scopes

### DIFF
--- a/src/lib/data/oauth-catalog.test.ts
+++ b/src/lib/data/oauth-catalog.test.ts
@@ -118,15 +118,7 @@ describe('oauthCatalog', () => {
     expect(atlassian!.url).toBe('https://mcp.atlassian.com/v1/mcp/authv2');
     expect(atlassian!.supportsDiscovery).toBe(true);
     expect(atlassian!.supportsDcr).toBe(true);
-    expect(atlassian!.defaultScopes).toEqual([
-      'offline_access',
-      'read:jira-work',
-      'write:jira-work',
-      'read:page:confluence',
-      'write:page:confluence',
-      'search:confluence',
-      'read:space:confluence',
-    ]);
+    expect(atlassian!.defaultScopes).toEqual([]);
   });
 });
 

--- a/src/lib/data/oauth-catalog.ts
+++ b/src/lib/data/oauth-catalog.ts
@@ -37,15 +37,12 @@ export const oauthCatalog: OAuthCatalogEntry[] = [
     icon: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"><path d="M6.5 11.5L3 17h6l1.5-2.5M13.5 8.5L17 3h-6L3 17M13.5 8.5l3.5 8.5h-6l-1.5-3"/></svg>',
     category: 'productivity',
     url: 'https://mcp.atlassian.com/v1/mcp/authv2',
-    defaultScopes: [
-      'offline_access',
-      'read:jira-work',
-      'write:jira-work',
-      'read:page:confluence',
-      'write:page:confluence',
-      'search:confluence',
-      'read:space:confluence',
-    ],
+    // Atlassian's MCP server determines product access server-side from the
+    // user's account and silently strips any `scope` field on DCR. Sending
+    // explicit scopes on `/authorize` triggers their post-consent
+    // `invalid_request` / "Incorrect request parameters" error, so we leave
+    // this empty and let the server infer the granted scopes.
+    defaultScopes: [],
     supportsDiscovery: true,
     supportsDcr: true,
     notes:


### PR DESCRIPTION
## Symptom (shipped in v0.1.8-rc.7)

Connecting Atlassian via the OAuth catalog completed the user-facing Atlassian consent screen but then failed at the post-consent `/authorize` redirect with an `invalid_request` / "Incorrect request parameters" error from Atlassian. The OAuth flow never produced a usable token.

## Root cause

Atlassian's MCP server determines product access server-side from the authenticated user's account. The Dynamic Client Registration (DCR) endpoint silently strips any `scope` field, and the `/authorize` endpoint rejects requests that carry an explicit `scope` parameter. rc.7's catalog entry shipped seven hard-coded scopes (`offline_access`, `read:jira-work`, `write:jira-work`, `read:page:confluence`, `write:page:confluence`, `search:confluence`, `read:space:confluence`), which triggered the rejection.

## Fix

Leave `defaultScopes` empty for the Atlassian entry so the server can infer the granted scopes. An inline comment on the field captures the reasoning for future maintainers so it isn't re-populated by a well-meaning edit.

## Test update

`src/lib/data/oauth-catalog.test.ts` previously asserted the seven-element array; updated to assert `[]`. Other Atlassian assertions (`url`, `supportsDiscovery`, `supportsDcr`) are unchanged.

## Release

Ships in **v0.1.8-rc.8** paired with a matching `endara-ai/endara-relay` tag on the same version (no relay code change — the desktop installer bundles the relay sidecar, so a matching desktop release is required to push the fix to end users).
