### PR TITLE
feat(logs,overlay): MCP caller identity + structured JSON logs + filter UX

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "core:window:allow-start-dragging",
     "opener:default",
     {
       "identifier": "shell:allow-execute",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -256,68 +256,70 @@ fn strip_ansi(s: &str) -> String {
     result
 }
 
-/// Extract the endpoint name from the relay's tracing span.
+/// Extract the endpoint name from the relay's structured JSON log line.
 ///
-/// The relay sidecar is launched with `--log-format text` (see
-/// [`build_sidecar_args`]) so tracing-subscriber emits its "Full" formatter
-/// shape, with span fields inline:
+/// The relay sidecar is launched with `--log-format json` (see
+/// [`build_sidecar_args`]) so tracing-subscriber emits one JSON object per
+/// line. Span context is carried in the top-level `spans` array, where each
+/// element is a span object with a `name` field plus that span's fields:
 ///
 /// ```text
-/// 2026-05-22T15:10:43Z  INFO endpoint{endpoint="github" transport="stdio"}: <target>: <msg>
+/// {"level":"INFO","fields":{…},"spans":[{"endpoint":"github","transport":"stdio","name":"endpoint"}]}
 /// ```
 ///
-/// Returns `Some("github")` when the `endpoint{...}` span is present and
-/// `None` for relay-level events that have no span context (e.g. "Relay
-/// listening on …"). A leading and trailing pair of double-quotes is stripped
-/// from the captured token so callers get the bare endpoint name — the Full
-/// formatter quotes string-typed field values, while older test fixtures and
-/// the compact format used unquoted values, so the parser accepts both.
-///
-/// Lines emitted in the relay's `compact` format (`INFO endpoint: <target>:
-/// <msg> endpoint="NAME" transport="…"`) do NOT match because the span fields
-/// trail the message instead of appearing inline — this is why the sidecar
-/// must run with `--log-format text`.
+/// Returns `Some("github")` when a span with `name == "endpoint"` is present
+/// and carries a non-empty `endpoint` field. Returns `None` for non-JSON lines
+/// (raw adapter stdout/stderr) and for relay-level JSON events that have no
+/// `endpoint` span (e.g. "Starting endara-relay").
 fn parse_endpoint_from_span(line: &str) -> Option<String> {
-    use std::sync::OnceLock;
-    static RE: OnceLock<regex::Regex> = OnceLock::new();
-    let re = RE.get_or_init(|| {
-        regex::Regex::new(r"endpoint\{endpoint=([^ }]+)")
-            .expect("parse_endpoint_from_span regex is valid")
-    });
-    re.captures(line)
-        .and_then(|c| c.get(1))
-        .map(|m| strip_quote_pair(m.as_str()).to_string())
-        .filter(|s| !s.is_empty())
+    let value: serde_json::Value = serde_json::from_str(line).ok()?;
+    let spans = value.get("spans")?.as_array()?;
+    for span in spans {
+        if span.get("name").and_then(|n| n.as_str()) == Some("endpoint") {
+            if let Some(endpoint) = span.get("endpoint").and_then(|e| e.as_str()) {
+                if !endpoint.is_empty() {
+                    return Some(endpoint.to_string());
+                }
+            }
+        }
+    }
+    None
 }
 
-/// Strip exactly one leading and one trailing `"` from `s` when both are
-/// present. Returns the input unchanged if the value is not double-quoted on
-/// both sides — this avoids over-eager trimming of values that legitimately
-/// begin or end with a quote character.
-fn strip_quote_pair(s: &str) -> &str {
-    if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
-        &s[1..s.len() - 1]
-    } else {
-        s
+/// Map an UPPERCASE tracing level token to its lowercased static string,
+/// returning `None` for any token that is not one of the five known levels.
+fn level_token_to_static(token: &str) -> Option<&'static str> {
+    match token {
+        "ERROR" => Some("error"),
+        "WARN" => Some("warn"),
+        "INFO" => Some("info"),
+        "DEBUG" => Some("debug"),
+        "TRACE" => Some("trace"),
+        _ => None,
     }
 }
 
-/// Extract the tracing level token from a relay compact-format log line.
+/// Extract the log level from a relay log line.
 ///
-/// The relay's stdout/stderr emits lines whose level token (`ERROR` / `WARN` /
-/// `INFO` / `DEBUG` / `TRACE`) appears as a whole word right after the ISO
-/// timestamp prefix, with one or two spaces of padding (compact format
-/// right-aligns the level). The regex anchors near the start of the line so it
-/// will not return `Some` just because the message body happens to contain the
-/// English word "error".
+/// JSON-format lines (the relay sidecar runs with `--log-format json`) carry an
+/// UPPERCASE top-level `level` field, which is mapped to the lowercased static
+/// level string. For raw non-JSON stdout/stderr lines emitted by adapters
+/// without tracing context (e.g. npm warnings), falls back to matching a
+/// whole-word level token right after the leading timestamp prefix. The regex
+/// anchors near the start of the line so it will not return `Some` just because
+/// the message body happens to contain the English word "error".
 ///
 /// Returns the lowercased static level string (`"error"` / `"warn"` / `"info"`
-/// / `"debug"` / `"trace"`) when the token is present, or `None` for raw
-/// stdout/stderr lines emitted by adapters without tracing context. Callers
-/// (the stdout/stderr capture branches) supply their own fallback when the
-/// helper returns `None`.
+/// / `"debug"` / `"trace"`) when a level is found, or `None` for raw
+/// stdout/stderr lines with no recognizable level. Callers (the stdout/stderr
+/// capture branches) supply their own fallback when the helper returns `None`.
 fn parse_level_from_line(line: &str) -> Option<&'static str> {
     use std::sync::OnceLock;
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(line) {
+        if let Some(level) = value.get("level").and_then(|l| l.as_str()) {
+            return level_token_to_static(level);
+        }
+    }
     static RE: OnceLock<regex::Regex> = OnceLock::new();
     let re = RE.get_or_init(|| {
         // Match a whole-word level token after the ISO timestamp prefix. The
@@ -328,14 +330,7 @@ fn parse_level_from_line(line: &str) -> Option<&'static str> {
     });
     re.captures(line)
         .and_then(|c| c.get(1))
-        .map(|m| match m.as_str() {
-            "ERROR" => "error",
-            "WARN" => "warn",
-            "INFO" => "info",
-            "DEBUG" => "debug",
-            "TRACE" => "trace",
-            _ => unreachable!("regex alternation restricts matches to the five level tokens"),
-        })
+        .and_then(|m| level_token_to_static(m.as_str()))
 }
 
 /// Return the path to config.toml in the appropriate data directory
@@ -350,12 +345,12 @@ fn config_path() -> Result<std::path::PathBuf, String> {
 /// perform the first-run copy from production). In production we pass `--config`
 /// directly. Extracted as a pure helper so it is trivially unit-testable.
 ///
-/// We also force `--log-format text` (tracing-subscriber's "Full" formatter)
-/// so span fields appear inline as `endpoint{endpoint="NAME" ...}:` instead of
-/// the relay's CLI default `compact` shape, which trails the span fields at
-/// the end of the line. Both [`parse_endpoint_from_span`] and the front-end
-/// `SPAN_RE` parser are written against the inline shape — without this pin
-/// every relay-log event would report a `null` endpoint and the Logs view's
+/// We also force `--log-format json` (tracing-subscriber's `.json()` formatter)
+/// so each line is one JSON object with span fields carried in a structured
+/// `spans` array instead of the relay's CLI default `compact` shape, which
+/// trails the span fields at the end of the line. Both [`parse_endpoint_from_span`]
+/// and the front-end parser read the JSON shape — without this pin every
+/// relay-log event would report a `null` endpoint and the Logs view's
 /// "Endpoint" column would render `---` for every row.
 fn build_sidecar_args<'a>(
     dev: bool,
@@ -371,7 +366,7 @@ fn build_sidecar_args<'a>(
             "--port",
             port,
             "--log-format",
-            "text",
+            "json",
         ]
     } else {
         vec![
@@ -381,7 +376,7 @@ fn build_sidecar_args<'a>(
             "--port",
             port,
             "--log-format",
-            "text",
+            "json",
         ]
     }
 }
@@ -508,9 +503,10 @@ pub struct RelayStatusInfo {
 pub struct RelayLogPayload {
     pub level: String,
     pub message: String,
-    /// Endpoint name extracted from the compact-format tracing span
-    /// (`endpoint{endpoint=NAME ...}`), or `None` for relay-level events with
-    /// no span context. Populated by [`parse_endpoint_from_span`] during
+    /// Endpoint name extracted from the JSON-format tracing span (the object in
+    /// the line's `spans` array whose `name == "endpoint"`, read from its
+    /// `endpoint` field), or `None` for relay-level events with no such span.
+    /// Populated by [`parse_endpoint_from_span`] during
     /// stdout/stderr capture so downstream consumers (live `relay-log` events
     /// and the buffered-logs fetch) see the same authoritative value.
     /// Serialized as JSON `null` (not omitted) when absent so the desktop
@@ -2933,12 +2929,12 @@ mod dev_mode_tests {
 
     #[test]
     fn build_sidecar_args_dev_vs_prod() {
-        // Both branches must end with `--log-format text` so the relay's
-        // tracing layer emits the inline span shape the desktop parsers
-        // (`parse_endpoint_from_span` + the front-end `SPAN_RE`) expect.
-        // Without it the relay's compact-format default would hide span
-        // fields at the end of the line and the Logs view's Endpoint
-        // column would render `---` for every row.
+        // Both branches must end with `--log-format json` so the relay's
+        // tracing layer emits one structured JSON object per line, which the
+        // desktop parsers (`parse_endpoint_from_span` + the front-end JSON
+        // parser) read. Without it the relay's compact-format default would
+        // trail span fields at the end of the line and the Logs view's
+        // Endpoint column would render `---` for every row.
         let dev = build_sidecar_args(true, "/tmp/dev", "/tmp/dev/config.toml", "9500");
         assert_eq!(
             dev,
@@ -2949,7 +2945,7 @@ mod dev_mode_tests {
                 "--port",
                 "9500",
                 "--log-format",
-                "text",
+                "json",
             ]
         );
 
@@ -2963,7 +2959,7 @@ mod dev_mode_tests {
                 "--port",
                 "9400",
                 "--log-format",
-                "text",
+                "json",
             ]
         );
     }
@@ -3614,147 +3610,139 @@ mod toon_output_tests {
 #[cfg(test)]
 mod parse_endpoint_from_span_tests {
     //! Coverage for [`parse_endpoint_from_span`] — the helper that lifts the
-    //! endpoint name out of the relay's Full-format tracing span so each
+    //! endpoint name out of the relay's structured JSON log line so each
     //! `relay-log` Tauri event carries an authoritative `endpoint` field.
     //!
-    //! The sidecar is pinned to `--log-format text` ([`build_sidecar_args`]),
-    //! which produces tracing-subscriber's Full-formatter shape with QUOTED
-    //! span field values: `endpoint{endpoint="github" transport="stdio"}`.
-    //! Fixtures here use that real wire shape so a future regression in the
-    //! quote-stripping path would fail loudly. One backward-compatible
-    //! unquoted fixture is retained, and a negative compact-format fixture
-    //! documents why the sidecar must run with `--log-format text`.
+    //! The sidecar is pinned to `--log-format json` ([`build_sidecar_args`]),
+    //! which produces tracing-subscriber's `.json()` shape: one JSON object per
+    //! line, with span context in a top-level `spans` array. The positive
+    //! fixtures below are REAL lines captured from `endara-relay start
+    //! --log-format json` (verbatim, raw string literals), so a future
+    //! regression in the JSON span lookup would fail loudly. Negative fixtures
+    //! confirm that a flat `fields.endpoint` (no span) and a non-JSON raw line
+    //! both yield `None`.
 
     use super::*;
 
     #[test]
     fn endpoint_present_in_span_returns_some() {
-        // Real Full-format wire shape — tracing-subscriber quotes the field.
-        let line = "2026-05-20T10:00:00.000Z  INFO endpoint{endpoint=\"github\" transport=\"stdio\"}: Tool call completed";
+        // Real captured JSON line (stdio adapter, single endpoint span).
+        let line = r#"{"timestamp":"2026-06-09T15:20:36.427384Z","level":"INFO","fields":{"message":"MCP server reported serverInfo.name","raw_name":"gmail","sanitized":"gmail","effective":"Some(\"gmail\")"},"target":"endara_relay::adapter::stdio","span":{"endpoint":"Gmail","transport":"stdio","name":"endpoint"},"spans":[{"endpoint":"Gmail","transport":"stdio","name":"endpoint"}]}"#;
         assert_eq!(
             parse_endpoint_from_span(line),
-            Some("github".to_string()),
-            "endpoint name should be extracted from endpoint{{endpoint=\"NAME\" ...}} span"
+            Some("Gmail".to_string()),
+            "endpoint name should be extracted from the spans[] entry named \"endpoint\""
         );
     }
 
     #[test]
-    fn no_span_returns_none() {
-        // Relay-level event with no endpoint span.
-        let line = "2026-05-20T10:00:00.000Z  INFO Relay listening on 127.0.0.1:47107";
+    fn endpoint_span_with_extra_fields_still_extracts_endpoint() {
+        // Real captured JSON line (oauth adapter) — the endpoint span carries
+        // additional fields (server_type, transport) which must be ignored.
+        let line = r#"{"timestamp":"2026-06-09T15:20:34.910906Z","level":"INFO","fields":{"message":"OAuth state transition","from":"NeedsLogin","to":"Authenticated","oauth_state":"Authenticated","reason":"tokens applied, inner adapter ready"},"target":"endara_relay::adapter::oauth","span":{"endpoint":"Linear","server_type":"linear","transport":"oauth","name":"endpoint"},"spans":[{"endpoint":"Linear","server_type":"linear","transport":"oauth","name":"endpoint"}]}"#;
+        assert_eq!(parse_endpoint_from_span(line), Some("Linear".to_string()),);
+    }
+
+    #[test]
+    fn relay_level_line_with_no_spans_returns_none() {
+        // Real captured JSON line — a relay-level event has no `spans` array.
+        let line = r#"{"timestamp":"2026-06-09T15:20:34.324891Z","level":"INFO","fields":{"message":"Starting endara-relay","config":"/Users/clement/.endara-dev/config.toml","data_dir":"/Users/clement/.endara-dev"},"target":"endara_relay"}"#;
         assert_eq!(
             parse_endpoint_from_span(line),
             None,
-            "lines without an endpoint{{...}} span must yield None"
+            "JSON lines without a spans[] endpoint entry must yield None"
         );
     }
 
     #[test]
-    fn nested_request_and_endpoint_spans_still_extract_endpoint() {
-        // Full format with multiple span scopes (request{...} endpoint{...}).
-        let line = "2026-05-20T10:00:00.000Z  INFO request{method=\"tools/call\" id=42} endpoint{endpoint=\"gmail\" transport=\"stdio\"}: handled";
-        assert_eq!(parse_endpoint_from_span(line), Some("gmail".to_string()),);
-    }
-
-    #[test]
-    fn quoted_endpoint_name_is_unquoted() {
-        // A name with a hyphen — the surrounding pair of double-quotes from
-        // the Full formatter must be stripped to yield the bare key.
-        let line = "endpoint{endpoint=\"slack-prod\" transport=\"http\"}: connected";
-        assert_eq!(
-            parse_endpoint_from_span(line),
-            Some("slack-prod".to_string()),
-        );
-    }
-
-    #[test]
-    fn unquoted_endpoint_name_still_parses_for_backward_compat() {
-        // Older relay builds (and the spec §5 fixtures predating PR #67's
-        // log-format flag) emitted bare unquoted values. Keep parsing them so
-        // a stale buffered log line from a previous run still surfaces an
-        // endpoint name.
-        let line = "endpoint{endpoint=postgres transport=stdio}: ready";
-        assert_eq!(parse_endpoint_from_span(line), Some("postgres".to_string()),);
+    fn flat_fields_endpoint_without_span_returns_none() {
+        // Real captured JSON line — `fields.endpoint` is present but there is
+        // NO endpoint span, so the helper (which only reads the spans array)
+        // must return None rather than scraping the flat field.
+        let line = r#"{"timestamp":"2026-06-09T15:20:34.344797Z","level":"WARN","fields":{"message":"Using legacy `client_secret` from config.toml; re-provision via POST /api/endpoints/{name}/credentials to remove the secret from TOML","endpoint":"Todoist"},"target":"endara_relay::watcher"}"#;
+        assert_eq!(parse_endpoint_from_span(line), None);
     }
 
     #[test]
     fn empty_endpoint_field_returns_none() {
-        // Defensive: a malformed `endpoint{endpoint=}` should not produce an
-        // empty-string endpoint that the front-end might display as a row.
-        let line = "endpoint{endpoint= transport=\"stdio\"}: weird";
+        // Defensive: an endpoint span whose `endpoint` value is empty must not
+        // produce an empty-string endpoint the front-end could render as a row.
+        let line = r#"{"level":"INFO","fields":{"message":"x"},"spans":[{"endpoint":"","name":"endpoint"}]}"#;
         assert_eq!(parse_endpoint_from_span(line), None);
     }
 
     #[test]
-    fn empty_quoted_endpoint_field_returns_none() {
-        // Same defense for the quoted shape — `endpoint=""` strips to "" and
-        // must be filtered out so the front-end never renders a blank row.
-        let line = "endpoint{endpoint=\"\" transport=\"stdio\"}: weird";
+    fn endpoint_span_missing_endpoint_field_returns_none() {
+        // Defensive: a span named "endpoint" with no `endpoint` key yields None.
+        let line = r#"{"level":"INFO","fields":{"message":"x"},"spans":[{"transport":"stdio","name":"endpoint"}]}"#;
         assert_eq!(parse_endpoint_from_span(line), None);
     }
 
     #[test]
-    fn endpoint_at_end_of_span_closing_brace() {
-        // Quoted endpoint field with no trailing space — terminator is `}`.
-        let line = "endpoint{endpoint=\"postgres\"}: ready";
-        assert_eq!(parse_endpoint_from_span(line), Some("postgres".to_string()),);
-    }
-
-    #[test]
-    fn compact_format_line_returns_none() {
-        // Documents why the sidecar must run with `--log-format text`: the
-        // relay's CLI default (`compact`) emits span fields at the END of
-        // the line, not inline. The parser intentionally returns `None` for
-        // this shape so future maintainers see the dependency.
-        let line = "2026-05-22T15:10:11Z  INFO endpoint: endara_relay::adapter::http: MCP server reported serverInfo.name endpoint=\"github\" transport=\"stdio\"";
+    fn non_json_raw_line_returns_none() {
+        // Raw adapter stdout (e.g. an npm warning) is not JSON — return None.
+        let line = "npm warn deprecated some-package@1.0.0: no longer maintained";
         assert_eq!(
             parse_endpoint_from_span(line),
             None,
-            "compact-format lines have trailing span fields and must not match"
+            "non-JSON raw lines have no spans array and must yield None"
         );
     }
 }
 
 #[cfg(test)]
 mod parse_level_from_line_tests {
-    //! Coverage for [`parse_level_from_line`] — the helper that lifts the
-    //! tracing level token (ERROR/WARN/INFO/DEBUG/TRACE) out of the relay's
-    //! compact-format log line. Drives the level pill in both the top-level
-    //! Logs view and the per-endpoint LogsTab so DEBUG / WARN / TRACE lines
-    //! no longer fall through to the hardcoded `"info"` default.
+    //! Coverage for [`parse_level_from_line`] — the helper that derives the log
+    //! level. For JSON-format lines (the sidecar runs with `--log-format json`)
+    //! it reads the UPPERCASE top-level `level` field and lowercases it; for raw
+    //! non-JSON stdout/stderr lines it falls back to a whole-word level token
+    //! after a timestamp prefix. Drives the level pill in both the top-level
+    //! Logs view and the per-endpoint LogsTab so DEBUG / WARN / TRACE lines no
+    //! longer fall through to the hardcoded `"info"` default.
 
     use super::*;
 
     #[test]
-    fn debug_line_returns_debug() {
-        let line = "2026-05-20T17:54:47.123Z DEBUG endara_relay::registry: Registering adapter";
-        assert_eq!(parse_level_from_line(line), Some("debug"));
-    }
-
-    #[test]
-    fn info_line_with_two_space_padding_returns_info() {
-        // Compact format right-aligns the level — INFO and WARN get an extra
-        // leading space so columns line up with ERROR / DEBUG / TRACE.
-        let line = "2026-05-20T17:54:47.123Z  INFO endpoint{endpoint=foo}: connected";
+    fn json_info_line_returns_info() {
+        // Real captured JSON line.
+        let line = r#"{"timestamp":"2026-06-09T15:20:34.324891Z","level":"INFO","fields":{"message":"Starting endara-relay"},"target":"endara_relay"}"#;
         assert_eq!(parse_level_from_line(line), Some("info"));
     }
 
     #[test]
-    fn warn_line_returns_warn() {
-        let line = "2026-05-20T17:54:47.123Z  WARN endpoint{endpoint=slack}: reconnecting";
+    fn json_warn_line_returns_warn() {
+        // Real captured JSON line.
+        let line = r#"{"timestamp":"2026-06-09T15:20:34.344797Z","level":"WARN","fields":{"message":"Using legacy `client_secret` from config.toml","endpoint":"Todoist"},"target":"endara_relay::watcher"}"#;
         assert_eq!(parse_level_from_line(line), Some("warn"));
     }
 
     #[test]
-    fn error_line_returns_error() {
-        let line = "2026-05-20T17:54:47.123Z ERROR endpoint{endpoint=postgres}: server exited";
+    fn json_debug_line_returns_debug() {
+        // Real captured JSON line.
+        let line = r#"{"timestamp":"2026-06-09T15:20:34.359173Z","level":"DEBUG","fields":{"message":"Registering adapter","endpoint":"Todoist","tool_prefix":"Some(\"todoist\")"},"target":"endara_relay::registry"}"#;
+        assert_eq!(parse_level_from_line(line), Some("debug"));
+    }
+
+    #[test]
+    fn json_error_line_returns_error() {
+        // Same `.json()` shape with an ERROR level.
+        let line = r#"{"timestamp":"2026-06-09T15:20:34.000000Z","level":"ERROR","fields":{"message":"server exited"},"target":"endara_relay::adapter::stdio"}"#;
         assert_eq!(parse_level_from_line(line), Some("error"));
     }
 
     #[test]
-    fn trace_line_returns_trace() {
-        let line = "2026-05-20T17:54:47.123Z TRACE endara_relay::core: very noisy";
+    fn json_trace_line_returns_trace() {
+        // Same `.json()` shape with a TRACE level.
+        let line = r#"{"timestamp":"2026-06-09T15:20:34.000000Z","level":"TRACE","fields":{"message":"very noisy"},"target":"endara_relay::core"}"#;
         assert_eq!(parse_level_from_line(line), Some("trace"));
+    }
+
+    #[test]
+    fn raw_text_line_falls_back_to_token() {
+        // Non-JSON adapter line with a tracing-style level token after the
+        // timestamp prefix still resolves via the regex fallback.
+        let line = "2026-05-20T17:54:47.123Z  WARN endara_relay::registry: reconnecting";
+        assert_eq!(parse_level_from_line(line), Some("warn"));
     }
 
     #[test]
@@ -3765,10 +3753,10 @@ mod parse_level_from_line_tests {
 
     #[test]
     fn message_body_word_error_does_not_match() {
-        // The helper anchors near the start of the line, so a lowercase
-        // English word "error" inside the message body must not be promoted
-        // to a tracing level. The stderr fallback substring matcher still
-        // handles this case, but the helper itself stays strict.
+        // The regex fallback anchors near the start of the line, so a lowercase
+        // English word "error" inside the message body of a non-JSON line must
+        // not be promoted to a tracing level. The stderr fallback substring
+        // matcher still handles this case, but the helper itself stays strict.
         let line = "2026-05-20T17:54:47.123Z something happened: an error occurred mid-body";
         assert_eq!(parse_level_from_line(line), None);
     }

--- a/src/lib/components/LogFilterBar.svelte
+++ b/src/lib/components/LogFilterBar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { LogLevel, ParsedLogLine } from '$lib/logParser';
+  import { closeAllMenus, nextMenuState, type MenuState } from './logfilterbar-helpers';
 
   // Level toggles render in this fixed display order so the bar layout
   // doesn't reshuffle as logs arrive.
@@ -30,8 +31,23 @@
   // Search input is bound locally and the debounced value is published into
   // the bindable `searchText` prop. 150ms matches the engineering spec.
   let searchInput = $state(searchText);
-  let endpointMenuOpen = $state(false);
-  let profileMenuOpen = $state(false);
+  // At most one dropdown is open at a time (mutual exclusion). Wrapper refs let
+  // the window handler tell an outside click from a click on the toggle/list.
+  let menus = $state<MenuState>(closeAllMenus());
+  let endpointWrapper = $state<HTMLDivElement>();
+  let profileWrapper = $state<HTMLDivElement>();
+
+  function handleWindowPointerDown(event: PointerEvent) {
+    if (!menus.endpoint && !menus.profile) return;
+    const target = event.target as Node | null;
+    const insideEndpoint = !!target && !!endpointWrapper?.contains(target);
+    const insideProfile = !!target && !!profileWrapper?.contains(target);
+    if (!insideEndpoint && !insideProfile) menus = closeAllMenus();
+  }
+
+  function handleWindowKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape' && (menus.endpoint || menus.profile)) menus = closeAllMenus();
+  }
 
   let debounceTimer: ReturnType<typeof setTimeout> | undefined;
   $effect(() => {
@@ -110,6 +126,8 @@
   }
 </script>
 
+<svelte:window onpointerdown={handleWindowPointerDown} onkeydown={handleWindowKeydown} />
+
 <div class="px-3 py-2 border-b border-(--border) bg-(--hd-bg) flex flex-col gap-2">
   <div class="flex items-center gap-2 flex-wrap">
     {#each LEVEL_ORDER as level (level)}
@@ -135,13 +153,13 @@
       ⚡ Tool calls only ({toolCallCount})
     </button>
 
-    <div class="ml-auto relative">
+    <div class="ml-auto relative" bind:this={endpointWrapper}>
       <button
         type="button"
         class="btn-sec btn-sm"
         aria-haspopup="listbox"
-        aria-expanded={endpointMenuOpen}
-        onclick={() => (endpointMenuOpen = !endpointMenuOpen)}
+        aria-expanded={menus.endpoint}
+        onclick={() => (menus = nextMenuState(menus, 'endpoint'))}
       >
         Endpoint: {selectedEndpoints.size === 0
           ? 'All'
@@ -149,7 +167,7 @@
             ? Array.from(selectedEndpoints)[0]
             : `${selectedEndpoints.size} selected`} ▾
       </button>
-      {#if endpointMenuOpen}
+      {#if menus.endpoint}
         <ul
           role="listbox"
           aria-multiselectable="true"
@@ -173,13 +191,13 @@
       {/if}
     </div>
 
-    <div class="relative">
+    <div class="relative" bind:this={profileWrapper}>
       <button
         type="button"
         class="btn-sec btn-sm"
         aria-haspopup="listbox"
-        aria-expanded={profileMenuOpen}
-        onclick={() => (profileMenuOpen = !profileMenuOpen)}
+        aria-expanded={menus.profile}
+        onclick={() => (menus = nextMenuState(menus, 'profile'))}
       >
         Profile: {selectedProfiles.size === 0
           ? 'All'
@@ -187,7 +205,7 @@
             ? Array.from(selectedProfiles)[0]
             : `${selectedProfiles.size} selected`} ▾
       </button>
-      {#if profileMenuOpen}
+      {#if menus.profile}
         <ul
           role="listbox"
           aria-multiselectable="true"

--- a/src/lib/components/LogFilterBar.test.ts
+++ b/src/lib/components/LogFilterBar.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { parseLogLine } from '$lib/logParser';
 import type { LogLevel, ParsedLogLine } from '$lib/logParser';
+import { closeAllMenus, nextMenuState } from './logfilterbar-helpers';
 
 // Pure mirror of the filter combine logic in `LogFilterBar.svelte` +
 // `RelayLogs.svelte`. Kept in sync with the components so we can unit-test
@@ -262,5 +263,33 @@ describe('applyLogFilters', () => {
       toolCallsOnly: true,
     });
     expect(slackToolCalls).toHaveLength(0);
+  });
+});
+
+// Pure open/close transitions backing the Endpoint/Profile dropdowns. Covers
+// mutual exclusion (only one open at a time) and close-all (outside click /
+// Escape) without rendering the Svelte component.
+describe('nextMenuState / closeAllMenus', () => {
+  it('opens a closed menu when toggled', () => {
+    expect(nextMenuState(closeAllMenus(), 'endpoint')).toEqual({ endpoint: true, profile: false });
+    expect(nextMenuState(closeAllMenus(), 'profile')).toEqual({ endpoint: false, profile: true });
+  });
+
+  it('closes an open menu when toggled again', () => {
+    const open = nextMenuState(closeAllMenus(), 'endpoint');
+    expect(nextMenuState(open, 'endpoint')).toEqual({ endpoint: false, profile: false });
+  });
+
+  it('opening one menu closes the other (mutual exclusion)', () => {
+    const endpointOpen = nextMenuState(closeAllMenus(), 'endpoint');
+    const afterProfile = nextMenuState(endpointOpen, 'profile');
+    expect(afterProfile).toEqual({ endpoint: false, profile: true });
+
+    const backToEndpoint = nextMenuState(afterProfile, 'endpoint');
+    expect(backToEndpoint).toEqual({ endpoint: true, profile: false });
+  });
+
+  it('closeAllMenus collapses both menus', () => {
+    expect(closeAllMenus()).toEqual({ endpoint: false, profile: false });
   });
 });

--- a/src/lib/components/LogRow.svelte
+++ b/src/lib/components/LogRow.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { LogLevel, ParsedLogLine } from '$lib/logParser';
   import { endpointStripeStyle } from '$lib/endpointColor';
+  import { relayEventDetail } from './relay-event-detail';
   import ToolCallRow from './ToolCallRow.svelte';
 
   // Pure presentation row shared by RelayLogs.svelte and LogsTab.svelte
@@ -74,7 +75,10 @@
     ];
   }
 
-  const segments = $derived(highlightSegments(line.message || line.raw, trimmedQuery));
+  // For bare relay-event rows ("MCP request" / "Routing tool call") surface an
+  // enriched detail string; every other non-tool-call line renders unchanged.
+  const displayText = $derived(relayEventDetail(line) ?? (line.message || line.raw));
+  const segments = $derived(highlightSegments(displayText, trimmedQuery));
   const timestampTitle = $derived(
     nowMs !== undefined
       ? `${line.timestamp.toISOString()} · ${formatRelative(line.timestamp, nowMs)}`

--- a/src/lib/components/ToolCallRow.svelte
+++ b/src/lib/components/ToolCallRow.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { ParsedLogLine } from '$lib/logParser';
   import {
+    callerSuffix,
     durationColorClass,
     statusIcon,
     statusIconClass,
@@ -18,6 +19,7 @@
   const icon = $derived(statusIcon(line.status));
   const iconClass = $derived(statusIconClass(line.status));
   const errSuffix = $derived(toolCallErrorSuffix(line));
+  const caller = $derived(callerSuffix(line.clientName, line.clientVersion));
 </script>
 
 <span class="inline-flex items-baseline gap-2 min-w-0 w-full" data-testid="tool-call-row">
@@ -25,6 +27,9 @@
   <span class="font-mono font-semibold text-(--fg1) truncate" data-testid="tool-name">
     {line.tool ?? ''}
   </span>
+  {#if caller}
+    <span class="text-(--fg2) truncate" data-testid="tool-caller">({caller})</span>
+  {/if}
   {#if durationLabel}
     <span
       class="ml-auto tabular-nums {durationClass}"

--- a/src/lib/components/ToolCallRow.test.ts
+++ b/src/lib/components/ToolCallRow.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest';
 import { parseLogLine } from '$lib/logParser';
 import type { ParsedLogLine } from '$lib/logParser';
 import {
+  callerSuffix,
   durationColorClass,
   statusIcon,
   statusIconClass,
@@ -135,5 +136,48 @@ describe('ToolCallRow — error suffix (test #17)', () => {
     expect(suffix).not.toBeNull();
     expect(suffix!.length).toBe(ERROR_SUFFIX_MAX_LEN);
     expect(suffix!.endsWith('…')).toBe(true);
+  });
+});
+
+// Caller suffix rendered inline after the tool name in the logs view. The
+// helper joins the parsed `clientName` + `clientVersion` flat fields into the
+// FULL caller label (unlike the overlay card, which uses the simplified
+// name-only `callerLabel`).
+describe('ToolCallRow — caller suffix', () => {
+  it('joins client name and version when both are present', () => {
+    expect(callerSuffix('claude-ai', '0.1.0')).toBe('claude-ai 0.1.0');
+  });
+
+  it('returns the bare name when only client name is present', () => {
+    expect(callerSuffix('Claude Desktop', undefined)).toBe('Claude Desktop');
+    expect(callerSuffix('Claude Desktop', '')).toBe('Claude Desktop');
+    expect(callerSuffix('Claude Desktop', null)).toBe('Claude Desktop');
+  });
+
+  it('returns null when client name is missing or empty', () => {
+    expect(callerSuffix(undefined, undefined)).toBeNull();
+    expect(callerSuffix(undefined, '0.1.0')).toBeNull();
+    expect(callerSuffix(null, '0.1.0')).toBeNull();
+    expect(callerSuffix('', '0.1.0')).toBeNull();
+    expect(callerSuffix('   ', '0.1.0')).toBeNull();
+  });
+
+  it('end-to-end: parseLogLine + callerSuffix surfaces the full label', () => {
+    const line = parseLogLine(
+      'info',
+      'endpoint{endpoint="github"}: Tool call completed tool=get_file_contents status=ok duration_ms=312 client_name="Claude Desktop" client_version="0.7.0"',
+    );
+    expect(line.clientName).toBe('Claude Desktop');
+    expect(line.clientVersion).toBe('0.7.0');
+    expect(callerSuffix(line.clientName, line.clientVersion)).toBe('Claude Desktop 0.7.0');
+  });
+
+  it('end-to-end: no client_name flat field → no caller suffix', () => {
+    const line = parseLogLine(
+      'info',
+      'endpoint{endpoint="github"}: Tool call completed tool=foo status=ok duration_ms=42',
+    );
+    expect(line.clientName).toBeUndefined();
+    expect(callerSuffix(line.clientName, line.clientVersion)).toBeNull();
   });
 });

--- a/src/lib/components/logfilterbar-helpers.ts
+++ b/src/lib/components/logfilterbar-helpers.ts
@@ -1,0 +1,24 @@
+// Pure open/close transitions for the LogFilterBar dropdowns. Kept as a
+// standalone helper (mirroring sidebar-helpers.ts) so the mutual-exclusion +
+// close-all logic can be unit-tested without a Svelte runtime.
+
+export type LogMenu = 'endpoint' | 'profile';
+
+export interface MenuState {
+  endpoint: boolean;
+  profile: boolean;
+}
+
+export function closeAllMenus(): MenuState {
+  return { endpoint: false, profile: false };
+}
+
+// Toggle one menu's open state. Opening a menu always closes the other
+// (mutual exclusion) so at most one dropdown is open at a time.
+export function nextMenuState(current: MenuState, menu: LogMenu): MenuState {
+  const willOpen = !current[menu];
+  return {
+    endpoint: menu === 'endpoint' ? willOpen : false,
+    profile: menu === 'profile' ? willOpen : false,
+  };
+}

--- a/src/lib/components/relay-event-detail.test.ts
+++ b/src/lib/components/relay-event-detail.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import type { ParsedLogLine } from '$lib/logParser';
+import { relayEventDetail } from './relay-event-detail';
+
+// Minimal ParsedLogLine factory — only the fields the detail helper reads
+// matter; the rest carry harmless defaults.
+function line(overrides: Partial<ParsedLogLine>): ParsedLogLine {
+  return {
+    timestamp: new Date('2026-06-10T00:00:00.000Z'),
+    level: 'info',
+    message: '',
+    raw: '',
+    isToolCall: false,
+    ...overrides,
+  };
+}
+
+describe('relayEventDetail — MCP request', () => {
+  it('joins method, status, elapsed, and caller', () => {
+    const detail = relayEventDetail(
+      line({
+        message: 'MCP request',
+        method: 'tools/call',
+        status: '200',
+        elapsedMs: 42,
+        clientName: 'LiveTest JSON Logs',
+        clientVersion: '2.0.0',
+      }),
+    );
+    expect(detail).toBe('MCP request · tools/call · 200 · 42ms · LiveTest JSON Logs 2.0.0');
+  });
+
+  it('omits each segment when its field is absent', () => {
+    expect(relayEventDetail(line({ message: 'MCP request' }))).toBe('MCP request');
+    expect(relayEventDetail(line({ message: 'MCP request', method: 'initialize' }))).toBe(
+      'MCP request · initialize',
+    );
+    expect(
+      relayEventDetail(line({ message: 'MCP request', elapsedMs: 7, clientName: 'Cursor' })),
+    ).toBe('MCP request · 7ms · Cursor');
+  });
+
+  it('uses the name only when the caller version is missing', () => {
+    expect(
+      relayEventDetail(line({ message: 'MCP request', method: 'tools/list', clientName: 'Cursor' })),
+    ).toBe('MCP request · tools/list · Cursor');
+  });
+
+  it('drops a NaN elapsedMs segment', () => {
+    expect(relayEventDetail(line({ message: 'MCP request', elapsedMs: Number.NaN }))).toBe(
+      'MCP request',
+    );
+  });
+});
+
+describe('relayEventDetail — Routing tool call', () => {
+  it('renders prefixed tool → endpoint', () => {
+    expect(
+      relayEventDetail(
+        line({
+          message: 'Routing tool call',
+          prefixed: 'atlassian__getAccessibleAtlassianResources',
+          tool: 'getAccessibleAtlassianResources',
+          endpoint: 'Atlassian',
+        }),
+      ),
+    ).toBe('Routing tool call · atlassian__getAccessibleAtlassianResources → Atlassian');
+  });
+
+  it('falls back to the bare tool when prefixed is absent', () => {
+    expect(
+      relayEventDetail(line({ message: 'Routing tool call', tool: 'send_email', endpoint: 'Gmail' })),
+    ).toBe('Routing tool call · send_email → Gmail');
+  });
+
+  it('omits the endpoint tail when endpoint is absent', () => {
+    expect(relayEventDetail(line({ message: 'Routing tool call', prefixed: 'gh__list' }))).toBe(
+      'Routing tool call · gh__list',
+    );
+  });
+
+  it('renders the bare label when neither tool nor endpoint is present', () => {
+    expect(relayEventDetail(line({ message: 'Routing tool call' }))).toBe('Routing tool call');
+  });
+});
+
+describe('relayEventDetail — other lines', () => {
+  it('returns null for any other message so the row renders unchanged', () => {
+    expect(relayEventDetail(line({ message: 'Tool call completed', tool: 'x' }))).toBeNull();
+    expect(relayEventDetail(line({ message: 'Relay listening on 127.0.0.1:47107' }))).toBeNull();
+    expect(relayEventDetail(line({ message: '' }))).toBeNull();
+  });
+});

--- a/src/lib/components/relay-event-detail.ts
+++ b/src/lib/components/relay-event-detail.ts
@@ -1,0 +1,55 @@
+import type { ParsedLogLine } from '$lib/logParser';
+import { callerSuffix } from './tool-call-row-helpers';
+
+// Pure helper that turns an otherwise-bare relay-event row ("MCP request" /
+// "Routing tool call") into a readable inline detail string, surfacing the
+// structured fields the relay already emits. Returns null for every other
+// message so the non-tool-call row renders its message exactly as today.
+//
+// Kept out of the Svelte component (matching the `*-helpers.ts` pattern) so the
+// formatting can be unit-tested without a Svelte runtime.
+
+const SEP = ' · ';
+
+function trimmed(value: string | undefined | null): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+// `MCP request · <method> · <status> · <elapsedMs>ms · <caller>` — each segment
+// is omitted when its field is absent. `caller` is the unquoted `name version`.
+function mcpRequestDetail(line: ParsedLogLine): string {
+  const parts: string[] = ['MCP request'];
+  const method = trimmed(line.method);
+  if (method) parts.push(method);
+  const status = trimmed(line.status);
+  if (status) parts.push(status);
+  if (line.elapsedMs !== undefined && !Number.isNaN(line.elapsedMs)) {
+    parts.push(`${line.elapsedMs}ms`);
+  }
+  const caller = callerSuffix(line.clientName, line.clientVersion);
+  if (caller) parts.push(caller);
+  return parts.join(SEP);
+}
+
+// `Routing tool call · <prefixed‖tool> → <endpoint>` — prefer the prefixed name
+// (`<endpoint>__<tool>`), fall back to the bare tool; the `→ <endpoint>` tail is
+// omitted when the endpoint is absent.
+function routingToolCallDetail(line: ParsedLogLine): string {
+  const name = trimmed(line.prefixed) || trimmed(line.tool);
+  if (!name) return 'Routing tool call';
+  const endpoint = trimmed(line.endpoint);
+  return endpoint
+    ? `Routing tool call${SEP}${name} → ${endpoint}`
+    : `Routing tool call${SEP}${name}`;
+}
+
+export function relayEventDetail(line: ParsedLogLine): string | null {
+  switch (line.message) {
+    case 'MCP request':
+      return mcpRequestDetail(line);
+    case 'Routing tool call':
+      return routingToolCallDetail(line);
+    default:
+      return null;
+  }
+}

--- a/src/lib/components/tool-call-row-helpers.ts
+++ b/src/lib/components/tool-call-row-helpers.ts
@@ -45,3 +45,18 @@ export function formatDurationMs(durationMs: number | undefined): string {
   if (durationMs === undefined || Number.isNaN(durationMs)) return '';
   return `${durationMs}ms`;
 }
+
+// Build the parenthetical caller suffix rendered inline after the tool name in
+// `ToolCallRow.svelte`. The logs view shows the FULL caller (name + version
+// when available), unlike the overlay card which uses the simplified
+// `callerLabel` (name only). Returns null when `clientName` is missing/empty
+// so the row renders the tool name alone.
+export function callerSuffix(
+  clientName: string | undefined | null,
+  clientVersion: string | undefined | null,
+): string | null {
+  const name = typeof clientName === 'string' ? clientName.trim() : '';
+  if (name.length === 0) return null;
+  const version = typeof clientVersion === 'string' ? clientVersion.trim() : '';
+  return version.length > 0 ? `${name} ${version}` : name;
+}

--- a/src/lib/logParser.test.ts
+++ b/src/lib/logParser.test.ts
@@ -187,6 +187,56 @@ describe('parseLogLine — profile field (matrix row #7)', () => {
   });
 });
 
+describe('parseLogLine — client identity fields', () => {
+  it('extracts quoted client_name and client_version from a tool-call line', () => {
+    const parsed = parseLogLine(
+      'info',
+      'endpoint{endpoint="github"}: Tool call completed tool=get_file_contents status=ok duration_ms=312 client_name="Claude Desktop" client_version="0.7.0"',
+    );
+    expect(parsed.clientName).toBe('Claude Desktop');
+    expect(parsed.clientVersion).toBe('0.7.0');
+    expect(parsed.tool).toBe('get_file_contents');
+    expect(parsed.message).toBe('Tool call completed');
+  });
+
+  it('extracts an unquoted single-token client_name', () => {
+    const parsed = parseLogLine(
+      'info',
+      'endpoint{endpoint="github"}: MCP request client_name=claude-ai client_version=0.1.0',
+    );
+    expect(parsed.clientName).toBe('claude-ai');
+    expect(parsed.clientVersion).toBe('0.1.0');
+  });
+
+  it('leaves clientVersion undefined when only client_name is present', () => {
+    const parsed = parseLogLine(
+      'info',
+      'endpoint{endpoint="github"}: MCP request client_name="Cursor"',
+    );
+    expect(parsed.clientName).toBe('Cursor');
+    expect(parsed.clientVersion).toBeUndefined();
+  });
+
+  it('leaves both undefined when neither field is present', () => {
+    const parsed = parseLogLine(
+      'info',
+      'endpoint{endpoint="github"}: Initialize handshake complete',
+    );
+    expect(parsed.clientName).toBeUndefined();
+    expect(parsed.clientVersion).toBeUndefined();
+  });
+
+  it('silently drops empty client_name= without leaking it into the message', () => {
+    const parsed = parseLogLine(
+      'info',
+      'endpoint{endpoint="github"}: MCP request client_name= client_version=',
+    );
+    expect(parsed.clientName).toBeUndefined();
+    expect(parsed.clientVersion).toBeUndefined();
+    expect(parsed.message).toBe('MCP request');
+  });
+});
+
 describe('parseLogLine — endpointOverride (Slice D.2)', () => {
   it('uses the override when provided, ignoring the parsed span value', () => {
     const parsed = parseLogLine(
@@ -220,6 +270,268 @@ describe('parseLogLine — endpointOverride (Slice D.2)', () => {
   it('supplies the endpoint when the message has no span context', () => {
     const parsed = parseLogLine('info', 'plain message', { endpointOverride: 'slack' });
     expect(parsed.endpoint).toBe('slack');
+  });
+});
+
+describe('parseLogLine — JSON-first structured lines (Wave C)', () => {
+  // The relay sidecar now runs with `--log-format json`, so the live pipeline
+  // hands the frontend one tracing-subscriber JSON object per line. These
+  // fixtures mirror the exact shape locked in the spec's cross-stack contract.
+  it('parses a tool-call JSON line with endpoint span + flat fields', () => {
+    const line = JSON.stringify({
+      timestamp: '2026-05-22T15:10:43.123456Z',
+      level: 'INFO',
+      fields: {
+        message: 'Tool call completed',
+        tool: 'get_file_contents',
+        status: 'ok',
+        duration_ms: 312,
+        client_name: 'Claude Desktop',
+        client_version: '1.4.2',
+      },
+      target: 'endara_relay::adapter::http',
+      spans: [
+        { name: 'endpoint', endpoint: 'github', transport: 'stdio', server_type: 'http' },
+        { name: 'mcp_request', profile: 'default' },
+        { name: 'request', method: 'tools/call', id: '7' },
+      ],
+    });
+    const parsed = parseLogLine('info', line);
+    expect(parsed.level).toBe('info');
+    expect(parsed.endpoint).toBe('github');
+    expect(parsed.transport).toBe('stdio');
+    expect(parsed.serverType).toBe('http');
+    expect(parsed.method).toBe('tools/call');
+    expect(parsed.requestId).toBe('7');
+    expect(parsed.profile).toBe('default');
+    expect(parsed.tool).toBe('get_file_contents');
+    expect(parsed.status).toBe('ok');
+    expect(parsed.durationMs).toBe(312);
+    expect(parsed.clientName).toBe('Claude Desktop');
+    expect(parsed.clientVersion).toBe('1.4.2');
+    // Clean message — no `}: ` artifact, no leaked client=/content-/user- tokens.
+    expect(parsed.message).toBe('Tool call completed');
+    expect(parsed.message).not.toContain('}: ');
+    expect(parsed.message).not.toContain('client=');
+    expect(parsed.isToolCall).toBe(true);
+  });
+
+  it('does not leak a nested client={…} blob into the message (regression)', () => {
+    // The text formatter let the `request` span carry a balanced-brace
+    // `client={"name":...}` value that produced a `}: ` artifact and stray
+    // quotes. In JSON the desktop reads only the flat client_name/version.
+    const line = JSON.stringify({
+      timestamp: '2026-05-22T15:10:43.123456Z',
+      level: 'INFO',
+      fields: {
+        message: 'Tool call completed',
+        tool: 'send_email',
+        status: 'ok',
+        duration_ms: 234,
+        client_name: 'Claude Desktop',
+        client_version: '0.7.0',
+      },
+      spans: [
+        { name: 'endpoint', endpoint: 'gmail' },
+        {
+          name: 'request',
+          method: 'tools/call',
+          id: '9',
+          client: '{"name":"Claude Desktop","version":"0.7.0"}',
+        },
+      ],
+    });
+    const parsed = parseLogLine('info', line);
+    expect(parsed.message).toBe('Tool call completed');
+    expect(parsed.message).not.toContain('}: ');
+    expect(parsed.message).not.toContain('{');
+    expect(parsed.message).not.toContain('"');
+    expect(parsed.clientName).toBe('Claude Desktop');
+    expect(parsed.clientVersion).toBe('0.7.0');
+  });
+
+  it('parses a relay-level JSON line with no endpoint span (endpoint undefined)', () => {
+    const line = JSON.stringify({
+      timestamp: '2026-05-22T15:10:43.123456Z',
+      level: 'INFO',
+      fields: { message: 'Relay listening on 127.0.0.1:47107' },
+      target: 'endara_relay',
+      spans: [],
+    });
+    const parsed = parseLogLine('info', line);
+    expect(parsed.endpoint).toBeUndefined();
+    expect(parsed.transport).toBeUndefined();
+    expect(parsed.method).toBeUndefined();
+    expect(parsed.profile).toBeUndefined();
+    expect(parsed.message).toBe('Relay listening on 127.0.0.1:47107');
+    expect(parsed.isToolCall).toBe(false);
+  });
+
+  it('coerces a numeric duration_ms and drops a non-numeric one', () => {
+    const numeric = parseLogLine(
+      'info',
+      JSON.stringify({ level: 'INFO', fields: { message: 'x', status: 'ok', duration_ms: 42 } }),
+    );
+    expect(numeric.durationMs).toBe(42);
+    expect(numeric.isToolCall).toBe(true);
+    const garbage = parseLogLine(
+      'info',
+      JSON.stringify({ level: 'INFO', fields: { message: 'x', duration_ms: 'nope' } }),
+    );
+    expect(garbage.durationMs).toBeUndefined();
+  });
+
+  it('lowercases the JSON level token', () => {
+    const parsed = parseLogLine(
+      'info',
+      JSON.stringify({ level: 'ERROR', fields: { message: 'boom' } }),
+    );
+    expect(parsed.level).toBe('error');
+  });
+
+  it('lets endpointOverride win over the JSON endpoint span', () => {
+    const line = JSON.stringify({
+      level: 'INFO',
+      fields: { message: 'hello' },
+      spans: [{ name: 'endpoint', endpoint: 'github', transport: 'stdio' }],
+    });
+    const parsed = parseLogLine('info', line, { endpointOverride: 'gmail' });
+    expect(parsed.endpoint).toBe('gmail');
+    // Other span fields still come from the JSON.
+    expect(parsed.transport).toBe('stdio');
+  });
+
+  it('keeps the raw JSON string on the parsed line', () => {
+    const line = JSON.stringify({ level: 'INFO', fields: { message: 'hi' } });
+    const parsed = parseLogLine('info', line);
+    expect(parsed.raw).toBe(line);
+  });
+
+  it('falls back to the text parser for the activity-log seed shape', () => {
+    // The per-endpoint `/logs` seed returns the adapters' custom text
+    // activity-log lines (NOT tracing JSON); the text fallback must keep
+    // parsing them exactly as before.
+    const parsed = parseLogLine(
+      'info',
+      '2026-05-22T15:10:43.123Z INFO call_tool tool=get_file_contents status=ok duration=312ms',
+    );
+    expect(parsed.tool).toBe('get_file_contents');
+    expect(parsed.status).toBe('ok');
+    expect(parsed.message).toContain('call_tool');
+    expect(parsed.level).toBe('info');
+  });
+});
+
+describe('parseLogLine — JSON relay-event fields (Wave D2)', () => {
+  // The relay emits `client_name`/`client_version` via Rust Debug (`?`), so in
+  // the JSON output their values arrive wrapped in a literal surrounding
+  // quote-pair. The parser strips exactly one pair so the caller is unquoted.
+  it('strips the Debug quote-pair from client_name / client_version', () => {
+    const parsed = parseLogLine(
+      'info',
+      JSON.stringify({
+        level: 'INFO',
+        fields: {
+          message: 'MCP request',
+          method: 'tools/call',
+          status: 200,
+          elapsed_ms: 42,
+          client_name: '"LiveTest JSON Logs"',
+          client_version: '"2.0.0"',
+        },
+        spans: [{ name: 'request', method: 'tools/call', id: '3' }],
+      }),
+    );
+    expect(parsed.clientName).toBe('LiveTest JSON Logs');
+    expect(parsed.clientVersion).toBe('2.0.0');
+  });
+
+  it('treats an empty Debug string ("") as missing', () => {
+    const parsed = parseLogLine(
+      'info',
+      JSON.stringify({
+        level: 'INFO',
+        fields: { message: 'MCP request', client_name: '""', client_version: '""' },
+      }),
+    );
+    expect(parsed.clientName).toBeUndefined();
+    expect(parsed.clientVersion).toBeUndefined();
+  });
+
+  it('leaves an already-unquoted client_name unchanged', () => {
+    const parsed = parseLogLine(
+      'info',
+      JSON.stringify({ level: 'INFO', fields: { message: 'MCP request', client_name: 'Cursor' } }),
+    );
+    expect(parsed.clientName).toBe('Cursor');
+  });
+
+  it('captures elapsedMs / reqBytes / respBytes / status without setting durationMs', () => {
+    const parsed = parseLogLine(
+      'info',
+      JSON.stringify({
+        level: 'INFO',
+        fields: {
+          message: 'MCP request',
+          method: 'tools/call',
+          status: 200,
+          elapsed_ms: 87,
+          req_bytes: 120,
+          resp_bytes: 4096,
+        },
+        spans: [{ name: 'request', method: 'tools/call', id: '5' }],
+      }),
+    );
+    expect(parsed.elapsedMs).toBe(87);
+    expect(parsed.reqBytes).toBe(120);
+    expect(parsed.respBytes).toBe(4096);
+    expect(parsed.status).toBe('200');
+    expect(parsed.method).toBe('tools/call');
+    // CRITICAL: elapsed_ms must NOT leak into durationMs, otherwise the row
+    // gets misclassified as a tool-call row by isToolCall.
+    expect(parsed.durationMs).toBeUndefined();
+    expect(parsed.isToolCall).toBe(false);
+  });
+
+  it('falls back to fields.method when no request span is present', () => {
+    const parsed = parseLogLine(
+      'info',
+      JSON.stringify({
+        level: 'INFO',
+        fields: { message: 'MCP request', method: 'initialize', status: 200, elapsed_ms: 3 },
+      }),
+    );
+    expect(parsed.method).toBe('initialize');
+  });
+
+  it('maps the Routing tool call prefixed/tool/endpoint flat fields', () => {
+    const parsed = parseLogLine(
+      'info',
+      JSON.stringify({
+        level: 'INFO',
+        fields: {
+          message: 'Routing tool call',
+          tool: 'getAccessibleAtlassianResources',
+          endpoint: 'Atlassian',
+          prefixed: 'atlassian__getAccessibleAtlassianResources',
+        },
+      }),
+    );
+    expect(parsed.prefixed).toBe('atlassian__getAccessibleAtlassianResources');
+    expect(parsed.tool).toBe('getAccessibleAtlassianResources');
+    expect(parsed.endpoint).toBe('Atlassian');
+    expect(parsed.isToolCall).toBe(false);
+  });
+
+  it('leaves the new fields undefined on lines that do not carry them', () => {
+    const parsed = parseLogLine(
+      'info',
+      JSON.stringify({ level: 'INFO', fields: { message: 'Relay listening' } }),
+    );
+    expect(parsed.elapsedMs).toBeUndefined();
+    expect(parsed.reqBytes).toBeUndefined();
+    expect(parsed.respBytes).toBeUndefined();
+    expect(parsed.prefixed).toBeUndefined();
   });
 });
 

--- a/src/lib/logParser.ts
+++ b/src/lib/logParser.ts
@@ -21,6 +21,21 @@ export interface ParsedLogLine {
   status?: string;
   durationMs?: number;
   profile?: string;
+  // Relay-event metrics emitted on `MCP request` lines (distinct from
+  // `durationMs`, which only ever comes from a tool-call `duration_ms` field —
+  // keeping `elapsedMs` separate is what stops `MCP request` rows from being
+  // misclassified as tool-call rows by `isToolCall`).
+  elapsedMs?: number;
+  reqBytes?: number;
+  respBytes?: number;
+  // Prefixed tool name (`<endpoint>__<tool>`) emitted on `Routing tool call`
+  // lines by the relay registry.
+  prefixed?: string;
+  // Identity of the calling MCP client, captured from the relay's flat
+  // `client_name=...` / `client_version=...` event fields. Either may be
+  // missing independently — the renderer treats "missing" and `""` the same.
+  clientName?: string;
+  clientVersion?: string;
   message: string;
   raw: string;
   isToolCall: boolean;
@@ -72,11 +87,150 @@ export interface ParseLogLineOptions {
   endpointOverride?: string | null;
 }
 
+// Shape of one line emitted by tracing-subscriber's `.json()` formatter. Every
+// field is optional/defensive because the desktop never controls the exact
+// layout — see the spec's "Cross-stack contract — the relay's tracing JSON
+// line shape".
+interface TracingJsonSpan {
+  name?: string;
+  endpoint?: string;
+  transport?: string;
+  server_type?: string;
+  method?: string;
+  id?: string | number;
+  profile?: string;
+  [key: string]: unknown;
+}
+interface TracingJsonLine {
+  timestamp?: string;
+  level?: string;
+  target?: string;
+  fields?: Record<string, unknown>;
+  spans?: TracingJsonSpan[];
+}
+
+function asString(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  return typeof value === 'string' ? value : String(value);
+}
+
+// Coerce a JSON value to a finite number, dropping `undefined`/`null`/NaN.
+// The relay emits `elapsed_ms` / `req_bytes` / `resp_bytes` as JSON numbers.
+function asNumber(value: unknown): number | undefined {
+  if (value === undefined || value === null) return undefined;
+  const n = Number(value);
+  return Number.isNaN(n) ? undefined : n;
+}
+
+// The relay emits `client_name` / `client_version` via Rust Debug (`?`), so in
+// the JSON output their values arrive wrapped in a literal surrounding
+// quote-pair (e.g. the value string is `"Claude Desktop"`, quotes included).
+// Strip exactly one surrounding quote-pair so the rendered caller is unquoted;
+// an empty Debug string (`""`) collapses to undefined ("missing"). Values with
+// no surrounding quotes (e.g. test fixtures) pass through unchanged.
+function stripDebugQuotes(value: unknown): string | undefined {
+  const s = asString(value);
+  if (s === undefined) return undefined;
+  const out =
+    s.length >= 2 && s.startsWith('"') && s.endsWith('"') ? s.slice(1, -1) : s;
+  return out.length === 0 ? undefined : out;
+}
+
+// JSON-first branch: map a parsed tracing-subscriber JSON line onto
+// `ParsedLogLine` per the locked field-mapping contract. Span/event fields are
+// no longer a non-regular language we have to scrape, so the brittle text
+// regexes never run for these lines.
+function parseJsonLogLine(
+  json: TracingJsonLine,
+  level: string,
+  raw: string,
+  options?: ParseLogLineOptions,
+): ParsedLogLine {
+  const fields: Record<string, unknown> =
+    json.fields && typeof json.fields === 'object' ? json.fields : {};
+  const spans: TracingJsonSpan[] = Array.isArray(json.spans) ? json.spans : [];
+  const findSpan = (name: string): TracingJsonSpan =>
+    spans.find((s) => s && typeof s === 'object' && s.name === name) ?? {};
+  const endpointSpan = findSpan('endpoint');
+  const requestSpan = findSpan('request');
+  const mcpRequestSpan = findSpan('mcp_request');
+
+  const parsedTimestamp = json.timestamp ? new Date(json.timestamp) : new Date();
+  const timestamp = Number.isNaN(parsedTimestamp.getTime()) ? new Date() : parsedTimestamp;
+
+  // Prefer the `endpoint` span, falling back to a flat `fields.endpoint` so
+  // relay events that carry the endpoint as an event field (e.g. the registry's
+  // `Routing tool call` line) still resolve their endpoint.
+  const parsedEndpoint = asString(endpointSpan.endpoint) ?? asString(fields.endpoint);
+  const endpoint =
+    options?.endpointOverride !== undefined && options.endpointOverride !== null
+      ? options.endpointOverride
+      : parsedEndpoint;
+
+  const tool = asString(fields.tool);
+  const status = asString(fields.status);
+  // `duration_ms` arrives as a JSON number in this format (not a quoted string
+  // as in the Full text format); coerce defensively and drop NaN.
+  const durationNum = fields.duration_ms !== undefined ? Number(fields.duration_ms) : undefined;
+  const durationMs =
+    durationNum !== undefined && !Number.isNaN(durationNum) ? durationNum : undefined;
+
+  const message = asString(fields.message) ?? '';
+
+  const isToolCall =
+    (tool !== undefined &&
+      (message.includes('Tool call completed') || message.includes('Tool call failed'))) ||
+    (status !== undefined && durationMs !== undefined);
+
+  // Per Engineering Spec §7.1 the canonical span is `mcp_request`; fall back to
+  // any span carrying a `profile` field to stay robust to the exact span name.
+  const profile =
+    asString(mcpRequestSpan.profile) ?? asString(spans.find((s) => s && s.profile)?.profile);
+
+  return {
+    timestamp,
+    level: normalizeLevel(json.level ?? level),
+    endpoint,
+    transport: asString(endpointSpan.transport),
+    serverType: asString(endpointSpan.server_type),
+    method: asString(requestSpan.method) ?? asString(fields.method),
+    requestId: asString(requestSpan.id),
+    tool,
+    status,
+    durationMs,
+    // Distinct from `durationMs` on purpose — see the `ParsedLogLine` note.
+    elapsedMs: asNumber(fields.elapsed_ms),
+    reqBytes: asNumber(fields.req_bytes),
+    respBytes: asNumber(fields.resp_bytes),
+    prefixed: asString(fields.prefixed),
+    profile,
+    clientName: stripDebugQuotes(fields.client_name),
+    clientVersion: stripDebugQuotes(fields.client_version),
+    message,
+    raw,
+    isToolCall,
+  };
+}
+
 export function parseLogLine(
   level: string,
   message: string,
   options?: ParseLogLineOptions,
 ): ParsedLogLine {
+  // JSON-first: the relay sidecar runs with `--log-format json`, so the live
+  // pipeline hands us one tracing JSON object per line. Parse it structurally
+  // and map per the contract. Non-JSON input — the per-endpoint `/logs`
+  // activity-log seed and raw adapter stdout — throws here and falls through to
+  // the text-regex parser below, which keeps those lines rendering as today.
+  try {
+    const parsed: unknown = JSON.parse(message);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parseJsonLogLine(parsed as TracingJsonLine, level, message, options);
+    }
+  } catch {
+    // Not JSON — fall through to the text-regex parser.
+  }
+
   const { timestamp, rest: afterTimestamp } = extractTimestamp(message);
 
   // Strip the level token (ERROR/WARN/INFO/DEBUG/TRACE) that the relay emits
@@ -162,6 +316,8 @@ export function parseLogLine(
     status,
     durationMs: durationMs !== undefined && !Number.isNaN(durationMs) ? durationMs : undefined,
     profile,
+    clientName: fields.client_name,
+    clientVersion: fields.client_version,
     message: cleanedMessage,
     raw: message,
     isToolCall,

--- a/src/lib/overlay/OverlayCard.svelte
+++ b/src/lib/overlay/OverlayCard.svelte
@@ -22,6 +22,7 @@
   import type { ToolCallGroup } from './toastStore';
   import {
     averageDurationMs,
+    callerLabel,
     canFocusLog,
     groupVisualState,
     hintsForAnnotations,
@@ -85,6 +86,9 @@
         : 'var(--offline)',
   );
   const iconSvg = $derived(serverIconFor(group.serverType));
+  // Short caller label rendered on row 2 as `"<caller> → <serverType>"`.
+  // When null we fall back to the unchanged server-type-only rendering.
+  const caller = $derived(callerLabel(group.client));
 
   async function onClick() {
     await cardClick(group);
@@ -153,6 +157,10 @@
       </div>
 
       <div class="tf-row-2">
+        {#if caller}
+          <span class="tf-caller">{caller}</span>
+          <span class="tf-caller-arrow" aria-hidden="true">→</span>
+        {/if}
         <span class="tf-server-type">{group.serverType ?? 'unknown'}</span>
         {#if !sameServer}
           <span class="tf-sep">·</span>

--- a/src/lib/overlay/OverlayCard.test.ts
+++ b/src/lib/overlay/OverlayCard.test.ts
@@ -28,6 +28,7 @@ function g(over: Partial<ToolCallGroup> = {}): ToolCallGroup {
     tool: 'list_issues',
     annotations: undefined,
     profile: null,
+    client: null,
     inflight: 0,
     success: 0,
     error: 0,
@@ -210,6 +211,53 @@ describe('OverlayCard — collapsed row 2 when serverType === serverName', () =>
     expect(src).toMatch(
       /\{#if showProfile && group\.profile\}\s*<span class="tf-sep">·<\/span>\s*<span class="tf-profile">/,
     );
+  });
+});
+
+
+// Row 2's first item: when a caller is known the card renders
+// `"<caller> → <serverType>"`; when no caller is known it falls back to the
+// server-type-only rendering (no arrow). Vitest is in Node, so we (1) assert
+// the `callerLabel(group.client)` predicate the component's `$derived` uses
+// and (2) source-grep `OverlayCard.svelte` to confirm the markup.
+describe('OverlayCard — caller label on row 2', () => {
+  it('renders `<caller> → <serverType>` when client.name is present', async () => {
+    const group = g({
+      client: { name: 'Claude Desktop', version: '0.7.0' },
+      serverType: 'Linear',
+    });
+    const { callerLabel } = await import('./overlay-helpers');
+    expect(callerLabel(group.client)).toBe('Claude Desktop');
+  });
+
+  it('falls back to user_agent product token when name is absent', async () => {
+    const group = g({
+      client: { user_agent: 'claude-ai/0.1.0' },
+      serverType: 'Linear',
+    });
+    const { callerLabel } = await import('./overlay-helpers');
+    expect(callerLabel(group.client)).toBe('claude-ai');
+  });
+
+  it('renders no caller when group.client is null', async () => {
+    const group = g({ client: null, serverType: 'Linear' });
+    const { callerLabel } = await import('./overlay-helpers');
+    expect(callerLabel(group.client)).toBeNull();
+  });
+
+  it('OverlayCard.svelte gates `tf-caller` + `tf-caller-arrow` on `{#if caller}` inside row 2', async () => {
+    const src = (await import('./OverlayCard.svelte?raw')).default as string;
+    // The caller label and the arrow live inside row 2, behind `{#if caller}`.
+    expect(src).toMatch(
+      /<div class="tf-row-2">\s*\{#if caller\}\s*<span class="tf-caller">\{caller\}<\/span>\s*<span class="tf-caller-arrow"[^>]*>→<\/span>\s*\{\/if\}/,
+    );
+    // `tf-server-type` still renders unconditionally afterwards, so the
+    // caller-absent path keeps the existing server-type-only layout.
+    expect(src).toMatch(
+      /\{\/if\}\s*<span class="tf-server-type">\{group\.serverType \?\? 'unknown'\}<\/span>/,
+    );
+    // `caller` is derived from `callerLabel(group.client)`.
+    expect(src).toMatch(/const caller = \$derived\(callerLabel\(group\.client\)\)/);
   });
 });
 

--- a/src/lib/overlay/overlay-actions.test.ts
+++ b/src/lib/overlay/overlay-actions.test.ts
@@ -23,6 +23,7 @@ function g(over: Partial<ToolCallGroup> = {}): ToolCallGroup {
     tool: 'list_issues',
     annotations: undefined,
     profile: null,
+    client: null,
     inflight: 0,
     success: 0,
     error: 0,

--- a/src/lib/overlay/overlay-helpers.test.ts
+++ b/src/lib/overlay/overlay-helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   averageDurationMs,
+  callerLabel,
   canFocusLog,
   groupVisualState,
   hiddenGroupCount,
@@ -30,6 +31,7 @@ function makeGroup(over: Partial<ToolCallGroup> = {}): ToolCallGroup {
     tool: 'list_issues',
     annotations: undefined,
     profile: null,
+    client: null,
     inflight: 0,
     success: 0,
     error: 0,
@@ -129,6 +131,44 @@ describe('isDestructive', () => {
     expect(isDestructive(makeGroup({ annotations: { destructive: false } }))).toBe(false);
     expect(isDestructive(makeGroup({ annotations: {} }))).toBe(false);
     expect(isDestructive(makeGroup())).toBe(false);
+  });
+});
+
+describe('callerLabel', () => {
+  it('returns null when client is null/undefined', () => {
+    expect(callerLabel(null)).toBeNull();
+    expect(callerLabel(undefined)).toBeNull();
+  });
+
+  it('returns null when client has no name and no user_agent', () => {
+    expect(callerLabel({})).toBeNull();
+    expect(callerLabel({ origin: 'https://example.com' })).toBeNull();
+  });
+
+  it('prefers client.name (without version) when present', () => {
+    expect(callerLabel({ name: 'Claude Desktop', version: '0.7.0' })).toBe('Claude Desktop');
+  });
+
+  it('trims whitespace from name', () => {
+    expect(callerLabel({ name: '  Cursor  ' })).toBe('Cursor');
+  });
+
+  it('treats empty / whitespace-only name as missing and falls through to user_agent', () => {
+    expect(callerLabel({ name: '', user_agent: 'claude-ai/0.1.0' })).toBe('claude-ai');
+    expect(callerLabel({ name: '   ', user_agent: 'cursor/2.0.0' })).toBe('cursor');
+  });
+
+  it('derives the leading product token from a typical user_agent', () => {
+    expect(callerLabel({ user_agent: 'claude-desktop/0.7.0' })).toBe('claude-desktop');
+    expect(callerLabel({ user_agent: 'claude-ai/0.1.0 (extra)' })).toBe('claude-ai');
+  });
+
+  it('falls back to the full user_agent when no slash is present', () => {
+    expect(callerLabel({ user_agent: 'SomeRawUA' })).toBe('SomeRawUA');
+  });
+
+  it('treats null name and null user_agent as missing', () => {
+    expect(callerLabel({ name: null, user_agent: null })).toBeNull();
   });
 });
 

--- a/src/lib/overlay/overlay-helpers.ts
+++ b/src/lib/overlay/overlay-helpers.ts
@@ -4,7 +4,7 @@
 // and keep markup-only concerns inside the `.svelte` files.
 
 import type { ToolCallGroup } from './toastStore';
-import type { ToolCallAnnotations } from './types';
+import type { ClientIdentity, ToolCallAnnotations } from './types';
 
 /** Aggregate visual state for a group, derived from its inflight/error/success counts. */
 export type GroupVisualState = 'inflight' | 'success' | 'fail';
@@ -87,3 +87,26 @@ export function isDestructive(g: ToolCallGroup): boolean {
 export type OverlayPosition = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 
 export const DEFAULT_OVERLAY_POSITION: OverlayPosition = 'bottom-right';
+
+/**
+ * Resolve a short, friendly caller label for the overlay card.
+ *
+ * Returns `client.name` (trimmed, without version) when present; otherwise a
+ * friendly label derived from `user_agent` (the leading product token, before
+ * the first `/`); otherwise `null` when no caller signal is known. "Missing
+ * key" and explicit `null`/empty values are treated identically.
+ */
+export function callerLabel(client: ClientIdentity | null | undefined): string | null {
+  if (!client) return null;
+  const name = typeof client.name === 'string' ? client.name.trim() : '';
+  if (name.length > 0) return name;
+  const ua = typeof client.user_agent === 'string' ? client.user_agent.trim() : '';
+  if (ua.length > 0) {
+    // Pull the leading product token from a typical `product/version …` UA.
+    // Falls back to the raw UA when no `/` is present.
+    const slash = ua.indexOf('/');
+    const head = slash >= 0 ? ua.slice(0, slash).trim() : ua;
+    if (head.length > 0) return head;
+  }
+  return null;
+}

--- a/src/lib/overlay/overlay.css
+++ b/src/lib/overlay/overlay.css
@@ -144,6 +144,8 @@
 .tf-counts { display: flex; gap: 4px; }
 
 .tf-row-2 { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; font-size: 12px; line-height: 1.35; padding-left: 38px; color: var(--fg2); }
+.tf-caller { font-weight: 600; color: var(--fg1); }
+.tf-caller-arrow { color: var(--fg3); opacity: 0.7; }
 .tf-server-type { font-weight: 600; color: var(--fg1); }
 .tf-server-name { color: var(--fg2); }
 .tf-sep { color: var(--fg3); opacity: 0.6; }

--- a/src/lib/overlay/toastStore.test.ts
+++ b/src/lib/overlay/toastStore.test.ts
@@ -49,7 +49,7 @@ describe('toastStore', () => {
     store.addStarted(started());
     const groups = get(store) as ToolCallGroup[];
     expect(groups).toHaveLength(1);
-    expect(groups[0].id).toBe('github|github|list_issues');
+    expect(groups[0].id).toBe('|github|github|list_issues');
     expect(groups[0].inflight).toBe(1);
     expect(groups[0].success).toBe(0);
     expect(groups[0].error).toBe(0);
@@ -155,8 +155,44 @@ describe('toastStore', () => {
     );
     const groups = get(store) as ToolCallGroup[];
     expect(groups).toHaveLength(1);
-    expect(groups[0].id).toBe('||t');
+    expect(groups[0].id).toBe('|||t');
     expect(groups[0].inflight).toBe(2);
+  });
+
+  it('populates group.client from the started event and folds caller into the group id', () => {
+    const store = createToastStore();
+    store.addStarted(
+      started({
+        request_id: 'req-1',
+        client: { name: 'Claude Desktop', version: '0.7.0' },
+      }),
+    );
+    const groups = get(store) as ToolCallGroup[];
+    expect(groups).toHaveLength(1);
+    expect(groups[0].client).toEqual({ name: 'Claude Desktop', version: '0.7.0' });
+    expect(groups[0].id).toBe('Claude Desktop|github|github|list_issues');
+  });
+
+  it('defaults group.client to null when the started event omits it', () => {
+    const store = createToastStore();
+    store.addStarted(started({ request_id: 'req-1' }));
+    const groups = get(store) as ToolCallGroup[];
+    expect(groups[0].client).toBeNull();
+  });
+
+  it('keeps two callers on the same tool as distinct groups (caller in groupKey)', () => {
+    const store = createToastStore();
+    store.addStarted(
+      started({ request_id: 'a-1', client: { name: 'Claude Desktop' } }),
+    );
+    store.addStarted(
+      started({ request_id: 'b-1', client: { name: 'Cursor' } }),
+    );
+    const groups = get(store) as ToolCallGroup[];
+    expect(groups).toHaveLength(2);
+    const labels = groups.map((g) => g.client?.name);
+    expect(labels).toContain('Claude Desktop');
+    expect(labels).toContain('Cursor');
   });
 
   it('persists jsonrpcId from started event onto the request', () => {

--- a/src/lib/overlay/toastStore.ts
+++ b/src/lib/overlay/toastStore.ts
@@ -33,7 +33,9 @@
 //     on the next arm). It NEVER decreases.
 
 import { writable, type Readable } from 'svelte/store';
+import { callerLabel } from './overlay-helpers';
 import type {
+  ClientIdentity,
   CompletedEvent,
   FailedEvent,
   StartedEvent,
@@ -60,6 +62,11 @@ export type ToolCallGroup = {
   tool: string;
   annotations?: ToolCallAnnotations;
   profile: string | null;
+  // Identity of the calling MCP client captured from the latest started
+  // event. `null` when no caller signal is known. The resolved short label
+  // (from `callerLabel`) is folded into the group's `id` so calls from
+  // distinct callers to the same tool render as separate cards.
+  client: ClientIdentity | null;
   inflight: number;
   success: number;
   error: number;
@@ -97,10 +104,13 @@ export type ToastStore = Readable<ToolCallGroup[]> & {
 function groupKey(event: StartedEvent): string {
   // Treat null/undefined as empty string so `(null, null, "tool")` and
   // `(undefined, null, "tool")` collapse into the same key — the only fields
-  // the user can distinguish are the ones the event carries.
+  // the user can distinguish are the ones the event carries. The resolved
+  // caller label is folded in so two different apps calling the same tool
+  // do NOT merge into one ambiguous card.
   const t = event.server_type ?? '';
   const n = event.server_name ?? '';
-  return `${t}|${n}|${event.tool}`;
+  const c = callerLabel(event.client ?? null) ?? '';
+  return `${c}|${t}|${n}|${event.tool}`;
 }
 
 export function createToastStore(initial?: Partial<ToastStoreOpts>): ToastStore {
@@ -169,6 +179,7 @@ export function createToastStore(initial?: Partial<ToastStoreOpts>): ToastStore 
         // Most recent values from the latest started event win.
         annotations: event.annotations ?? existing.annotations,
         profile: event.profile ?? null,
+        client: event.client ?? existing.client,
         dismissAt: wasCountingDown ? null : existing.dismissAt,
         dismissTick: wasCountingDown ? existing.dismissTick + 1 : existing.dismissTick,
       };
@@ -182,6 +193,7 @@ export function createToastStore(initial?: Partial<ToastStoreOpts>): ToastStore 
         tool: event.tool,
         annotations: event.annotations,
         profile: event.profile ?? null,
+        client: event.client ?? null,
         inflight: 1,
         success: 0,
         error: 0,

--- a/src/lib/overlay/types.ts
+++ b/src/lib/overlay/types.ts
@@ -14,6 +14,17 @@ export type ToolCallAnnotations = {
   idempotent?: boolean;
 };
 
+// Mirrors the relay's `ClientIdentity` struct (see
+// `packages/relay/src/events.rs`). All fields are independently optional —
+// the on-wire JSON omits any `None` field, so the renderer must treat
+// "missing key" and "null" as the same "no value" state.
+export type ClientIdentity = {
+  name?: string | null;
+  version?: string | null;
+  user_agent?: string | null;
+  origin?: string | null;
+};
+
 export type StartedEvent = {
   kind: 'started';
   request_id: string;
@@ -32,6 +43,9 @@ export type StartedEvent = {
   jsonrpc_id?: string | null;
   tool: string;
   annotations?: ToolCallAnnotations;
+  // Identity of the calling MCP client. Omitted by the relay when no caller
+  // signal is known; treat "missing key" and "null" as the same "no caller".
+  client?: ClientIdentity | null;
 };
 
 export type CompletedEvent = {


### PR DESCRIPTION
## Summary

Surface the calling MCP app in the desktop UI, migrate the logs view off brittle regex text-scraping to the relay's structured JSON output, and fix two log-filter UX bugs.

## What changed

### Caller identity (D1)
- Shared `ClientIdentity` type on `StartedEvent`; `client` threaded through `toastStore` (part of `groupKey`).
- Overlay card row 2 shows a **simplified** caller: `"<caller> -> <serverType>"` (e.g. `Claude Desktop -> Linear`), falling back to server-type only.
- Logs view appends the **full** caller inline after the tool name: `<tool> (claude-ai 0.1.0)`, falling back to the tool name alone.

### Structured JSON log migration (Wave C)
- `build_sidecar_args` flips the relay sidecar to `--log-format json` (dev + prod).
- Host (`lib.rs`): `parse_endpoint_from_span` scans the JSON `spans` array; `parse_level_from_line` reads top-level JSON `level` first (text fallback retained for raw adapter stdout).
- Frontend (`logParser.ts`): JSON-first parse with the original text parser kept verbatim as a fallback for the per-endpoint `/logs` activity-log seed. Durably eliminates the brittle-regex bug class (multi-word names, quoting, nested-brace artifacts).

### Enriched relay-event rows (D2)
- JSON branch strips surrounding Debug quote-pairs from `client_name`/`client_version`; maps `elapsedMs`/`reqBytes`/`respBytes`/`prefixed` + `status`/`method`. New pure helper `relay-event-detail.ts` renders enriched `MCP request` / `Routing tool call` rows.

### Filter UX + permission fixes
- Log-filter dropdowns: mutual exclusion (only one open) + outside-click dismissal (`<svelte:window onpointerdown>`) + Escape-to-close, via pure helper `logfilterbar-helpers.ts`.
- Granted `core:window:allow-start-dragging` (main-window capability) — fixes the unhandled `start_dragging` rejection that intermittently swallowed dropdown clicks.

## Tests

`npm run check` 0 errors, `npm run lint` clean, `npm test` 816 passed / 24 skipped; `src-tauri` `cargo fmt --check` clean + `cargo test` 107 passed.

## Notes

Rebased onto current `main`; #114 (config scaffold) and #115 (macOS restart race) preserved. Pairs with endara-ai/endara-relay#99.