### PR TITLE
test: add OAuth/HTTP catalog live-validation tests and CI workflow

### DIFF
--- a/.github/workflows/catalog-validation.yml
+++ b/.github/workflows/catalog-validation.yml
@@ -1,0 +1,30 @@
+name: Catalog Validation
+on:
+  schedule:
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'src/lib/catalog.ts'
+      - 'src/lib/data/oauth-catalog.ts'
+      - 'src/lib/data/oauth-catalog.live.test.ts'
+      - 'src/lib/catalog-http.live.test.ts'
+      - '.github/workflows/catalog-validation.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  live-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run catalog live tests
+        run: RUN_LIVE_TESTS=1 npx vitest run src/lib/data/oauth-catalog.live.test.ts src/lib/catalog-http.live.test.ts

--- a/src/lib/catalog-http.live.test.ts
+++ b/src/lib/catalog-http.live.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { CATALOG_SERVERS } from './catalog';
+
+// Use a try/catch to avoid direct `process` reference
+// which fails svelte-check (no @types/node in this project)
+let RUN_LIVE_TESTS = false;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  RUN_LIVE_TESTS = !!(globalThis as any).process?.env?.RUN_LIVE_TESTS;
+} catch {
+  // not in Node
+}
+
+const RUN_LIVE = RUN_LIVE_TESTS;
+
+// Plain-HTTP/SSE remote catalog entries (no OAuth) with a concrete endpoint URL.
+const remoteEntries = CATALOG_SERVERS.filter(
+  (e) => (e.transport === 'http' || e.transport === 'sse') && !!e.url
+);
+
+const MCP_PROTOCOL_VERSION = '2025-03-26';
+
+interface JsonRpcResponse {
+  jsonrpc: string;
+  id?: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  result?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  error?: any;
+}
+
+// Parse a Streamable HTTP POST response body, which may be plain JSON or an
+// SSE stream containing the JSON-RPC response in `data:` lines.
+async function parseJsonRpcResponse(resp: Response): Promise<JsonRpcResponse> {
+  const contentType = resp.headers.get('content-type') ?? '';
+  const body = await resp.text();
+  if (contentType.includes('text/event-stream')) {
+    for (const event of body.split('\n\n')) {
+      const data = event
+        .split('\n')
+        .filter((line) => line.startsWith('data:'))
+        .map((line) => line.slice(5).trim())
+        .join('\n');
+      if (!data) continue;
+      const parsed = JSON.parse(data) as JsonRpcResponse;
+      if (parsed.result !== undefined || parsed.error !== undefined) {
+        return parsed;
+      }
+    }
+    throw new Error(`No JSON-RPC response found in SSE body: ${body.slice(0, 500)}`);
+  }
+  return JSON.parse(body) as JsonRpcResponse;
+}
+
+async function postJsonRpc(
+  url: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  payload: Record<string, any>,
+  sessionId: string | null
+): Promise<Response> {
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    accept: 'application/json, text/event-stream',
+  };
+  if (sessionId) {
+    headers['mcp-session-id'] = sessionId;
+  }
+  return fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ jsonrpc: '2.0', ...payload }),
+  });
+}
+
+// Perform an MCP Streamable HTTP handshake (initialize + initialized
+// notification) and return the result of `tools/list`.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function listTools(url: string): Promise<any> {
+  const initResp = await postJsonRpc(
+    url,
+    {
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: 'endara-catalog-live-test', version: '0.0.0' },
+      },
+    },
+    null
+  );
+  expect(initResp.ok, `initialize returned HTTP ${initResp.status}`).toBe(true);
+  const sessionId = initResp.headers.get('mcp-session-id');
+  const init = await parseJsonRpcResponse(initResp);
+  expect(init.error, `initialize error: ${JSON.stringify(init.error)}`).toBeUndefined();
+
+  // Best-effort `notifications/initialized`; some servers require it before
+  // serving requests, others reject notifications — ignore the outcome.
+  await postJsonRpc(url, { method: 'notifications/initialized' }, sessionId).catch(() => {});
+
+  const toolsResp = await postJsonRpc(url, { id: 2, method: 'tools/list', params: {} }, sessionId);
+  expect(toolsResp.ok, `tools/list returned HTTP ${toolsResp.status}`).toBe(true);
+  const tools = await parseJsonRpcResponse(toolsResp);
+  expect(tools.error, `tools/list error: ${JSON.stringify(tools.error)}`).toBeUndefined();
+  return tools.result;
+}
+
+// --- Live tests (network, run on demand with RUN_LIVE_TESTS=1) ---
+
+describe.skipIf(!RUN_LIVE)('live HTTP catalog tools listing', () => {
+  // Today the catalog has zero plain-http/sse entries with a URL; this
+  // placeholder keeps the suite green while proving the filter ran.
+  it('filters http/sse catalog entries with a url', () => {
+    expect(Array.isArray(remoteEntries)).toBe(true);
+    for (const entry of remoteEntries) {
+      expect(entry.url, `${entry.id}: url should be non-empty`).toBeTruthy();
+    }
+  });
+
+  if (remoteEntries.length > 0) {
+    it.each(remoteEntries.map((e) => [e.id, e.url!]))(
+      'tools/list for %s (%s) returns tools',
+      async (_id, url) => {
+        const result = await listTools(url);
+        expect(result, 'tools/list returned no result').toBeTruthy();
+        expect(result.tools, 'tools/list result missing tools array').toBeInstanceOf(Array);
+        expect(result.tools.length, 'tools/list returned an empty tools array').toBeGreaterThan(0);
+      },
+      20_000
+    );
+  }
+});

--- a/src/lib/catalog.ts
+++ b/src/lib/catalog.ts
@@ -13,6 +13,8 @@ export interface CatalogServer {
   icon: string;
   category: 'developer' | 'search' | 'productivity' | 'data';
   transport: 'stdio' | 'sse' | 'http';
+  /** Remote endpoint URL for `http`/`sse` transports (unused for `stdio`). */
+  url?: string;
   command: string;
   args: string[];
   envVars: CatalogEnvVar[];

--- a/src/lib/data/oauth-catalog.live.test.ts
+++ b/src/lib/data/oauth-catalog.live.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect } from 'vitest';
+import { oauthCatalog, type OAuthCatalogEntry } from './oauth-catalog';
+
+// Use a try/catch to avoid direct `process` reference which fails
+// svelte-check (no @types/node in this project)
+let RUN_LIVE_TESTS = false;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  RUN_LIVE_TESTS = !!(globalThis as any).process?.env?.RUN_LIVE_TESTS;
+} catch {
+  // not in Node
+}
+
+const LIVE_TIMEOUT = 20_000;
+
+// Mirrors the redirect_uri the relay registers and sends:
+// `http://127.0.0.1:{relay_port}/oauth/callback` (management.rs).
+const REDIRECT_URI = 'http://127.0.0.1:9400/oauth/callback';
+
+// client_id used to build authorize URLs for entries where DCR is unavailable.
+const PLACEHOLDER_CLIENT_ID = 'endara-ci-placeholder';
+
+/** Protected Resource Metadata per RFC 9728 (fields we assert on). */
+interface ProtectedResourceMetadata {
+  resource?: string;
+  authorization_servers?: string[];
+}
+
+/** Authorization Server Metadata per RFC 8414 (fields we assert on). */
+interface AuthorizationServerMetadata {
+  authorization_endpoint?: string;
+  token_endpoint?: string;
+  registration_endpoint?: string;
+  code_challenge_methods_supported?: string[];
+}
+
+// --- Well-known URL helpers mirroring packages/relay/src/oauth/discovery.rs ---
+
+/** RFC 5785/8414 well-known URL: `.well-known` inserted between host and path. */
+function buildWellKnownUrl(baseUrl: string, suffix: string): string {
+  const parsed = new URL(baseUrl);
+  const path = parsed.pathname.replace(/^\/+|\/+$/g, '');
+  return path
+    ? `${parsed.origin}/.well-known/${suffix}/${path}`
+    : `${parsed.origin}/.well-known/${suffix}`;
+}
+
+/** Root-only well-known URL (no path suffix), used as the 404 fallback. */
+function buildWellKnownUrlRoot(baseUrl: string, suffix: string): string {
+  return `${new URL(baseUrl).origin}/.well-known/${suffix}`;
+}
+
+function hasPath(baseUrl: string): boolean {
+  return new URL(baseUrl).pathname.replace(/^\/+|\/+$/g, '') !== '';
+}
+
+/**
+ * Fetch a well-known document with the relay's fallback order: path-based
+ * URL first, then root-only URL when the path-based one 404s and the base
+ * URL has a path component. discovery.rs implements no other fallback
+ * (no openid-configuration probe), so neither does this helper.
+ */
+async function fetchWellKnown<T>(baseUrl: string, suffix: string): Promise<T> {
+  const pathUrl = buildWellKnownUrl(baseUrl, suffix);
+  let resp = await fetch(pathUrl, { headers: { accept: 'application/json' } });
+  if (resp.status === 404 && hasPath(baseUrl)) {
+    const rootUrl = buildWellKnownUrlRoot(baseUrl, suffix);
+    resp = await fetch(rootUrl, { headers: { accept: 'application/json' } });
+  }
+  expect(
+    resp.ok,
+    `${suffix} metadata fetch for ${baseUrl} returned ${resp.status}`
+  ).toBe(true);
+  return (await resp.json()) as T;
+}
+
+// --- PKCE helpers mirroring packages/relay/src/oauth/mod.rs ---
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+/** BASE64URL(SHA256(verifier)) from a 32-byte random verifier (S256). */
+async function generatePkceChallenge(): Promise<string> {
+  const verifierBytes = new Uint8Array(32);
+  crypto.getRandomValues(verifierBytes);
+  const verifier = base64UrlEncode(verifierBytes);
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+  return base64UrlEncode(new Uint8Array(digest));
+}
+
+/** 22-char URL-safe base64 state from 16 random bytes. */
+function generateState(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return base64UrlEncode(bytes);
+}
+
+// --- Authorize URL construction mirroring management.rs ---
+
+/** Mirrors `url::form_urlencoded::byte_serialize` (space → '+', `*-._` kept). */
+function formUrlEncode(s: string): string {
+  const bytes = new TextEncoder().encode(s);
+  let out = '';
+  for (const b of bytes) {
+    const c = String.fromCharCode(b);
+    if (/[A-Za-z0-9*\-._]/.test(c)) out += c;
+    else if (c === ' ') out += '+';
+    else out += '%' + b.toString(16).toUpperCase().padStart(2, '0');
+  }
+  return out;
+}
+
+function buildAuthorizeUrl(
+  authorizationEndpoint: string,
+  clientId: string,
+  state: string,
+  codeChallenge: string,
+  scopes: string[]
+): string {
+  let url =
+    `${authorizationEndpoint}?response_type=code` +
+    `&client_id=${formUrlEncode(clientId)}` +
+    `&redirect_uri=${formUrlEncode(REDIRECT_URI)}` +
+    `&state=${formUrlEncode(state)}` +
+    `&code_challenge=${formUrlEncode(codeChallenge)}` +
+    `&code_challenge_method=S256`;
+  if (scopes.length > 0) {
+    url += `&scope=${formUrlEncode(scopes.join(' '))}`;
+  }
+  return url;
+}
+
+/** Build the authorize URL as the relay does and assert it is well-formed. */
+async function assertAuthorizeUrl(
+  entry: OAuthCatalogEntry,
+  authorizationEndpoint: string,
+  clientId: string
+): Promise<void> {
+  const state = generateState();
+  const codeChallenge = await generatePkceChallenge();
+  const authorizeUrl = buildAuthorizeUrl(
+    authorizationEndpoint,
+    clientId,
+    state,
+    codeChallenge,
+    entry.defaultScopes
+  );
+
+  const parsed = new URL(authorizeUrl);
+  expect(parsed.protocol, `${entry.id}: authorize URL must be https`).toBe('https:');
+  expect(
+    authorizeUrl.startsWith(`${authorizationEndpoint}?`),
+    `${entry.id}: authorize URL must be rooted at the authorization endpoint`
+  ).toBe(true);
+  const params = parsed.searchParams;
+  expect(params.get('response_type'), `${entry.id}: response_type`).toBe('code');
+  expect(params.get('client_id'), `${entry.id}: client_id`).toBe(clientId);
+  expect(params.get('redirect_uri'), `${entry.id}: redirect_uri`).toBe(REDIRECT_URI);
+  expect(params.get('state'), `${entry.id}: state`).toBe(state);
+  expect(params.get('code_challenge'), `${entry.id}: code_challenge`).toBe(codeChallenge);
+  expect(params.get('code_challenge_method'), `${entry.id}: code_challenge_method`).toBe('S256');
+  if (entry.defaultScopes.length > 0) {
+    expect(params.get('scope'), `${entry.id}: scope`).toBe(entry.defaultScopes.join(' '));
+  } else {
+    expect(
+      params.has('scope'),
+      `${entry.id}: scope must be omitted when defaultScopes is empty`
+    ).toBe(false);
+  }
+}
+
+// --- Dynamic Client Registration mirroring packages/relay/src/oauth/dcr.rs ---
+
+async function registerClient(
+  entry: OAuthCatalogEntry,
+  registrationEndpoint: string
+): Promise<string> {
+  const resp = await fetch(registrationEndpoint, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', accept: 'application/json' },
+    body: JSON.stringify({
+      client_name: `Endara Relay — ${entry.name}`,
+      redirect_uris: [REDIRECT_URI],
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+    }),
+  });
+  expect(
+    resp.ok,
+    `${entry.id}: DCR at ${registrationEndpoint} returned ${resp.status}`
+  ).toBe(true);
+  const body = (await resp.json()) as { client_id?: string };
+  expect(
+    body.client_id,
+    `${entry.id}: DCR response must contain a non-empty client_id`
+  ).toBeTruthy();
+  return body.client_id as string;
+}
+
+// --- Live tests (network, run on demand with RUN_LIVE_TESTS=1) ---
+
+const discoveryEntries = oauthCatalog.filter((e) => e.supportsDiscovery);
+const nonDiscoveryEntries = oauthCatalog.filter((e) => !e.supportsDiscovery);
+
+describe.skipIf(!RUN_LIVE_TESTS)('live OAuth catalog validation', () => {
+  it.each(discoveryEntries.map((e) => [e.id, e] as [string, OAuthCatalogEntry]))(
+    'discovery entry %s validates end-to-end',
+    async (_id, entry) => {
+      // 1. RFC 9728 protected resource metadata (path → root fallback)
+      const resourceMeta = await fetchWellKnown<ProtectedResourceMetadata>(
+        entry.url,
+        'oauth-protected-resource'
+      );
+      expect(resourceMeta.resource, `${entry.id}: missing resource`).toBeTruthy();
+      const authServerUrl = resourceMeta.authorization_servers?.[0];
+      expect(authServerUrl, `${entry.id}: missing authorization_servers[0]`).toBeTruthy();
+
+      // 2. RFC 8414 authorization server metadata (path → root fallback)
+      const asMeta = await fetchWellKnown<AuthorizationServerMetadata>(
+        authServerUrl!,
+        'oauth-authorization-server'
+      );
+      expect(asMeta.authorization_endpoint, `${entry.id}: missing authorization_endpoint`).toBeTruthy();
+      expect(asMeta.token_endpoint, `${entry.id}: missing token_endpoint`).toBeTruthy();
+      const methods = asMeta.code_challenge_methods_supported ?? [];
+      if (methods.length > 0) {
+        expect(methods, `${entry.id}: S256 PKCE must be supported`).toContain('S256');
+      }
+      expect(
+        !!asMeta.registration_endpoint,
+        `${entry.id}: registration_endpoint presence must match supportsDcr=${entry.supportsDcr}`
+      ).toBe(entry.supportsDcr);
+
+      // 3. Real DCR when supported
+      let clientId = PLACEHOLDER_CLIENT_ID;
+      if (entry.supportsDcr) {
+        clientId = await registerClient(entry, asMeta.registration_endpoint!);
+      }
+
+      // 4. Authorize URL exactly as the relay builds it
+      await assertAuthorizeUrl(entry, asMeta.authorization_endpoint!, clientId);
+    },
+    LIVE_TIMEOUT
+  );
+
+  it.each(nonDiscoveryEntries.map((e) => [e.id, e] as [string, OAuthCatalogEntry]))(
+    'non-discovery entry %s validates end-to-end',
+    async (_id, entry) => {
+      // Convention-based endpoints (management.rs fallback path):
+      // `{oauth_server_url}/authorize` + the catalog's explicit tokenEndpoint.
+      expect(
+        entry.oauthServerUrl,
+        `${entry.id}: non-discovery entry must set oauthServerUrl`
+      ).toBeTruthy();
+      expect(
+        entry.tokenEndpoint,
+        `${entry.id}: non-discovery entry must set tokenEndpoint`
+      ).toBeTruthy();
+      const authorizationEndpoint = `${entry.oauthServerUrl!.replace(/\/+$/g, '')}/authorize`;
+
+      const authResp = await fetch(authorizationEndpoint, { redirect: 'manual' });
+      expect(
+        authResp.status,
+        `${entry.id}: authorize endpoint ${authorizationEndpoint} returned ${authResp.status}`
+      ).not.toBe(404);
+      expect(
+        authResp.status,
+        `${entry.id}: authorize endpoint ${authorizationEndpoint} returned ${authResp.status}`
+      ).toBeLessThan(500);
+
+      const tokenResp = await fetch(entry.tokenEndpoint!, {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: '',
+      });
+      expect(
+        tokenResp.status,
+        `${entry.id}: token endpoint ${entry.tokenEndpoint} returned ${tokenResp.status}`
+      ).toBeLessThan(500);
+
+      await assertAuthorizeUrl(entry, authorizationEndpoint, PLACEHOLDER_CLIENT_ID);
+    },
+    LIVE_TIMEOUT
+  );
+});


### PR DESCRIPTION
Adds CI-runnable live validation for the HTTP and OAuth MCP servers in the desktop catalog, so we catch errors on our end and detect when provider endpoints go stale.

## What

- src/lib/data/oauth-catalog.live.test.ts — RUN_LIVE_TESTS-gated vitest suite validating every oauthCatalog entry end-to-end up to the browser authorize URL: RFC 9728/8414 discovery with path-to-root fallback, real dynamic client registration for supportsDcr entries, and PKCE S256 authorize-URL construction mirroring the relay. GitHub (no discovery) gets reachability checks on its static endpoints; non-DCR providers use a documented placeholder client_id.
- src/lib/catalog-http.live.test.ts — data-driven MCP Streamable HTTP initialize + tools/list over http/sse CATALOG_SERVERS entries with a url. Zero such entries today; the suite picks them up automatically when added.
- src/lib/catalog.ts — optional url field on CatalogServer to support remote entries.
- .github/workflows/catalog-validation.yml — runs the two live suites on a daily cron, manual dispatch, and PRs touching catalog files. No secrets required.

## Verification

- Default npm test: live suites skipped, 763 passed / 35 skipped.
- RUN_LIVE_TESTS=1 run of the two suites: 11/11 green (10 OAuth entries + HTTP placeholder).
- svelte-check 0 errors; workflow validated with yaml-lint and actionlint.