### PR TITLE
fix(overlay): make toast cards clickable in release builds (cursor poller + hit rects)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1445,12 +1445,17 @@ async fn hide_overlay(app: AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+/// Renderer-reported hit rects for the visible overlay cards (viewport /
+/// logical px). Drives the Rust-side cursor poller that toggles the overlay
+/// window's ignore-cursor-events flag — see `overlay::update_hit_rects` for
+/// why a renderer pointer handler cannot do this (click-through deadlock).
 #[tauri::command]
-async fn set_overlay_ignore_cursor_events(app: AppHandle, ignore: bool) -> Result<(), String> {
-    if let Some(w) = app.get_webview_window(overlay::OVERLAY_WINDOW_LABEL) {
-        w.set_ignore_cursor_events(ignore)
-            .map_err(|e| e.to_string())?;
-    }
+async fn set_overlay_hit_rects(
+    app: AppHandle,
+    state: State<'_, overlay::OverlayHitState>,
+    rects: Vec<overlay::HitRect>,
+) -> Result<(), String> {
+    overlay::update_hit_rects(&app, &state, rects);
     Ok(())
 }
 
@@ -2341,6 +2346,7 @@ pub fn run() {
         .manage(pending_update)
         .manage(UpdaterBackoffState::default())
         .manage(overlay::OverlaySubscriberState::default())
+        .manage(overlay::OverlayHitState::default())
         .invoke_handler(tauri::generate_handler![
             start_relay,
             stop_relay,
@@ -2371,7 +2377,7 @@ pub fn run() {
             set_tray_health,
             show_overlay,
             hide_overlay,
-            set_overlay_ignore_cursor_events,
+            set_overlay_hit_rects,
             reposition_overlay,
             subscribe_tool_call_events,
             unsubscribe_tool_call_events,

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -143,6 +143,154 @@ pub struct OverlaySubscriberState {
     pub task: Arc<Mutex<Option<JoinHandle<()>>>>,
 }
 
+// ---- Cursor poller + hit rects ---------------------------------------------
+//
+// Production builds keep the overlay window in `set_ignore_cursor_events(true)`
+// so it never steals input. That makes renderer pointer handlers useless for
+// re-enabling interactivity: a click-through window receives no pointer events
+// from the OS, so `pointerenter` never fires — the classic deadlock. Instead,
+// the renderer reports the visible card rects (`set_overlay_hit_rects`), and a
+// Rust-side poller compares the global cursor position against them, flipping
+// the ignore flag on inside/outside transitions. With no rects there is
+// nothing to hover, so the poller is stopped entirely (zero idle cost).
+
+/// Poll interval for the cursor poller while hit rects are present. Fast
+/// enough that hover feels immediate, slow enough to be negligible CPU.
+const HIT_RECT_POLL_INTERVAL: Duration = Duration::from_millis(90);
+
+/// Axis-aligned card hit rect in overlay-window viewport coordinates
+/// (CSS / logical pixels), as reported by the renderer. Mirrors the
+/// `HitRect` type in `src/lib/overlay/overlay-helpers.ts`.
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
+pub struct HitRect {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+}
+
+impl HitRect {
+    /// Half-open containment check (`[x, x+w) × [y, y+h)`).
+    pub fn contains(&self, px: f64, py: f64) -> bool {
+        px >= self.x && px < self.x + self.width && py >= self.y && py < self.y + self.height
+    }
+}
+
+/// True when any rect contains the point.
+pub fn any_rect_contains(rects: &[HitRect], x: f64, y: f64) -> bool {
+    rects.iter().any(|r| r.contains(x, y))
+}
+
+/// Convert a global cursor position (physical pixels) into the overlay
+/// window's viewport coordinate space (logical / CSS pixels) so it can be
+/// compared against renderer-reported `getBoundingClientRect` values. The
+/// overlay window is undecorated, so its outer position IS the viewport
+/// origin. A non-positive scale factor (defensive; never expected from
+/// Tauri) falls back to 1.0 rather than dividing by zero.
+pub fn cursor_to_viewport(
+    cursor: PhysicalPosition<f64>,
+    window_pos: PhysicalPosition<i32>,
+    scale_factor: f64,
+) -> (f64, f64) {
+    let scale = if scale_factor > 0.0 {
+        scale_factor
+    } else {
+        1.0
+    };
+    (
+        (cursor.x - window_pos.x as f64) / scale,
+        (cursor.y - window_pos.y as f64) / scale,
+    )
+}
+
+/// Tauri-managed state for the cursor poller. `rects` is shared with the
+/// running poller task (refreshed in place on every renderer report);
+/// `poller` holds the task handle so an empty report can abort it.
+#[derive(Default)]
+pub struct OverlayHitState {
+    rects: Arc<std::sync::Mutex<Vec<HitRect>>>,
+    poller: std::sync::Mutex<Option<JoinHandle<()>>>,
+}
+
+/// Apply a renderer hit-rect report: store the rects, then start or stop the
+/// poller as needed. Empty report → abort the poller and restore
+/// click-through (covers "last card dismissed while hovered"). Non-empty →
+/// ensure exactly one poller task is running.
+///
+/// Debug builds are a no-op: `build_overlay_window` never enables
+/// click-through there (the window stays fully interactive for devtools), so
+/// a poller toggling the ignore flag would only break that.
+pub fn update_hit_rects(app: &AppHandle, state: &OverlayHitState, rects: Vec<HitRect>) {
+    if cfg!(debug_assertions) {
+        return;
+    }
+    let empty = rects.is_empty();
+    *state.rects.lock().expect("hit-rect mutex poisoned") = rects;
+
+    let mut poller = state.poller.lock().expect("poller mutex poisoned");
+    if empty {
+        if let Some(task) = poller.take() {
+            task.abort();
+        }
+        // The aborted poller may have left the window interactive (cursor
+        // was inside a card when it disappeared) — restore click-through.
+        if let Some(w) = app.get_webview_window(OVERLAY_WINDOW_LABEL) {
+            if let Err(e) = w.set_ignore_cursor_events(true) {
+                log::warn!("[overlay] set_ignore_cursor_events(true) on idle failed: {e}");
+            }
+        }
+        return;
+    }
+
+    let running = poller.as_ref().map(|t| !t.is_finished()).unwrap_or(false);
+    if running {
+        return;
+    }
+    let app = app.clone();
+    let rects = Arc::clone(&state.rects);
+    *poller = Some(tokio::spawn(async move {
+        cursor_poll_loop(app, rects).await;
+    }));
+}
+
+/// Poll the global cursor position against the shared hit rects, toggling
+/// the overlay window's ignore-cursor-events flag on inside/outside
+/// transitions only (the underlying OS call is not free). Exits when the
+/// overlay window is gone (overlay disabled); `update_hit_rects` aborts it
+/// when the rect list empties.
+async fn cursor_poll_loop(app: AppHandle, rects: Arc<std::sync::Mutex<Vec<HitRect>>>) {
+    let mut hovering = false;
+    loop {
+        tokio::time::sleep(HIT_RECT_POLL_INTERVAL).await;
+        let Some(window) = app.get_webview_window(OVERLAY_WINDOW_LABEL) else {
+            return;
+        };
+        // `cursor_position()` is global/physical; combine with the window's
+        // position + scale factor to land in the renderer's coordinate
+        // space. Any error (e.g. cursor query unsupported mid-teardown)
+        // counts as "outside" so the window fails safe into click-through.
+        let inside = match (window.cursor_position(), window.outer_position()) {
+            (Ok(cursor), Ok(pos)) => {
+                let scale = window.scale_factor().unwrap_or(1.0);
+                let (x, y) = cursor_to_viewport(cursor, pos, scale);
+                let rects = rects.lock().expect("hit-rect mutex poisoned");
+                any_rect_contains(&rects, x, y)
+            }
+            _ => false,
+        };
+        if inside != hovering {
+            if let Err(e) = window.set_ignore_cursor_events(!inside) {
+                log::warn!(
+                    "[overlay] set_ignore_cursor_events({}) failed: {e}",
+                    !inside
+                );
+                continue;
+            }
+            hovering = inside;
+        }
+    }
+}
+
 /// Resolve the overlay's effective settings on startup, writing migration
 /// state to disk on first run / first upgrade.
 ///
@@ -481,13 +629,13 @@ pub fn build_overlay_window(
         }
     }
 
-    // Click-through by default — Phase 4 flips this per-card via the
-    // `overlayPointerEnter`/`overlayPointerLeave` actions wired in
-    // `OverlayApp.svelte`. In debug builds we skip the global
-    // click-through so the overlay window is fully interactive and
-    // right-click → Inspect works from devtools; production builds keep
-    // the original click-through behaviour so the overlay never steals
-    // input from the user's other windows.
+    // Click-through by default — the Rust-side cursor poller (see
+    // `update_hit_rects` / `cursor_poll_loop` above) flips this while the
+    // global cursor is over a renderer-reported card rect. In debug builds
+    // we skip the global click-through so the overlay window is fully
+    // interactive and right-click → Inspect works from devtools; production
+    // builds keep the original click-through behaviour so the overlay never
+    // steals input from the user's other windows.
     if cfg!(debug_assertions) {
         log::info!(
             target: "overlay",
@@ -801,6 +949,92 @@ mod tests {
         );
         // Width at scale 2.0 = 800 px. Right edge of secondary = 1920+2560 = 4480.
         assert_eq!(pos.x, 4480 - 800);
+    }
+
+    #[test]
+    fn hit_rect_contains_inside_and_edges() {
+        let r = HitRect {
+            x: 20.0,
+            y: 100.0,
+            width: 340.0,
+            height: 72.0,
+        };
+        assert!(r.contains(20.0, 100.0), "top-left corner is inclusive");
+        assert!(r.contains(189.0, 135.0), "interior point");
+        assert!(!r.contains(360.0, 135.0), "right edge is exclusive");
+        assert!(!r.contains(189.0, 172.0), "bottom edge is exclusive");
+        assert!(!r.contains(19.9, 135.0), "left of rect");
+        assert!(!r.contains(189.0, 99.9), "above rect");
+    }
+
+    #[test]
+    fn any_rect_contains_checks_all_rects() {
+        let rects = [
+            HitRect {
+                x: 0.0,
+                y: 0.0,
+                width: 10.0,
+                height: 10.0,
+            },
+            HitRect {
+                x: 100.0,
+                y: 100.0,
+                width: 10.0,
+                height: 10.0,
+            },
+        ];
+        assert!(any_rect_contains(&rects, 5.0, 5.0));
+        assert!(any_rect_contains(&rects, 105.0, 105.0));
+        assert!(!any_rect_contains(&rects, 50.0, 50.0));
+        assert!(!any_rect_contains(&[], 5.0, 5.0));
+    }
+
+    #[test]
+    fn cursor_to_viewport_translates_and_scales() {
+        // Window at physical (1520, 216) on a 2x display; cursor at
+        // physical (1560, 416) → viewport logical (20, 100).
+        let (x, y) = cursor_to_viewport(
+            PhysicalPosition::new(1560.0f64, 416.0f64),
+            PhysicalPosition::new(1520i32, 216i32),
+            2.0,
+        );
+        assert_eq!(x, 20.0);
+        assert_eq!(y, 100.0);
+    }
+
+    #[test]
+    fn cursor_to_viewport_identity_at_scale_one() {
+        let (x, y) = cursor_to_viewport(
+            PhysicalPosition::new(100.0f64, 50.0f64),
+            PhysicalPosition::new(0i32, 0i32),
+            1.0,
+        );
+        assert_eq!((x, y), (100.0, 50.0));
+    }
+
+    #[test]
+    fn cursor_to_viewport_guards_non_positive_scale() {
+        let (x, y) = cursor_to_viewport(
+            PhysicalPosition::new(10.0f64, 10.0f64),
+            PhysicalPosition::new(0i32, 0i32),
+            0.0,
+        );
+        assert_eq!((x, y), (10.0, 10.0));
+    }
+
+    #[test]
+    fn hit_rect_deserializes_from_renderer_shape() {
+        let json = r#"{"x":20.5,"y":100.0,"width":340.0,"height":72.25}"#;
+        let r: HitRect = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            r,
+            HitRect {
+                x: 20.5,
+                y: 100.0,
+                width: 340.0,
+                height: 72.25,
+            }
+        );
     }
 
     #[test]

--- a/src/lib/overlay/OverlayApp.svelte
+++ b/src/lib/overlay/OverlayApp.svelte
@@ -4,8 +4,13 @@
     2. Mirror the main window's theme onto this window's
        `document.documentElement` via the shared `theme` store + matchMedia.
     3. Render the toast feed.
-    4. Toggle the overlay's ignore-cursor-events flag on pointer enter/leave
-       so the feed becomes interactive while hovered, click-through otherwise.
+
+  Click-through is owned by the Rust-side cursor poller: `ToastFeed` reports
+  the visible card hit rects via `set_overlay_hit_rects`, and Rust toggles
+  the window's ignore-cursor-events flag when the global cursor enters /
+  leaves a card. Renderer pointer handlers cannot do this — a click-through
+  window receives no pointer events from the OS, so `pointerenter` would
+  never fire (the production deadlock this design fixes).
 -->
 <script lang="ts">
   import { onMount } from 'svelte';
@@ -20,16 +25,12 @@
     overlaySettings,
     subscribeOverlaySettingsChanges,
   } from './overlaySettingsStore';
-  import { overlayPointerEnter, overlayPointerLeave } from './overlay-actions';
   import ToastFeed from './ToastFeed.svelte';
   import './overlay.css';
 
-  // Pointer enter/leave toggle the Tauri ignore-cursor-events flag so
-  // the feed becomes interactive while hovered (clicking a card focuses
-  // the matching log row in the main window) and click-through
-  // otherwise. The per-card dismiss timer is intentionally NOT paused
-  // on hover — each card's countdown runs to completion regardless of
-  // cursor position.
+  // The per-card dismiss timer is intentionally NOT paused on hover —
+  // each card's countdown runs to completion regardless of cursor
+  // position.
 
   // One store instance per overlay-window lifetime. Seed with the persisted
   // defaults so the first render uses the correct dismiss timer + visible
@@ -99,12 +100,7 @@
   <title>Endara Overlay</title>
 </svelte:head>
 
-<div
-  class="overlay-root"
-  onpointerenter={() => { void overlayPointerEnter(); }}
-  onpointerleave={() => { void overlayPointerLeave(); }}
-  role="presentation"
->
+<div class="overlay-root">
   <ToastFeed
     {store}
     position={$overlaySettings.position}

--- a/src/lib/overlay/ToastFeed.svelte
+++ b/src/lib/overlay/ToastFeed.svelte
@@ -7,10 +7,12 @@
 <script lang="ts">
   import type { ToastStore } from './toastStore';
   import {
+    collectHitRects,
     hiddenGroupCount,
     visibleGroups,
     type OverlayPosition,
   } from './overlay-helpers';
+  import { reportOverlayHitRects } from './overlay-actions';
   import OverlayCard from './OverlayCard.svelte';
   import { fade, fly } from 'svelte/transition';
   import { quintOut } from 'svelte/easing';
@@ -72,6 +74,54 @@
   const outDuration = reducedMotion ? 100 : 200;
   const inX = $derived(reducedMotion ? 0 : slideDir * slidePx);
   const outX = $derived(reducedMotion ? 0 : slideDir * slidePx);
+
+  // ---- Hit-rect reporting --------------------------------------------------
+  // Measure the visible card slots and report their bounding rects to the
+  // Rust-side cursor poller (`set_overlay_hit_rects`). The poller — not a
+  // renderer pointer handler — toggles the window's ignore-cursor-events
+  // flag, because a click-through window receives no pointer events from
+  // the OS. An empty report idles the poller and restores click-through.
+  //
+  // Two-step measurement: a rAF captures the new layout as soon as it
+  // exists, and a delayed re-measure after the slide/fade transitions have
+  // settled (`inDuration` + margin) captures the final card positions (the
+  // feed-level fly translates the whole stack horizontally while animating).
+  let feedEl: HTMLElement | null = $state(null);
+  let measureRaf = 0;
+  let settleTimer: ReturnType<typeof setTimeout> | undefined;
+
+  function measureAndReport() {
+    const slots = feedEl ? feedEl.querySelectorAll('.tf-card-slot') : [];
+    void reportOverlayHitRects(collectHitRects(slots));
+  }
+
+  function scheduleHitRectMeasure() {
+    if (typeof window === 'undefined') return;
+    cancelAnimationFrame(measureRaf);
+    measureRaf = requestAnimationFrame(measureAndReport);
+    clearTimeout(settleTimer);
+    settleTimer = setTimeout(measureAndReport, inDuration + 120);
+  }
+
+  // Re-measure whenever the visible card list (or the "+N earlier" row)
+  // changes. The settle-timer pass also covers the 1 → 0 case where the
+  // out-transition keeps slot elements in the DOM briefly.
+  $effect(() => {
+    void visible;
+    void hidden;
+    scheduleHitRectMeasure();
+  });
+
+  // Re-measure on window resize (monitor / scale changes move the cards).
+  $effect(() => {
+    const onResize = () => scheduleHitRectMeasure();
+    window.addEventListener('resize', onResize);
+    return () => {
+      window.removeEventListener('resize', onResize);
+      cancelAnimationFrame(measureRaf);
+      clearTimeout(settleTimer);
+    };
+  });
 </script>
 
 <div
@@ -79,6 +129,7 @@
   data-position={position}
   data-testid="toast-feed"
   style:--tf-card-w="{cardWidth}px"
+  bind:this={feedEl}
 >
   {#if visible.length > 0}
     <div

--- a/src/lib/overlay/ToastFeed.test.ts
+++ b/src/lib/overlay/ToastFeed.test.ts
@@ -376,13 +376,27 @@ describe('ToastFeed — per-card dismiss bar plumbing', () => {
     expect(src).toMatch(/style:animation-duration="\{dismissDurationMs\}ms"/);
   });
 
-  it('OverlayApp.svelte does NOT call pauseDismiss/resumeDismiss on pointer enter/leave', async () => {
+  it('OverlayApp.svelte has no hover-pause or renderer pointer handlers', async () => {
     const src = (await import('./OverlayApp.svelte?raw')).default as string;
     expect(src).not.toMatch(/pauseDismiss/);
     expect(src).not.toMatch(/resumeDismiss/);
-    // Pointer enter/leave only toggle the Tauri ignore-cursor-events flag.
-    expect(src).toMatch(/overlayPointerEnter/);
-    expect(src).toMatch(/overlayPointerLeave/);
+    // Click-through toggling is owned by the Rust cursor poller, not
+    // renderer pointer handlers (which never fire on a click-through
+    // window — the production deadlock).
+    expect(src).not.toMatch(/onpointerenter/);
+    expect(src).not.toMatch(/onpointerleave/);
+    expect(src).not.toMatch(/overlayPointer/);
+  });
+
+  it('ToastFeed.svelte reports hit rects to the Rust cursor poller', async () => {
+    const src = (await import('./ToastFeed.svelte?raw')).default as string;
+    // Measures the card slots and pipes them through the action helper.
+    expect(src).toMatch(/reportOverlayHitRects/);
+    expect(src).toMatch(/collectHitRects/);
+    expect(src).toMatch(/\.tf-card-slot/);
+    // Re-measures when the visible cards change and on window resize.
+    expect(src).toMatch(/\$effect/);
+    expect(src).toMatch(/addEventListener\('resize'/);
   });
 
   it('overlay.css ships @keyframes tfDismissFill and per-card .tf-dismiss-bar/.tf-dismiss-fill rules', async () => {

--- a/src/lib/overlay/overlay-actions.test.ts
+++ b/src/lib/overlay/overlay-actions.test.ts
@@ -1,14 +1,10 @@
 // Tests for the action helpers extracted from `OverlayCard.svelte` and
-// `OverlayApp.svelte`. These verify the exact Tauri commands the overlay
-// invokes on user input, since the components themselves can't be mounted in
-// the Node vitest env.
+// `ToastFeed.svelte`. These verify the exact Tauri commands the overlay
+// invokes, since the components themselves can't be mounted in the Node
+// vitest env.
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { invoke } from '@tauri-apps/api/core';
-import {
-  cardClick,
-  overlayPointerEnter,
-  overlayPointerLeave,
-} from './overlay-actions';
+import { cardClick, reportOverlayHitRects } from './overlay-actions';
 import type { ToolCallGroup, ToolCallRequest } from './toastStore';
 
 function req(over: Partial<ToolCallRequest> = {}): ToolCallRequest {
@@ -76,25 +72,22 @@ describe('cardClick', () => {
   });
 });
 
-describe('overlay pointer cursor toggles', () => {
+describe('reportOverlayHitRects', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('overlayPointerEnter sets ignore_cursor_events(false)', async () => {
+  it('invokes set_overlay_hit_rects with the measured rects', async () => {
     const mockInvoke = vi.mocked(invoke);
     mockInvoke.mockResolvedValue(undefined);
-    await overlayPointerEnter();
-    expect(mockInvoke).toHaveBeenCalledWith('set_overlay_ignore_cursor_events', {
-      ignore: false,
-    });
+    const rects = [{ x: 20, y: 100, width: 340, height: 72 }];
+    await reportOverlayHitRects(rects);
+    expect(mockInvoke).toHaveBeenCalledWith('set_overlay_hit_rects', { rects });
   });
 
-  it('overlayPointerLeave sets ignore_cursor_events(true)', async () => {
+  it('reports an empty list so the Rust poller can idle', async () => {
     const mockInvoke = vi.mocked(invoke);
     mockInvoke.mockResolvedValue(undefined);
-    await overlayPointerLeave();
-    expect(mockInvoke).toHaveBeenCalledWith('set_overlay_ignore_cursor_events', {
-      ignore: true,
-    });
+    await reportOverlayHitRects([]);
+    expect(mockInvoke).toHaveBeenCalledWith('set_overlay_hit_rects', { rects: [] });
   });
 
   it('swallows errors from invoke so a flaky window command never breaks the UI', async () => {
@@ -102,9 +95,8 @@ describe('overlay pointer cursor toggles', () => {
     mockInvoke.mockRejectedValue(new Error('boom'));
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    await expect(overlayPointerEnter()).resolves.toBeUndefined();
-    await expect(overlayPointerLeave()).resolves.toBeUndefined();
-    expect(warnSpy).toHaveBeenCalledTimes(2);
+    await expect(reportOverlayHitRects([])).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
     warnSpy.mockRestore();
   });
 });

--- a/src/lib/overlay/overlay-actions.ts
+++ b/src/lib/overlay/overlay-actions.ts
@@ -1,10 +1,10 @@
-// Thin action helpers extracted from `OverlayCard.svelte` / `OverlayApp.svelte`
+// Thin action helpers extracted from `OverlayCard.svelte` / `ToastFeed.svelte`
 // so they can be exercised in the Node test env (vitest runs without jsdom).
-// These mirror exactly what the corresponding components run on user input.
+// These mirror exactly what the corresponding components run.
 
 import { invoke } from '@tauri-apps/api/core';
 import type { ToolCallGroup } from './toastStore';
-import { canFocusLog, latestRequest } from './overlay-helpers';
+import { canFocusLog, latestRequest, type HitRect } from './overlay-helpers';
 import { focusLogForRequest } from './focusLog';
 
 /**
@@ -18,20 +18,17 @@ export async function cardClick(group: ToolCallGroup): Promise<void> {
   await focusLogForRequest(last?.jsonrpcId ?? null);
 }
 
-/** Overlay window pointer enter — re-enable cursor events on the host window. */
-export async function overlayPointerEnter(): Promise<void> {
+/**
+ * Report the visible card hit rects to Rust. The Rust-side cursor poller
+ * (see `update_hit_rects` in `src-tauri/src/overlay.rs`) polls the global
+ * cursor position while rects are non-empty and toggles the window's
+ * ignore-cursor-events flag on inside/outside transitions. An empty list
+ * stops the poller and restores click-through.
+ */
+export async function reportOverlayHitRects(rects: HitRect[]): Promise<void> {
   try {
-    await invoke('set_overlay_ignore_cursor_events', { ignore: false });
+    await invoke('set_overlay_hit_rects', { rects });
   } catch (e) {
-    console.warn('[overlay] set_overlay_ignore_cursor_events(false) failed:', e);
-  }
-}
-
-/** Overlay window pointer leave — restore click-through. */
-export async function overlayPointerLeave(): Promise<void> {
-  try {
-    await invoke('set_overlay_ignore_cursor_events', { ignore: true });
-  } catch (e) {
-    console.warn('[overlay] set_overlay_ignore_cursor_events(true) failed:', e);
+    console.warn('[overlay] set_overlay_hit_rects failed:', e);
   }
 }

--- a/src/lib/overlay/overlay-helpers.test.ts
+++ b/src/lib/overlay/overlay-helpers.test.ts
@@ -3,6 +3,7 @@ import {
   averageDurationMs,
   callerLabel,
   canFocusLog,
+  collectHitRects,
   groupVisualState,
   hiddenGroupCount,
   hintsForAnnotations,
@@ -185,5 +186,42 @@ describe('visibleGroups / hiddenGroupCount', () => {
   it('returns a copy', () => {
     const out = visibleGroups(all, 100);
     expect(out).not.toBe(all);
+  });
+});
+
+describe('collectHitRects', () => {
+  const el = (x: number, y: number, width: number, height: number) => ({
+    getBoundingClientRect: () => ({ x, y, width, height }),
+  });
+
+  it('maps elements to their bounding rects in order', () => {
+    expect(collectHitRects([el(20, 100, 340, 72), el(20, 184, 340, 64)])).toEqual([
+      { x: 20, y: 100, width: 340, height: 72 },
+      { x: 20, y: 184, width: 340, height: 64 },
+    ]);
+  });
+
+  it('returns an empty list for no elements (poller idles)', () => {
+    expect(collectHitRects([])).toEqual([]);
+  });
+
+  it('skips null/undefined entries', () => {
+    expect(collectHitRects([null, el(1, 2, 3, 4), undefined])).toEqual([
+      { x: 1, y: 2, width: 3, height: 4 },
+    ]);
+  });
+
+  it('drops zero-area rects (collapsed / not yet laid out elements)', () => {
+    expect(
+      collectHitRects([el(0, 0, 0, 50), el(0, 0, 50, 0), el(5, 5, 10, 10)]),
+    ).toEqual([{ x: 5, y: 5, width: 10, height: 10 }]);
+  });
+
+  it('accepts any iterable (e.g. a NodeList-like)', () => {
+    function* gen() {
+      yield el(0, 0, 1, 1);
+      yield el(2, 2, 1, 1);
+    }
+    expect(collectHitRects(gen())).toHaveLength(2);
   });
 });

--- a/src/lib/overlay/overlay-helpers.ts
+++ b/src/lib/overlay/overlay-helpers.ts
@@ -83,6 +83,34 @@ export function isDestructive(g: ToolCallGroup): boolean {
   return g.annotations?.destructive === true;
 }
 
+/**
+ * Axis-aligned card hit rect in overlay-window viewport coordinates (CSS /
+ * logical pixels). Mirrors the `HitRect` struct in `src-tauri/src/overlay.rs`
+ * consumed by the Rust-side cursor poller.
+ */
+export type HitRect = { x: number; y: number; width: number; height: number };
+
+/** Minimal element shape needed to measure a hit rect (testable without jsdom). */
+type Measurable = {
+  getBoundingClientRect(): { x: number; y: number; width: number; height: number };
+};
+
+/**
+ * Measure the bounding rects of the visible card elements. Zero-area rects
+ * (display:none, not yet laid out) are dropped so the Rust poller never
+ * treats a collapsed element as a hover target.
+ */
+export function collectHitRects(elements: Iterable<Measurable | null | undefined>): HitRect[] {
+  const out: HitRect[] = [];
+  for (const el of elements) {
+    if (!el) continue;
+    const r = el.getBoundingClientRect();
+    if (!(r.width > 0) || !(r.height > 0)) continue;
+    out.push({ x: r.x, y: r.y, width: r.width, height: r.height });
+  }
+  return out;
+}
+
 /** Valid overlay positions; the route default is `bottom-right`. */
 export type OverlayPosition = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 


### PR DESCRIPTION
## Problem

Release builds set the overlay window click-through (set_ignore_cursor_events(true)) at creation. The only path that re-enabled interactivity was a pointerenter handler inside the overlay webview — but a click-through window receives no pointer events from the OS, so it could never fire. Result: overlay tool-call cards were permanently unclickable in every installed build, and clicks passed through to the window beneath. Debug builds skip click-through entirely, which is why this was never caught in dev.

## Fix

- New set_overlay_hit_rects Tauri command: ToastFeed measures the bounding rects of visible cards (re-measured on card-list changes and resize) and reports them to Rust; reports an empty list when the feed is empty.
- Rust-side cursor poller (~90ms tick) runs only while hit rects are non-empty and the overlay window exists; it converts the global cursor position to overlay-viewport logical coordinates (outer_position + scale_factor, including non-1x scales) and toggles set_ignore_cursor_events only on enter/leave transitions.
- Per-card rects mean the empty area of the overlay strip never steals clicks from underlying apps.
- Removed the now-dead overlayPointerEnter/overlayPointerLeave handlers.
- Debug-build behavior unchanged (window stays fully interactive for devtools).

Failure/abort races converge fail-safe to click-through.

## Testing

- svelte-check: 0 errors; vitest: 822 passed (incl. new collectHitRects coverage)
- cargo fmt --check, cargo clippy -- -D warnings: clean; cargo test: 113 passed (incl. point-in-rect + cursor-to-viewport conversion at 2x scale and degenerate-scale guard)
- Outstanding: manual release-build smoke test (click a card while another app has focus)