### PR TITLE
feat: isolation toggle, container badges, and container metrics for stdio endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@endara/desktop",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@endara/desktop",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1995,6 +1995,11 @@ struct EndpointConfig {
     /// Mirrors `server_type_override` from `config.toml`; absent when no
     /// override is configured for this endpoint.
     server_type_override: Option<String>,
+    /// Mirrors `isolation` from `config.toml` (`"container"` or `"none"`);
+    /// absent for legacy endpoints that never set it (= direct spawn). The
+    /// UI passes it through on update so the relay's PUT — which rebuilds
+    /// the whole endpoint config — doesn't drop the stored value.
+    isolation: Option<String>,
 }
 
 /// Path to the DCR credentials file for an endpoint, e.g.
@@ -2082,6 +2087,11 @@ async fn get_endpoint_config(name: String) -> Result<EndpointConfig, String> {
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string())
                     .filter(|s| !s.is_empty());
+                let isolation = ep
+                    .get("isolation")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+                    .filter(|s| !s.is_empty());
 
                 return Ok(EndpointConfig {
                     name: name.clone(),
@@ -2099,6 +2109,7 @@ async fn get_endpoint_config(name: String) -> Result<EndpointConfig, String> {
                     scopes,
                     token_endpoint,
                     server_type_override,
+                    isolation,
                 });
             }
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2000,6 +2000,11 @@ struct EndpointConfig {
     /// UI passes it through on update so the relay's PUT — which rebuilds
     /// the whole endpoint config — doesn't drop the stored value.
     isolation: Option<String>,
+    /// Mirrors `mounts` from `config.toml` for containerized stdio endpoints
+    /// (verbatim docker `-v` `"host:container"` pairs); absent when none are
+    /// configured. The UI seeds its mount editor from this and passes the
+    /// array back on update so the relay's PUT doesn't drop stored mounts.
+    mounts: Option<Vec<String>>,
 }
 
 /// Path to the DCR credentials file for an endpoint, e.g.
@@ -2092,6 +2097,15 @@ async fn get_endpoint_config(name: String) -> Result<EndpointConfig, String> {
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string())
                     .filter(|s| !s.is_empty());
+                let mounts = ep
+                    .get("mounts")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                            .collect::<Vec<_>>()
+                    })
+                    .filter(|m| !m.is_empty());
 
                 return Ok(EndpointConfig {
                     name: name.clone(),
@@ -2110,6 +2124,7 @@ async fn get_endpoint_config(name: String) -> Result<EndpointConfig, String> {
                     token_endpoint,
                     server_type_override,
                     isolation,
+                    mounts,
                 });
             }
         }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -140,6 +140,12 @@ export interface AddEndpointParams {
    * digits, `-`, `_` only — empty/absent leaves the field unset.
    */
   server_type_override?: string;
+  /**
+   * Isolation mode for stdio endpoints. The desktop always sends an explicit
+   * value when creating a stdio endpoint — `"container"` or `"none"`, never
+   * omitted — because the relay treats an absent field as direct spawn.
+   */
+  isolation?: 'container' | 'none';
 }
 
 /**
@@ -252,6 +258,11 @@ export interface EndpointConfig {
    * `server_type_override`. Absent when no override is configured.
    */
   server_type_override?: string;
+  /**
+   * Isolation mode stored for stdio endpoints (`"container"` or `"none"`).
+   * Absent for legacy endpoints that never set it (= direct spawn).
+   */
+  isolation?: string;
 }
 
 export async function getEndpointConfig(name: string): Promise<EndpointConfig> {
@@ -285,6 +296,13 @@ export interface UpdateEndpointParams {
    * string clears the override; absent leaves the stored value unchanged.
    */
   server_type_override?: string;
+  /**
+   * Isolation mode for stdio endpoints. The relay's PUT handler rebuilds the
+   * whole endpoint config from the request body, so updates must pass the
+   * stored value through or a containerized endpoint silently reverts to
+   * direct spawn on save.
+   */
+  isolation?: string;
 }
 
 export async function startOAuth(name: string): Promise<OAuthStartResult> {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -146,6 +146,12 @@ export interface AddEndpointParams {
    * omitted — because the relay treats an absent field as direct spawn.
    */
   isolation?: 'container' | 'none';
+  /**
+   * Bind mounts for containerized stdio endpoints. Each entry is a verbatim
+   * docker `-v` `"host_path:container_path"` pair (relative host paths are
+   * resolved by the relay). Omitted when empty.
+   */
+  mounts?: string[];
 }
 
 /**
@@ -263,6 +269,11 @@ export interface EndpointConfig {
    * Absent for legacy endpoints that never set it (= direct spawn).
    */
   isolation?: string;
+  /**
+   * Bind mounts stored for containerized stdio endpoints, as verbatim docker
+   * `-v` `"host_path:container_path"` pairs. Absent when none are configured.
+   */
+  mounts?: string[];
 }
 
 export async function getEndpointConfig(name: string): Promise<EndpointConfig> {
@@ -303,6 +314,13 @@ export interface UpdateEndpointParams {
    * direct spawn on save.
    */
   isolation?: string;
+  /**
+   * Bind mounts for containerized stdio endpoints, as verbatim docker `-v`
+   * `"host_path:container_path"` pairs. The relay's PUT rebuilds the whole
+   * endpoint config from the body, so the desktop always sends an explicit
+   * array (possibly empty, to clear) for stdio endpoints.
+   */
+  mounts?: string[];
 }
 
 export async function startOAuth(name: string): Promise<OAuthStartResult> {

--- a/src/lib/catalog.ts
+++ b/src/lib/catalog.ts
@@ -23,6 +23,14 @@ export interface CatalogServer {
    * digits, `-`, `_` only (mirrors the relay's `sanitize_server_name`).
    */
   serverTypeOverride?: string;
+  /**
+   * Set to `false` for entries that must not run in a container. The add flow
+   * shows a "Not containerized" badge, hides the isolation toggle, and writes
+   * `isolation = "none"`. Absent means the entry containerizes by default.
+   */
+  containerizable?: false;
+  /** Short user-facing reason shown alongside the "Not containerized" badge. */
+  containerNote?: string;
 }
 
 export const CATALOG_SERVERS: CatalogServer[] = [
@@ -37,6 +45,8 @@ export const CATALOG_SERVERS: CatalogServer[] = [
     args: ['-y', '@modelcontextprotocol/server-filesystem'],
     envVars: [],
     userArgs: [{ label: 'Allowed directory', placeholder: '/Users/you/projects', type: 'directory' }],
+    containerizable: false,
+    containerNote: 'Needs direct access to your local filesystem.',
   },
   {
     id: 'github',
@@ -87,6 +97,8 @@ export const CATALOG_SERVERS: CatalogServer[] = [
     command: 'npx',
     args: ['-y', '@modelcontextprotocol/server-puppeteer'],
     envVars: [],
+    containerizable: false,
+    containerNote: 'Needs a host browser (Chromium) that the container image does not include.',
   },
   {
     id: 'memory',
@@ -98,6 +110,8 @@ export const CATALOG_SERVERS: CatalogServer[] = [
     command: 'npx',
     args: ['-y', '@modelcontextprotocol/server-memory'],
     envVars: [],
+    containerizable: false,
+    containerNote: 'Stores its knowledge graph in a file that would be lost when the container restarts.',
   },
   {
     id: 'sequential-thinking',

--- a/src/lib/components/AddEndpointModal.svelte
+++ b/src/lib/components/AddEndpointModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { addEndpoint, getEndpoints, testConnection, oauthSetup, oauthSetupStatus, oauthSetupCredentials, oauthSetupCommit, oauthSetupCancel, reloadConfig, type AddEndpointParams, type TestConnectionParams, type OAuthSetupParams } from '$lib/api';
+  import { addEndpoint, getEndpoints, getStatus, testConnection, oauthSetup, oauthSetupStatus, oauthSetupCredentials, oauthSetupCommit, oauthSetupCancel, reloadConfig, type AddEndpointParams, type TestConnectionParams, type OAuthSetupParams } from '$lib/api';
   import { endpoints, selectedEndpoint } from '$lib/stores';
   import { toast } from 'svelte-sonner';
   import { CATALOG_SERVERS, type CatalogServer } from '$lib/catalog';
@@ -11,6 +11,7 @@
     validateAddEndpointForm,
     firstAddEndpointFieldError,
     computeAddEndpointIsDirty,
+    resolveIsolation,
     type AddEndpointFieldErrors,
     type AddEndpointFormSnapshot,
   } from './add-endpoint-helpers';
@@ -92,6 +93,21 @@
   // value at ≤64 chars, but pasted content can occasionally bypass that on
   // some platforms. Surface a hint if it ever happens.
   let serverTypeOverrideTooLong = $derived(serverTypeOverride.length > 64);
+  // Isolation toggle for stdio endpoints — default ON so new endpoints
+  // containerize by default. The submit path always sends an explicit
+  // "container"/"none" value (see resolveIsolation).
+  let isolationEnabled = $state(true);
+  // True when the active catalog entry is flagged not-containerizable —
+  // the toggle is replaced by a "Not containerized" notice and the endpoint
+  // is created with isolation = "none".
+  let catalogNotContainerizable = $derived.by(() => selectedCatalog?.containerizable === false);
+  // null = unknown (older relay or status fetch failed); only an explicit
+  // `false` from the relay drives the "no runtime" inline notice.
+  let containerRuntimeAvailable: boolean | null = $state(null);
+  let runtimeMissing = $derived(containerRuntimeAvailable === false);
+  getStatus()
+    .then((s) => { containerRuntimeAvailable = s.container_runtime_available ?? null; })
+    .catch(() => { /* relay unreachable — leave runtime availability unknown */ });
 
   // Captured at the moment `step` transitions to `'configure'` so any
   // catalog pre-fills (name, command, args, etc.) become the dirty-check
@@ -119,6 +135,7 @@
       clientSecret,
       scopes,
       serverTypeOverride,
+      isolationEnabled,
     });
   });
   let showDiscardConfirm = $state(false);
@@ -140,6 +157,7 @@
       clientSecret,
       scopes,
       serverTypeOverride,
+      isolationEnabled,
     };
   }
 
@@ -228,6 +246,7 @@
     dcrClientSecret = '';
     serverTypeOverride = service.serverTypeOverride ?? '';
     serverTypeOverrideHasDefault = Boolean(service.serverTypeOverride);
+    isolationEnabled = true;
     error = '';
     fieldErrors = {};
     originalSnapshot = captureSnapshot();
@@ -256,6 +275,7 @@
     showingDcrFallback = false;
     serverTypeOverride = server.serverTypeOverride ?? '';
     serverTypeOverrideHasDefault = Boolean(server.serverTypeOverride);
+    isolationEnabled = true;
     error = '';
     fieldErrors = {};
     originalSnapshot = captureSnapshot();
@@ -285,6 +305,7 @@
     showingDcrFallback = false;
     serverTypeOverride = '';
     serverTypeOverrideHasDefault = false;
+    isolationEnabled = true;
     error = '';
     fieldErrors = {};
     originalSnapshot = captureSnapshot();
@@ -433,6 +454,14 @@
       if (finalArgs.length > 0) {
         params.args = finalArgs;
       }
+
+      // Always explicit for stdio — the relay treats an omitted field as
+      // direct spawn, so "container"/"none" is never left implicit.
+      params.isolation = resolveIsolation(
+        transport,
+        !catalogNotContainerizable,
+        isolationEnabled,
+      );
     } else if (transport === 'oauth') {
       params.url = url.trim();
       if (oauthServerUrl.trim()) params.oauth_server_url = oauthServerUrl.trim();
@@ -826,6 +855,14 @@
                     API Key
                   </span>
                 {/if}
+                {#if server.containerizable === false}
+                  <span
+                    class="inline-block text-[10px] px-1.5 py-0.5 rounded-full bg-(--surface-hover) text-(--fg2) border border-(--border) font-medium"
+                    title={server.containerNote}
+                  >
+                    Not containerized
+                  </span>
+                {/if}
               </div>
             </button>
           {/if}
@@ -944,6 +981,44 @@
             <input id="modal-ep-args" type="text" bind:value={args} placeholder="-y @modelcontextprotocol/server-filesystem /tmp"
               class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent)" />
           </div>
+
+          <!-- Isolation setting (stdio only). Flagged catalog entries can't
+               containerize — show the badge + reason instead of the toggle. -->
+          {#if catalogNotContainerizable}
+            <div class="flex items-start gap-2 px-3 py-2 rounded-lg border border-(--border) bg-(--surface-hover)">
+              <span class="inline-block text-[10px] px-1.5 py-0.5 rounded-full bg-(--surface) text-(--fg2) border border-(--border) font-medium flex-shrink-0">
+                Not containerized
+              </span>
+              <p class="text-[11px] text-(--fg2)">
+                {selectedCatalog?.containerNote} This server runs directly on your machine.
+              </p>
+            </div>
+          {:else}
+            <div>
+              <div class="flex items-center justify-between gap-2">
+                <label for="modal-ep-isolation" class="text-xs font-medium text-(--fg2)">
+                  Run in container <span class="text-(--fg2)/50">(isolation)</span>
+                </label>
+                <button
+                  id="modal-ep-isolation"
+                  type="button"
+                  class="tgl {isolationEnabled ? '' : 'tgl-off'}"
+                  role="switch"
+                  aria-checked={isolationEnabled}
+                  title={isolationEnabled ? 'Disable container isolation' : 'Enable container isolation'}
+                  onclick={() => isolationEnabled = !isolationEnabled}
+                ><span></span></button>
+              </div>
+              <p class="text-[11px] text-(--fg2) mt-0.5">
+                Runs the server in an isolated container (Docker or Podman) instead of directly on your machine.
+              </p>
+              {#if runtimeMissing && isolationEnabled}
+                <p class="text-[11px] text-(--attention) mt-1">
+                  No container runtime detected — the server will fall back to running directly on your machine. Install Docker or Podman to enable isolation.
+                </p>
+              {/if}
+            </div>
+          {/if}
         {:else if transport === 'oauth'}
           <div>
             <label for="modal-ep-url" class="block text-xs font-medium mb-1 text-(--fg2)">Server URL</label>
@@ -1385,4 +1460,38 @@
     </div>
   </div>
 {/if}
+
+<style>
+  /* Toggle pill (36x20) — mirrors the enable/disable switch in DetailPanel */
+  .tgl {
+    position: relative;
+    width: 36px;
+    height: 20px;
+    border-radius: 999px;
+    background: var(--healthy);
+    border: 0;
+    cursor: pointer;
+    padding: 0;
+    flex-shrink: 0;
+    transition: background-color 150ms var(--ease);
+  }
+  .tgl.tgl-off {
+    background: var(--toggle-off);
+  }
+  .tgl > span {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 16px;
+    height: 16px;
+    border-radius: 999px;
+    background: #fff;
+    box-shadow: 0 1px 2px var(--scrim);
+    transition: transform 150ms var(--ease);
+  }
+  .tgl:not(.tgl-off) > span {
+    transform: translateX(16px);
+  }
+</style>
+
 

--- a/src/lib/components/AddEndpointModal.svelte
+++ b/src/lib/components/AddEndpointModal.svelte
@@ -15,6 +15,7 @@
     serializeMountRows,
     mountRowError,
     hasMountRowErrors,
+    buildMountExample,
     type AddEndpointFieldErrors,
     type AddEndpointFormSnapshot,
     type MountRow,
@@ -24,6 +25,7 @@
   import ConfirmModal from './ConfirmModal.svelte';
   import { openUrl } from '@tauri-apps/plugin-opener';
   import { open as dialogOpen } from '@tauri-apps/plugin-dialog';
+  import { homeDir } from '@tauri-apps/api/path';
 
   type TransportType = 'stdio' | 'sse' | 'http' | 'oauth';
   type Step = 'browse' | 'configure';
@@ -111,6 +113,14 @@
   // The mount section is only meaningful when the endpoint will actually run
   // in a container — i.e. stdio, isolation ON, and not a flagged catalog entry.
   let showMounts = $derived(transport === 'stdio' && isolationEnabled && !catalogNotContainerizable);
+  // Resolved user home directory, used to build a valid absolute-path mount
+  // example. Left null until Tauri resolves it (or on failure), so the
+  // example falls back to a generic absolute path.
+  let homeDirPath: string | null = $state(null);
+  homeDir()
+    .then((h) => { homeDirPath = h; })
+    .catch(() => { /* leave null — buildMountExample falls back */ });
+  let mountExample = $derived(buildMountExample(homeDirPath));
   // null = unknown (older relay or status fetch failed); only an explicit
   // `false` from the relay drives the "no runtime" inline notice.
   let containerRuntimeAvailable: boolean | null = $state(null);
@@ -1282,7 +1292,7 @@
               {/if}
             {/each}
             <p class="text-[11px] text-(--fg2) mt-0.5">
-              Bind host paths into the container, e.g. <code>~/.gmail-mcp:/home/node/.gmail-mcp</code>.
+              Bind host paths into the container, e.g. <code>{mountExample}</code>.
             </p>
           </div>
         {/if}

--- a/src/lib/components/AddEndpointModal.svelte
+++ b/src/lib/components/AddEndpointModal.svelte
@@ -12,8 +12,12 @@
     firstAddEndpointFieldError,
     computeAddEndpointIsDirty,
     resolveIsolation,
+    serializeMountRows,
+    mountRowError,
+    hasMountRowErrors,
     type AddEndpointFieldErrors,
     type AddEndpointFormSnapshot,
+    type MountRow,
   } from './add-endpoint-helpers';
   import { sanitizeName } from '$lib/utils';
   import { focusTrap } from '$lib/actions/focusTrap';
@@ -101,6 +105,12 @@
   // the toggle is replaced by a "Not containerized" notice and the endpoint
   // is created with isolation = "none".
   let catalogNotContainerizable = $derived.by(() => selectedCatalog?.containerizable === false);
+  // Volume mounts (stdio + container isolation only) — host/container path
+  // pairs sent as the relay's `mounts: string[]`. Mirrors the env-var editor.
+  let mountRows: MountRow[] = $state([]);
+  // The mount section is only meaningful when the endpoint will actually run
+  // in a container — i.e. stdio, isolation ON, and not a flagged catalog entry.
+  let showMounts = $derived(transport === 'stdio' && isolationEnabled && !catalogNotContainerizable);
   // null = unknown (older relay or status fetch failed); only an explicit
   // `false` from the relay drives the "no runtime" inline notice.
   let containerRuntimeAvailable: boolean | null = $state(null);
@@ -136,6 +146,7 @@
       scopes,
       serverTypeOverride,
       isolationEnabled,
+      mounts: mountRows,
     });
   });
   let showDiscardConfirm = $state(false);
@@ -158,6 +169,7 @@
       scopes,
       serverTypeOverride,
       isolationEnabled,
+      mounts: mountRows.map((m) => ({ host: m.host, container: m.container })),
     };
   }
 
@@ -247,6 +259,7 @@
     serverTypeOverride = service.serverTypeOverride ?? '';
     serverTypeOverrideHasDefault = Boolean(service.serverTypeOverride);
     isolationEnabled = true;
+    mountRows = [];
     error = '';
     fieldErrors = {};
     originalSnapshot = captureSnapshot();
@@ -276,6 +289,7 @@
     serverTypeOverride = server.serverTypeOverride ?? '';
     serverTypeOverrideHasDefault = Boolean(server.serverTypeOverride);
     isolationEnabled = true;
+    mountRows = [];
     error = '';
     fieldErrors = {};
     originalSnapshot = captureSnapshot();
@@ -306,6 +320,7 @@
     serverTypeOverride = '';
     serverTypeOverrideHasDefault = false;
     isolationEnabled = true;
+    mountRows = [];
     error = '';
     fieldErrors = {};
     originalSnapshot = captureSnapshot();
@@ -462,6 +477,19 @@
         !catalogNotContainerizable,
         isolationEnabled,
       );
+
+      // Volume mounts only apply to containerized stdio endpoints. Block on
+      // any malformed row, then send the serialized array (omitted when empty).
+      if (params.isolation === 'container') {
+        if (hasMountRowErrors(mountRows)) {
+          error = 'Fix the highlighted volume mount rows before continuing.';
+          return;
+        }
+        const mounts = serializeMountRows(mountRows);
+        if (mounts.length > 0) {
+          params.mounts = mounts;
+        }
+      }
     } else if (transport === 'oauth') {
       params.url = url.trim();
       if (oauthServerUrl.trim()) params.oauth_server_url = oauthServerUrl.trim();
@@ -1215,6 +1243,49 @@
             </div>
           {/each}
         </div>
+
+        <!-- Volume mounts (containerized stdio only) — host/container bind
+             pairs sent to the relay as `mounts: string[]`. -->
+        {#if showMounts}
+          <div>
+            <div class="flex items-center justify-between mb-1">
+              <span class="block text-xs font-medium text-(--fg2)">
+                Volume mounts
+                <span class="text-(--fg2)/50">(optional)</span>
+              </span>
+              <button
+                type="button"
+                class="text-xs text-(--accent) hover:text-(--accent-hover)"
+                onclick={() => mountRows = [...mountRows, { host: '', container: '' }]}
+              >
+                + Add
+              </button>
+            </div>
+            {#each mountRows as mount, i}
+              {@const rowError = mountRowError(mount)}
+              <div class="flex gap-1 mb-1">
+                <input type="text" bind:value={mount.host} placeholder="/host/path"
+                  aria-invalid={!!rowError}
+                  class="flex-1 text-sm px-2 py-1 rounded-lg border bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) font-mono {rowError ? 'border-(--offline)' : 'border-(--border)'}" />
+                <span class="self-center text-xs text-(--fg2)">:</span>
+                <input type="text" bind:value={mount.container} placeholder="/container/path"
+                  aria-invalid={!!rowError}
+                  class="flex-1 text-sm px-2 py-1 rounded-lg border bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) font-mono {rowError ? 'border-(--offline)' : 'border-(--border)'}" />
+                <button
+                  type="button"
+                  class="text-xs px-1.5 text-(--fg2) hover:text-(--offline)"
+                  onclick={() => mountRows = mountRows.filter((_, idx) => idx !== i)}
+                >✕</button>
+              </div>
+              {#if rowError}
+                <p class="text-[11px] text-(--offline) mb-1">{rowError}</p>
+              {/if}
+            {/each}
+            <p class="text-[11px] text-(--fg2) mt-0.5">
+              Bind host paths into the container, e.g. <code>~/.gmail-mcp:/home/node/.gmail-mcp</code>.
+            </p>
+          </div>
+        {/if}
 
         <!-- Custom HTTP headers (SSE/HTTP only) -->
         {#if transport !== 'stdio'}

--- a/src/lib/components/AddEndpointModal.test.ts
+++ b/src/lib/components/AddEndpointModal.test.ts
@@ -17,6 +17,8 @@ import {
   serializeMountRows,
   mountRowError,
   hasMountRowErrors,
+  buildMountExample,
+  MOUNT_EXAMPLE_FALLBACK_HOST,
   type AddEndpointFieldErrors,
   type AddEndpointFormSnapshot,
   type MountRow,
@@ -916,6 +918,33 @@ describe('mount row helpers', () => {
   it('serializeMountRows round-trips through parseMountRows', () => {
     const serialized = ['~/.gmail-mcp:/home/node/.gmail-mcp', '/data:/srv/data'];
     expect(serializeMountRows(parseMountRows(serialized))).toEqual(serialized);
+  });
+});
+
+// buildMountExample — the host side must be a valid absolute docker arg
+// (docker rejects `~/...`); the container side is always the generic
+// `/home/node/example`, and a failed home-dir lookup falls back to an
+// absolute placeholder path.
+describe('buildMountExample', () => {
+  it('uses the resolved home directory on the host side', () => {
+    expect(buildMountExample('/Users/alex')).toBe('/Users/alex/example:/home/node/example');
+  });
+
+  it('strips a trailing slash from the home directory', () => {
+    expect(buildMountExample('/home/alex/')).toBe('/home/alex/example:/home/node/example');
+  });
+
+  it('falls back to an absolute placeholder when home is null/blank', () => {
+    expect(buildMountExample(null)).toBe(`${MOUNT_EXAMPLE_FALLBACK_HOST}:/home/node/example`);
+    expect(buildMountExample(undefined)).toBe(`${MOUNT_EXAMPLE_FALLBACK_HOST}:/home/node/example`);
+    expect(buildMountExample('   ')).toBe(`${MOUNT_EXAMPLE_FALLBACK_HOST}:/home/node/example`);
+  });
+
+  it('never produces a `~`-prefixed or product-specific example', () => {
+    const example = buildMountExample('/Users/alex');
+    expect(example).not.toContain('~');
+    expect(example.toLowerCase()).not.toContain('gmail');
+    expect(MOUNT_EXAMPLE_FALLBACK_HOST.startsWith('/')).toBe(true);
   });
 });
 

--- a/src/lib/components/AddEndpointModal.test.ts
+++ b/src/lib/components/AddEndpointModal.test.ts
@@ -11,6 +11,7 @@ import {
   validateAddEndpointForm,
   firstAddEndpointFieldError,
   computeAddEndpointIsDirty,
+  resolveIsolation,
   type AddEndpointFieldErrors,
   type AddEndpointFormSnapshot,
 } from './add-endpoint-helpers';
@@ -723,6 +724,7 @@ describe('computeAddEndpointIsDirty', () => {
       clientSecret: '',
       scopes: '',
       serverTypeOverride: '',
+      isolationEnabled: true,
       ...overrides,
     };
   }
@@ -819,6 +821,55 @@ describe('computeAddEndpointIsDirty', () => {
     const snap = makeSnapshot({ userArgValues: [''] });
     const current = makeSnapshot({ userArgValues: ['', ''] });
     expect(computeAddEndpointIsDirty(snap, current)).toBe(true);
+  });
+
+  it('flags the isolation toggle when flipped away from the snapshot', () => {
+    const snap = makeSnapshot();
+    expect(computeAddEndpointIsDirty(snap, makeSnapshot({ isolationEnabled: false }))).toBe(true);
+    expect(computeAddEndpointIsDirty(snap, makeSnapshot({ isolationEnabled: true }))).toBe(false);
+  });
+});
+
+// Isolation defaults — stdio endpoints always send an explicit value
+// ("container"/"none", never omitted) because the relay treats an absent
+// field as direct spawn. Flagged catalog entries force "none".
+describe('resolveIsolation', () => {
+  it('returns "container" for stdio when containerizable and toggle is on (default)', () => {
+    expect(resolveIsolation('stdio', true, true)).toBe('container');
+  });
+
+  it('returns "none" for stdio when the user turns the toggle off', () => {
+    expect(resolveIsolation('stdio', true, false)).toBe('none');
+  });
+
+  it('returns "none" for flagged catalog entries regardless of the toggle', () => {
+    expect(resolveIsolation('stdio', false, true)).toBe('none');
+    expect(resolveIsolation('stdio', false, false)).toBe('none');
+  });
+
+  it('returns undefined for non-stdio transports', () => {
+    for (const t of ['sse', 'http', 'oauth'] as const) {
+      expect(resolveIsolation(t, true, true)).toBeUndefined();
+      expect(resolveIsolation(t, false, false)).toBeUndefined();
+    }
+  });
+});
+
+describe('catalog containerizable flags', () => {
+  it('exactly Filesystem, Puppeteer, and Memory are flagged not-containerizable', () => {
+    const flagged = CATALOG_SERVERS.filter((s) => s.containerizable === false)
+      .map((s) => s.id)
+      .sort();
+    expect(flagged).toEqual(['filesystem', 'memory', 'puppeteer']);
+  });
+
+  it('every flagged entry carries a non-empty containerNote reason', () => {
+    for (const s of CATALOG_SERVERS) {
+      if (s.containerizable === false) {
+        expect(s.containerNote, `${s.id}: missing containerNote`).toBeTruthy();
+        expect(s.containerNote!.trim().length).toBeGreaterThan(0);
+      }
+    }
   });
 });
 

--- a/src/lib/components/AddEndpointModal.test.ts
+++ b/src/lib/components/AddEndpointModal.test.ts
@@ -12,6 +12,7 @@ import {
   firstAddEndpointFieldError,
   computeAddEndpointIsDirty,
   resolveIsolation,
+  isolationEnabledFromConfig,
   type AddEndpointFieldErrors,
   type AddEndpointFormSnapshot,
 } from './add-endpoint-helpers';
@@ -852,6 +853,29 @@ describe('resolveIsolation', () => {
       expect(resolveIsolation(t, true, true)).toBeUndefined();
       expect(resolveIsolation(t, false, false)).toBeUndefined();
     }
+  });
+});
+
+// Config-tab seeding — maps the stored isolation value to the toggle state.
+// Only an explicit "container" reads ON; "none"/empty/absent all mean direct
+// spawn (the relay's default for an omitted field).
+describe('isolationEnabledFromConfig', () => {
+  it('returns true only for an explicit "container"', () => {
+    expect(isolationEnabledFromConfig('container')).toBe(true);
+  });
+
+  it('returns false for "none"', () => {
+    expect(isolationEnabledFromConfig('none')).toBe(false);
+  });
+
+  it('returns false for empty/absent values (direct-spawn default)', () => {
+    expect(isolationEnabledFromConfig('')).toBe(false);
+    expect(isolationEnabledFromConfig(undefined)).toBe(false);
+  });
+
+  it('returns false for unrecognized values', () => {
+    expect(isolationEnabledFromConfig('CONTAINER')).toBe(false);
+    expect(isolationEnabledFromConfig('docker')).toBe(false);
   });
 });
 

--- a/src/lib/components/AddEndpointModal.test.ts
+++ b/src/lib/components/AddEndpointModal.test.ts
@@ -13,8 +13,13 @@ import {
   computeAddEndpointIsDirty,
   resolveIsolation,
   isolationEnabledFromConfig,
+  parseMountRows,
+  serializeMountRows,
+  mountRowError,
+  hasMountRowErrors,
   type AddEndpointFieldErrors,
   type AddEndpointFormSnapshot,
+  type MountRow,
 } from './add-endpoint-helpers';
 
 // `sanitizeName` mirrors the relay's `sanitize_server_name`
@@ -726,6 +731,7 @@ describe('computeAddEndpointIsDirty', () => {
       scopes: '',
       serverTypeOverride: '',
       isolationEnabled: true,
+      mounts: [],
       ...overrides,
     };
   }
@@ -828,6 +834,88 @@ describe('computeAddEndpointIsDirty', () => {
     const snap = makeSnapshot();
     expect(computeAddEndpointIsDirty(snap, makeSnapshot({ isolationEnabled: false }))).toBe(true);
     expect(computeAddEndpointIsDirty(snap, makeSnapshot({ isolationEnabled: true }))).toBe(false);
+  });
+
+  it('flags mount rows when added, edited, or removed', () => {
+    const snap = makeSnapshot();
+    expect(
+      computeAddEndpointIsDirty(snap, makeSnapshot({ mounts: [{ host: '', container: '' }] })),
+    ).toBe(true);
+    const withMount = makeSnapshot({ mounts: [{ host: '/a', container: '/b' }] });
+    expect(
+      computeAddEndpointIsDirty(withMount, makeSnapshot({ mounts: [{ host: '/a', container: '/c' }] })),
+    ).toBe(true);
+    expect(computeAddEndpointIsDirty(withMount, makeSnapshot({ mounts: [] }))).toBe(true);
+  });
+
+  it('returns false when mount rows match element-for-element', () => {
+    const snap = makeSnapshot({ mounts: [{ host: '/a', container: '/b' }] });
+    const current = makeSnapshot({ mounts: [{ host: '/a', container: '/b' }] });
+    expect(computeAddEndpointIsDirty(snap, current)).toBe(false);
+  });
+});
+
+// Volume-mount editor helpers — parse stored `mounts: string[]` into rows,
+// validate the two-input host/container pairs, and serialize back to the
+// relay's `host:container` array form.
+describe('mount row helpers', () => {
+  it('parseMountRows splits each entry on its first colon and trims', () => {
+    expect(parseMountRows(['~/.gmail-mcp:/home/node/.gmail-mcp'])).toEqual([
+      { host: '~/.gmail-mcp', container: '/home/node/.gmail-mcp' },
+    ]);
+    expect(parseMountRows(['  /host  :  /container  '])).toEqual([
+      { host: '/host', container: '/container' },
+    ]);
+  });
+
+  it('parseMountRows yields a host-only row for an entry with no colon', () => {
+    expect(parseMountRows(['/host-only'])).toEqual([{ host: '/host-only', container: '' }]);
+  });
+
+  it('parseMountRows treats only the first colon as the separator', () => {
+    expect(parseMountRows(['/a:/b:/c'])).toEqual([{ host: '/a', container: '/b:/c' }]);
+  });
+
+  it('parseMountRows returns [] for undefined/empty input', () => {
+    expect(parseMountRows(undefined)).toEqual([]);
+    expect(parseMountRows([])).toEqual([]);
+  });
+
+  it('mountRowError accepts a valid pair and a fully-empty row', () => {
+    expect(mountRowError({ host: '/a', container: '/b' })).toBeNull();
+    expect(mountRowError({ host: '  ', container: '' })).toBeNull();
+  });
+
+  it('mountRowError flags a missing host or container', () => {
+    expect(mountRowError({ host: '', container: '/b' })).toBe('Host path is required');
+    expect(mountRowError({ host: '/a', container: '' })).toBe('Container path is required');
+  });
+
+  it('mountRowError rejects a colon inside either half', () => {
+    expect(mountRowError({ host: '/a:/x', container: '/b' })).toBe('Paths must not contain ":"');
+    expect(mountRowError({ host: '/a', container: '/b:ro' })).toBe('Paths must not contain ":"');
+  });
+
+  it('hasMountRowErrors is true when any row is malformed', () => {
+    expect(hasMountRowErrors([{ host: '/a', container: '/b' }, { host: '', container: '' }])).toBe(false);
+    expect(hasMountRowErrors([{ host: '/a', container: '' }])).toBe(true);
+  });
+
+  it('serializeMountRows trims, skips empty rows, and joins with a colon', () => {
+    const rows: MountRow[] = [
+      { host: '  /host  ', container: '  /container  ' },
+      { host: '', container: '' },
+      { host: '~/.gmail-mcp', container: '/home/node/.gmail-mcp' },
+    ];
+    expect(serializeMountRows(rows)).toEqual([
+      '/host:/container',
+      '~/.gmail-mcp:/home/node/.gmail-mcp',
+    ]);
+  });
+
+  it('serializeMountRows round-trips through parseMountRows', () => {
+    const serialized = ['~/.gmail-mcp:/home/node/.gmail-mcp', '/data:/srv/data'];
+    expect(serializeMountRows(parseMountRows(serialized))).toEqual(serialized);
   });
 });
 

--- a/src/lib/components/ConfigTab.svelte
+++ b/src/lib/components/ConfigTab.svelte
@@ -55,6 +55,11 @@
   // value at ≤64 chars, but pasted content can occasionally bypass that on
   // some platforms. Surface a hint if it ever happens.
   let serverTypeOverrideTooLong = $derived(serverTypeOverride.length > 64);
+  // Stored isolation mode, passed through verbatim on save. Not user-editable
+  // here — the relay's PUT rebuilds the whole endpoint config from the request
+  // body, so omitting it would silently revert a containerized endpoint to
+  // direct spawn.
+  let isolation = $state('');
 
   // The upstream-reported raw name from the relay's Lifecycle::Ready state,
   // used to preview what the override would replace. Null when the endpoint
@@ -185,6 +190,7 @@
         clientSecretSet = config.client_secret_set ?? false;
         scopes = config.scopes ?? '';
         serverTypeOverride = config.server_type_override ?? '';
+        isolation = config.isolation ?? '';
         snapshotOriginals();
       })
       .catch(() => {
@@ -229,6 +235,11 @@
       params.command = command.trim();
       if (args.trim()) {
         params.args = args.trim().split(/\s+/);
+      }
+      // Pass the stored isolation mode through — the relay's PUT rebuilds
+      // the endpoint config, so omitting it would clear the value.
+      if (isolation) {
+        params.isolation = isolation;
       }
     } else if (transport === 'oauth') {
       if (!url.trim()) { error = 'Server URL is required'; return; }

--- a/src/lib/components/ConfigTab.svelte
+++ b/src/lib/components/ConfigTab.svelte
@@ -2,7 +2,15 @@
   import { getEndpointConfig, updateEndpoint, getEndpoints, getStatus, type UpdateEndpointParams } from '$lib/api';
   import { selectedEndpoint, endpoints, selectedEndpointData } from '$lib/stores';
   import { registerDirtyChecker } from '$lib/stores/unsavedChangesGuard';
-  import { resolveIsolation, isolationEnabledFromConfig } from './add-endpoint-helpers';
+  import {
+    resolveIsolation,
+    isolationEnabledFromConfig,
+    parseMountRows,
+    serializeMountRows,
+    mountRowError,
+    hasMountRowErrors,
+    type MountRow,
+  } from './add-endpoint-helpers';
   import { sanitizeName } from '$lib/utils';
 
   type TransportType = 'stdio' | 'sse' | 'http' | 'oauth';
@@ -62,6 +70,11 @@
   // value (see resolveIsolation) because the relay's PUT rebuilds the whole
   // endpoint config from the request body.
   let isolationEnabled = $state(false);
+  // Volume mounts (stdio + container isolation only), seeded from the stored
+  // `mounts` array. Mirrors the env-var editor; serialized on save.
+  let mountRows: MountRow[] = $state([]);
+  // The mount section only applies when the endpoint runs in a container.
+  let showMounts = $derived(transport === 'stdio' && isolationEnabled);
   // null = unknown (older relay or status fetch failed); only an explicit
   // `false` from the relay drives the "no runtime" inline notice.
   let containerRuntimeAvailable: boolean | null = $state(null);
@@ -94,6 +107,7 @@
   let originalScopes = $state('');
   let originalServerTypeOverride = $state('');
   let originalIsolationEnabled = $state(false);
+  let originalMountRows = $state('[]');
 
   // Controls the Advanced <details> open state. Two-way bound so user toggles
   // stick across reactive re-renders; re-seeded from the loaded config on each
@@ -115,6 +129,7 @@
     originalScopes = scopes;
     originalServerTypeOverride = serverTypeOverride;
     originalIsolationEnabled = isolationEnabled;
+    originalMountRows = JSON.stringify(mountRows);
     advancedOpen = originalServerTypeOverride !== '';
   }
 
@@ -140,7 +155,8 @@
     clientSecretDirty ||
     scopes !== originalScopes ||
     serverTypeOverride !== originalServerTypeOverride ||
-    isolationEnabled !== originalIsolationEnabled
+    isolationEnabled !== originalIsolationEnabled ||
+    JSON.stringify(mountRows) !== originalMountRows
   );
 
   // Register a dirty-checker with the shared navigation guard so that any
@@ -203,6 +219,7 @@
         scopes = config.scopes ?? '';
         serverTypeOverride = config.server_type_override ?? '';
         isolationEnabled = isolationEnabledFromConfig(config.isolation);
+        mountRows = parseMountRows(config.mounts);
         snapshotOriginals();
       })
       .catch(() => {
@@ -252,6 +269,14 @@
       // config and treats an omitted field as direct spawn, so the toggle
       // state is sent as "container"/"none", never left implicit.
       params.isolation = resolveIsolation(transport, true, isolationEnabled);
+      // Block on any malformed mount row while the editor is visible, then
+      // always send an explicit array (possibly empty, to clear stored mounts)
+      // since the relay's PUT rebuilds the whole config from the body.
+      if (isolationEnabled && hasMountRowErrors(mountRows)) {
+        error = 'Fix the highlighted volume mount rows before saving.';
+        return;
+      }
+      params.mounts = serializeMountRows(mountRows);
     } else if (transport === 'oauth') {
       if (!url.trim()) { error = 'Server URL is required'; return; }
       params.url = url.trim();
@@ -541,6 +566,49 @@
             </div>
           {/each}
         </div>
+
+        <!-- Volume mounts (containerized stdio only) — host/container bind
+             pairs sent to the relay as `mounts: string[]`. -->
+        {#if showMounts}
+          <div>
+            <div class="flex items-center justify-between mb-1">
+              <span class="block text-xs font-medium text-(--fg2)">
+                Volume mounts
+                <span class="text-(--fg2)/50">(optional)</span>
+              </span>
+              <button
+                type="button"
+                class="text-xs text-(--accent) hover:text-(--accent-hover)"
+                onclick={() => mountRows = [...mountRows, { host: '', container: '' }]}
+              >
+                + Add
+              </button>
+            </div>
+            {#each mountRows as mount, i}
+              {@const rowError = mountRowError(mount)}
+              <div class="flex gap-1 mb-1">
+                <input type="text" bind:value={mount.host} placeholder="/host/path"
+                  aria-invalid={!!rowError}
+                  class="flex-1 text-sm px-2 py-1 rounded-lg border bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) font-mono {rowError ? 'border-(--offline)' : 'border-(--border)'}" />
+                <span class="self-center text-xs text-(--fg2)">:</span>
+                <input type="text" bind:value={mount.container} placeholder="/container/path"
+                  aria-invalid={!!rowError}
+                  class="flex-1 text-sm px-2 py-1 rounded-lg border bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) font-mono {rowError ? 'border-(--offline)' : 'border-(--border)'}" />
+                <button
+                  type="button"
+                  class="text-xs px-1.5 text-(--fg2) hover:text-(--offline)"
+                  onclick={() => mountRows = mountRows.filter((_, idx) => idx !== i)}
+                >✕</button>
+              </div>
+              {#if rowError}
+                <p class="text-[11px] text-(--offline) mb-1">{rowError}</p>
+              {/if}
+            {/each}
+            <p class="text-[11px] text-(--fg2) mt-0.5">
+              Bind host paths into the container, e.g. <code>~/.gmail-mcp:/home/node/.gmail-mcp</code>.
+            </p>
+          </div>
+        {/if}
 
         <!-- HTTP Headers (SSE/HTTP only) -->
         {#if transport !== 'stdio'}

--- a/src/lib/components/ConfigTab.svelte
+++ b/src/lib/components/ConfigTab.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import { getEndpointConfig, updateEndpoint, getEndpoints, type UpdateEndpointParams } from '$lib/api';
+  import { getEndpointConfig, updateEndpoint, getEndpoints, getStatus, type UpdateEndpointParams } from '$lib/api';
   import { selectedEndpoint, endpoints, selectedEndpointData } from '$lib/stores';
   import { registerDirtyChecker } from '$lib/stores/unsavedChangesGuard';
+  import { resolveIsolation, isolationEnabledFromConfig } from './add-endpoint-helpers';
   import { sanitizeName } from '$lib/utils';
 
   type TransportType = 'stdio' | 'sse' | 'http' | 'oauth';
@@ -55,11 +56,19 @@
   // value at ≤64 chars, but pasted content can occasionally bypass that on
   // some platforms. Surface a hint if it ever happens.
   let serverTypeOverrideTooLong = $derived(serverTypeOverride.length > 64);
-  // Stored isolation mode, passed through verbatim on save. Not user-editable
-  // here — the relay's PUT rebuilds the whole endpoint config from the request
-  // body, so omitting it would silently revert a containerized endpoint to
-  // direct spawn.
-  let isolation = $state('');
+  // Isolation toggle for stdio endpoints, seeded from the stored config.
+  // Empty/omitted/"none" all mean direct spawn → toggle OFF; only an explicit
+  // "container" reads ON. Saving always sends an explicit "container"/"none"
+  // value (see resolveIsolation) because the relay's PUT rebuilds the whole
+  // endpoint config from the request body.
+  let isolationEnabled = $state(false);
+  // null = unknown (older relay or status fetch failed); only an explicit
+  // `false` from the relay drives the "no runtime" inline notice.
+  let containerRuntimeAvailable: boolean | null = $state(null);
+  let runtimeMissing = $derived(containerRuntimeAvailable === false);
+  getStatus()
+    .then((s) => { containerRuntimeAvailable = s.container_runtime_available ?? null; })
+    .catch(() => { /* relay unreachable — leave runtime availability unknown */ });
 
   // The upstream-reported raw name from the relay's Lifecycle::Ready state,
   // used to preview what the override would replace. Null when the endpoint
@@ -84,6 +93,7 @@
   let originalClientId = $state('');
   let originalScopes = $state('');
   let originalServerTypeOverride = $state('');
+  let originalIsolationEnabled = $state(false);
 
   // Controls the Advanced <details> open state. Two-way bound so user toggles
   // stick across reactive re-renders; re-seeded from the loaded config on each
@@ -104,6 +114,7 @@
     originalClientId = clientId;
     originalScopes = scopes;
     originalServerTypeOverride = serverTypeOverride;
+    originalIsolationEnabled = isolationEnabled;
     advancedOpen = originalServerTypeOverride !== '';
   }
 
@@ -128,7 +139,8 @@
     clientId !== originalClientId ||
     clientSecretDirty ||
     scopes !== originalScopes ||
-    serverTypeOverride !== originalServerTypeOverride
+    serverTypeOverride !== originalServerTypeOverride ||
+    isolationEnabled !== originalIsolationEnabled
   );
 
   // Register a dirty-checker with the shared navigation guard so that any
@@ -190,7 +202,7 @@
         clientSecretSet = config.client_secret_set ?? false;
         scopes = config.scopes ?? '';
         serverTypeOverride = config.server_type_override ?? '';
-        isolation = config.isolation ?? '';
+        isolationEnabled = isolationEnabledFromConfig(config.isolation);
         snapshotOriginals();
       })
       .catch(() => {
@@ -236,11 +248,10 @@
       if (args.trim()) {
         params.args = args.trim().split(/\s+/);
       }
-      // Pass the stored isolation mode through — the relay's PUT rebuilds
-      // the endpoint config, so omitting it would clear the value.
-      if (isolation) {
-        params.isolation = isolation;
-      }
+      // Always explicit for stdio — the relay's PUT rebuilds the endpoint
+      // config and treats an omitted field as direct spawn, so the toggle
+      // state is sent as "container"/"none", never left implicit.
+      params.isolation = resolveIsolation(transport, true, isolationEnabled);
     } else if (transport === 'oauth') {
       if (!url.trim()) { error = 'Server URL is required'; return; }
       params.url = url.trim();
@@ -397,6 +408,31 @@
             <label for="config-ep-args" class="block text-xs font-medium mb-1 text-(--fg2)">Arguments <span class="text-(--fg2)/50">(space-separated)</span></label>
             <input id="config-ep-args" type="text" bind:value={args} placeholder="-y @modelcontextprotocol/server-filesystem /tmp"
               class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent)" />
+          </div>
+          <!-- Isolation setting (stdio only) — mirrors the toggle in AddEndpointModal. -->
+          <div>
+            <div class="flex items-center justify-between gap-2">
+              <label for="config-ep-isolation" class="text-xs font-medium text-(--fg2)">
+                Run in container <span class="text-(--fg2)/50">(isolation)</span>
+              </label>
+              <button
+                id="config-ep-isolation"
+                type="button"
+                class="tgl {isolationEnabled ? '' : 'tgl-off'}"
+                role="switch"
+                aria-checked={isolationEnabled}
+                title={isolationEnabled ? 'Disable container isolation' : 'Enable container isolation'}
+                onclick={() => isolationEnabled = !isolationEnabled}
+              ><span></span></button>
+            </div>
+            <p class="text-[11px] text-(--fg2) mt-0.5">
+              Runs the server in an isolated container (Docker or Podman) instead of directly on your machine.
+            </p>
+            {#if runtimeMissing && isolationEnabled}
+              <p class="text-[11px] text-(--attention) mt-1">
+                No container runtime detected — the server will fall back to running directly on your machine. Install Docker or Podman to enable isolation.
+              </p>
+            {/if}
           </div>
         {:else if transport === 'oauth'}
           <div>
@@ -632,5 +668,35 @@
     font-size: 12px;
     font-weight: 500;
     color: var(--fg2);
+  }
+  /* Toggle pill (36x20) — mirrors the enable/disable switch in DetailPanel */
+  .tgl {
+    position: relative;
+    width: 36px;
+    height: 20px;
+    border-radius: 999px;
+    background: var(--healthy);
+    border: 0;
+    cursor: pointer;
+    padding: 0;
+    flex-shrink: 0;
+    transition: background-color 150ms var(--ease);
+  }
+  .tgl.tgl-off {
+    background: var(--toggle-off);
+  }
+  .tgl > span {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 16px;
+    height: 16px;
+    border-radius: 999px;
+    background: #fff;
+    box-shadow: 0 1px 2px var(--scrim);
+    transition: transform 150ms var(--ease);
+  }
+  .tgl:not(.tgl-off) > span {
+    transform: translateX(16px);
   }
 </style>

--- a/src/lib/components/ConfigTab.svelte
+++ b/src/lib/components/ConfigTab.svelte
@@ -9,9 +9,11 @@
     serializeMountRows,
     mountRowError,
     hasMountRowErrors,
+    buildMountExample,
     type MountRow,
   } from './add-endpoint-helpers';
   import { sanitizeName } from '$lib/utils';
+  import { homeDir } from '@tauri-apps/api/path';
 
   type TransportType = 'stdio' | 'sse' | 'http' | 'oauth';
 
@@ -75,6 +77,14 @@
   let mountRows: MountRow[] = $state([]);
   // The mount section only applies when the endpoint runs in a container.
   let showMounts = $derived(transport === 'stdio' && isolationEnabled);
+  // Resolved user home directory, used to build a valid absolute-path mount
+  // example. Left null until Tauri resolves it (or on failure), so the
+  // example falls back to a generic absolute path.
+  let homeDirPath: string | null = $state(null);
+  homeDir()
+    .then((h) => { homeDirPath = h; })
+    .catch(() => { /* leave null — buildMountExample falls back */ });
+  let mountExample = $derived(buildMountExample(homeDirPath));
   // null = unknown (older relay or status fetch failed); only an explicit
   // `false` from the relay drives the "no runtime" inline notice.
   let containerRuntimeAvailable: boolean | null = $state(null);
@@ -605,7 +615,7 @@
               {/if}
             {/each}
             <p class="text-[11px] text-(--fg2) mt-0.5">
-              Bind host paths into the container, e.g. <code>~/.gmail-mcp:/home/node/.gmail-mcp</code>.
+              Bind host paths into the container, e.g. <code>{mountExample}</code>.
             </p>
           </div>
         {/if}

--- a/src/lib/components/DetailPanel.svelte
+++ b/src/lib/components/DetailPanel.svelte
@@ -23,7 +23,7 @@
     formatBytes,
     formatCpuPercent,
   } from './detail-panel-helpers';
-  import { getIsolationDetail } from './endpoint-row-helpers';
+  import { getCustomImage } from './endpoint-row-helpers';
 
   let showRestartConfirm = $state(false);
   let showDeleteConfirm = $state(false);
@@ -160,23 +160,27 @@
             <TransportBadge transport={ep.transport} />
             <IsolationBadge isolation={ep.isolation_state} />
             <span class="text-[11px] text-(--fg3)">{ep.tool_count} tools</span>
-            {#if getIsolationDetail(ep.isolation_state)}
-              <span
-                class="text-[11px] text-(--fg3) truncate"
-                title="Container image and container name"
-              >{getIsolationDetail(ep.isolation_state)}</span>
-            {/if}
-            {#if ep.container_stats}
-              <span
-                class="text-[11px] text-(--fg3) truncate"
-                title="Live container resource usage (CPU, memory, network received/sent)"
-              >
-                CPU {formatCpuPercent(ep.container_stats.cpu_percent)}
-                · Mem {formatBytes(ep.container_stats.mem_bytes)}
-                · Net ↓{formatBytes(ep.container_stats.net_rx_bytes)} ↑{formatBytes(ep.container_stats.net_tx_bytes)}
-              </span>
-            {/if}
           </div>
+          {#if getCustomImage(ep.isolation_state) || ep.container_stats}
+            <div class="flex items-center gap-2 mt-0.5">
+              {#if getCustomImage(ep.isolation_state)}
+                <span
+                  class="text-[11px] text-(--fg3) truncate"
+                  title="Custom container image"
+                >{getCustomImage(ep.isolation_state)}</span>
+              {/if}
+              {#if ep.container_stats}
+                <span
+                  class="text-[11px] text-(--fg3) truncate"
+                  title="Live container resource usage (CPU, memory, network received/sent)"
+                >
+                  CPU {formatCpuPercent(ep.container_stats.cpu_percent)}
+                  · Mem {formatBytes(ep.container_stats.mem_bytes)}
+                  · Net ↓{formatBytes(ep.container_stats.net_rx_bytes)} ↑{formatBytes(ep.container_stats.net_tx_bytes)}
+                </span>
+              {/if}
+            </div>
+          {/if}
         </div>
       </div>
       <div class="flex items-center gap-1.5 flex-shrink-0">

--- a/src/lib/components/DetailPanel.svelte
+++ b/src/lib/components/DetailPanel.svelte
@@ -12,6 +12,7 @@
   import HealthDot from './HealthDot.svelte';
   import EndpointIcon from './EndpointIcon.svelte';
   import TransportBadge from './TransportBadge.svelte';
+  import IsolationBadge from './IsolationBadge.svelte';
   import AuthTab from './AuthTab.svelte';
   import ProfilesTab from './ProfilesTab.svelte';
   import {
@@ -22,6 +23,7 @@
     formatBytes,
     formatCpuPercent,
   } from './detail-panel-helpers';
+  import { getIsolationDetail } from './endpoint-row-helpers';
 
   let showRestartConfirm = $state(false);
   let showDeleteConfirm = $state(false);
@@ -156,7 +158,14 @@
           <h2 class="dhdr-name truncate">{ep.name}</h2>
           <div class="flex items-center gap-2 mt-0.5">
             <TransportBadge transport={ep.transport} />
+            <IsolationBadge isolation={ep.isolation_state} />
             <span class="text-[11px] text-(--fg3)">{ep.tool_count} tools</span>
+            {#if getIsolationDetail(ep.isolation_state)}
+              <span
+                class="text-[11px] text-(--fg3) truncate"
+                title="Container image and container name"
+              >{getIsolationDetail(ep.isolation_state)}</span>
+            {/if}
             {#if ep.container_stats}
               <span
                 class="text-[11px] text-(--fg3) truncate"

--- a/src/lib/components/DetailPanel.svelte
+++ b/src/lib/components/DetailPanel.svelte
@@ -19,6 +19,8 @@
     shouldShowRefreshButton,
     shouldShowReauthorizeButton,
     visibleTabs,
+    formatBytes,
+    formatCpuPercent,
   } from './detail-panel-helpers';
 
   let showRestartConfirm = $state(false);
@@ -155,6 +157,16 @@
           <div class="flex items-center gap-2 mt-0.5">
             <TransportBadge transport={ep.transport} />
             <span class="text-[11px] text-(--fg3)">{ep.tool_count} tools</span>
+            {#if ep.container_stats}
+              <span
+                class="text-[11px] text-(--fg3) truncate"
+                title="Live container resource usage (CPU, memory, network received/sent)"
+              >
+                CPU {formatCpuPercent(ep.container_stats.cpu_percent)}
+                · Mem {formatBytes(ep.container_stats.mem_bytes)}
+                · Net ↓{formatBytes(ep.container_stats.net_rx_bytes)} ↑{formatBytes(ep.container_stats.net_tx_bytes)}
+              </span>
+            {/if}
           </div>
         </div>
       </div>

--- a/src/lib/components/EndpointRow.svelte
+++ b/src/lib/components/EndpointRow.svelte
@@ -5,7 +5,6 @@
   import HealthDot from './HealthDot.svelte';
   import EndpointIcon from './EndpointIcon.svelte';
   import TransportBadge from './TransportBadge.svelte';
-  import IsolationBadge from './IsolationBadge.svelte';
   import { getEndpointStatusLabel } from './endpoint-row-helpers';
 
   let { endpoint }: { endpoint: Endpoint } = $props();
@@ -48,7 +47,6 @@
     >{endpoint.name}</div>
     <div class="flex items-baseline gap-1.5 mt-px">
       <TransportBadge transport={endpoint.transport} />
-      <IsolationBadge isolation={endpoint.isolation_state} />
       {#if isFailed}
         <span
           class="text-[11px] text-(--offline) truncate max-w-[120px]"

--- a/src/lib/components/EndpointRow.svelte
+++ b/src/lib/components/EndpointRow.svelte
@@ -5,6 +5,7 @@
   import HealthDot from './HealthDot.svelte';
   import EndpointIcon from './EndpointIcon.svelte';
   import TransportBadge from './TransportBadge.svelte';
+  import IsolationBadge from './IsolationBadge.svelte';
   import { getEndpointStatusLabel } from './endpoint-row-helpers';
 
   let { endpoint }: { endpoint: Endpoint } = $props();
@@ -47,6 +48,7 @@
     >{endpoint.name}</div>
     <div class="flex items-baseline gap-1.5 mt-px">
       <TransportBadge transport={endpoint.transport} />
+      <IsolationBadge isolation={endpoint.isolation_state} />
       {#if isFailed}
         <span
           class="text-[11px] text-(--offline) truncate max-w-[120px]"

--- a/src/lib/components/IsolationBadge.svelte
+++ b/src/lib/components/IsolationBadge.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  import type { IsolationState } from '$lib/types';
+  import { getIsolationBadge } from './endpoint-row-helpers';
+
+  let {
+    isolation,
+    size = 'sm',
+  }: { isolation: IsolationState | null | undefined; size?: 'sm' | 'md' } = $props();
+
+  const badge = $derived(getIsolationBadge(isolation));
+</script>
+
+{#if badge}
+  <span
+    class="iso-badge iso-badge-{size} iso-badge-{badge.kind} inline-flex items-center font-semibold whitespace-nowrap"
+    title={badge.title}
+  >
+    {badge.label}
+  </span>
+{/if}
+
+<style>
+  .iso-badge {
+    letter-spacing: 0.02em;
+    font-family: var(--font-mono);
+  }
+  .iso-badge-sm {
+    font-size: 9px;
+    padding: 1px 5px;
+    border-radius: 3px;
+  }
+  .iso-badge-md {
+    font-size: 10px;
+    padding: 2px 8px;
+    border-radius: var(--radius-xs);
+  }
+  .iso-badge-container {
+    background: color-mix(in oklab, var(--healthy) 14%, transparent);
+    color: var(--healthy);
+  }
+  .iso-badge-fallback {
+    background: color-mix(in oklab, var(--degraded) 16%, transparent);
+    color: var(--degraded);
+  }
+</style>

--- a/src/lib/components/add-endpoint-helpers.ts
+++ b/src/lib/components/add-endpoint-helpers.ts
@@ -183,6 +183,27 @@ export function serializeMountRows(rows: MountRow[]): string[] {
   return out;
 }
 
+/**
+ * Host-side fallback for the volume-mount example when the user's home
+ * directory can't be resolved (e.g. the Tauri `homeDir()` call fails). Must
+ * be an absolute path — docker rejects `~/...` as an invalid local volume
+ * name and requires an absolute host path.
+ */
+export const MOUNT_EXAMPLE_FALLBACK_HOST = '/path/to/example';
+
+/**
+ * Builds the `host:container` example string shown under the volume-mount
+ * editor. The host side uses the resolved home directory (e.g.
+ * `/Users/alex/example`) so it is a valid absolute docker arg; the container
+ * side is always the generic `/home/node/example`. When `home` is absent or
+ * blank, the host side falls back to {@link MOUNT_EXAMPLE_FALLBACK_HOST}.
+ */
+export function buildMountExample(home: string | null | undefined): string {
+  const trimmed = typeof home === 'string' ? home.trim() : '';
+  const host = trimmed ? `${trimmed.replace(/\/+$/, '')}/example` : MOUNT_EXAMPLE_FALLBACK_HOST;
+  return `${host}:/home/node/example`;
+}
+
 /** Structural equality for mount-row lists, used by the dirty check. */
 function sameMountList(a: MountRow[], b: MountRow[]): boolean {
   if (a.length !== b.length) return false;

--- a/src/lib/components/add-endpoint-helpers.ts
+++ b/src/lib/components/add-endpoint-helpers.ts
@@ -117,6 +117,82 @@ export function isolationEnabledFromConfig(isolation: string | undefined): boole
 }
 
 /**
+ * A single editable volume-mount row in the Add/Config mount editors. Mirrors
+ * the env-var `{ key, value }` shape: two separate inputs whose `:`-joined
+ * form is the verbatim docker `-v` bind-mount string the relay stores in the
+ * stdio config's `mounts` array.
+ */
+export interface MountRow {
+  host: string;
+  container: string;
+}
+
+/**
+ * Seeds the mount editor from a stored `mounts: string[]` array. Each entry is
+ * split on its first `:` into host/container halves (trimmed); an entry with
+ * no `:` becomes a host-only row so the user can finish it. Absent/empty input
+ * yields no rows.
+ */
+export function parseMountRows(mounts: string[] | undefined): MountRow[] {
+  if (!mounts) return [];
+  return mounts.map((entry) => {
+    const idx = entry.indexOf(':');
+    if (idx === -1) return { host: entry.trim(), container: '' };
+    return { host: entry.slice(0, idx).trim(), container: entry.slice(idx + 1).trim() };
+  });
+}
+
+/**
+ * Validates a single mount row. Returns an inline error message, or `null`
+ * when the row is OK (including a fully-empty row, which is skipped on
+ * submit). Enforces a single `:` separator with non-empty host and container
+ * parts — since the two halves are separate inputs, a literal `:` in either
+ * one would produce a malformed `host:container` string, so it is rejected.
+ */
+export function mountRowError(row: MountRow): string | null {
+  const host = row.host.trim();
+  const container = row.container.trim();
+  if (!host && !container) return null;
+  if (!host) return 'Host path is required';
+  if (!container) return 'Container path is required';
+  if (host.includes(':') || container.includes(':')) {
+    return 'Paths must not contain ":"';
+  }
+  return null;
+}
+
+/** True when any row fails {@link mountRowError}. Blocks submit. */
+export function hasMountRowErrors(rows: MountRow[]): boolean {
+  return rows.some((row) => mountRowError(row) !== null);
+}
+
+/**
+ * Serializes mount rows into the relay's `mounts: string[]` form. Trims each
+ * half, skips fully-empty rows, and joins the rest as `host:container`.
+ * Callers should gate submit on {@link hasMountRowErrors} first; this does no
+ * validation of its own.
+ */
+export function serializeMountRows(rows: MountRow[]): string[] {
+  const out: string[] = [];
+  for (const row of rows) {
+    const host = row.host.trim();
+    const container = row.container.trim();
+    if (!host && !container) continue;
+    out.push(`${host}:${container}`);
+  }
+  return out;
+}
+
+/** Structural equality for mount-row lists, used by the dirty check. */
+function sameMountList(a: MountRow[], b: MountRow[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].host !== b[i].host || a[i].container !== b[i].container) return false;
+  }
+  return true;
+}
+
+/**
  * Per-field error map for inputs that surface `aria-invalid` in the Add
  * Server modal. Presence of a key means that field failed validation; the
  * value is the human-readable message reused for both the inline state and
@@ -195,6 +271,7 @@ export interface AddEndpointFormSnapshot {
   scopes: string;
   serverTypeOverride: string;
   isolationEnabled: boolean;
+  mounts: MountRow[];
 }
 
 function sameKvList(
@@ -250,6 +327,7 @@ export function computeAddEndpointIsDirty(
   if (snapshot.scopes !== current.scopes) return true;
   if (snapshot.serverTypeOverride !== current.serverTypeOverride) return true;
   if (snapshot.isolationEnabled !== current.isolationEnabled) return true;
+  if (!sameMountList(snapshot.mounts, current.mounts)) return true;
   if (!sameKvList(snapshot.envVars, current.envVars)) return true;
   if (!sameKvList(snapshot.headerVars, current.headerVars)) return true;
   if (!sameRecord(snapshot.catalogEnvValues, current.catalogEnvValues)) return true;

--- a/src/lib/components/add-endpoint-helpers.ts
+++ b/src/lib/components/add-endpoint-helpers.ts
@@ -106,6 +106,17 @@ export function resolveIsolation(
 }
 
 /**
+ * Maps a stored endpoint `isolation` value to the toggle's on/off state.
+ *
+ * Only an explicit `"container"` means containerized; `"none"`, an empty
+ * string, or an absent field all mean direct spawn (the relay's default for
+ * an omitted field), so the toggle reads OFF for those.
+ */
+export function isolationEnabledFromConfig(isolation: string | undefined): boolean {
+  return isolation === 'container';
+}
+
+/**
  * Per-field error map for inputs that surface `aria-invalid` in the Add
  * Server modal. Presence of a key means that field failed validation; the
  * value is the human-readable message reused for both the inline state and

--- a/src/lib/components/add-endpoint-helpers.ts
+++ b/src/lib/components/add-endpoint-helpers.ts
@@ -87,6 +87,25 @@ export function nextPollOrTimeout(
 export type AddEndpointTransport = 'stdio' | 'sse' | 'http' | 'oauth';
 
 /**
+ * Resolves the explicit `isolation` value sent when creating an endpoint.
+ *
+ * Stdio endpoints ALWAYS get an explicit value — `"container"` or `"none"`,
+ * never omitted — because the relay treats an absent field as direct spawn
+ * and we want new endpoints to containerize by default. Catalog entries
+ * flagged `containerizable: false` force `"none"` regardless of the toggle.
+ * Non-stdio transports return `undefined` (the field does not apply).
+ */
+export function resolveIsolation(
+  transport: AddEndpointTransport,
+  containerizable: boolean,
+  isolationEnabled: boolean,
+): 'container' | 'none' | undefined {
+  if (transport !== 'stdio') return undefined;
+  if (!containerizable) return 'none';
+  return isolationEnabled ? 'container' : 'none';
+}
+
+/**
  * Per-field error map for inputs that surface `aria-invalid` in the Add
  * Server modal. Presence of a key means that field failed validation; the
  * value is the human-readable message reused for both the inline state and
@@ -164,6 +183,7 @@ export interface AddEndpointFormSnapshot {
   clientSecret: string;
   scopes: string;
   serverTypeOverride: string;
+  isolationEnabled: boolean;
 }
 
 function sameKvList(
@@ -218,6 +238,7 @@ export function computeAddEndpointIsDirty(
   if (snapshot.clientSecret !== current.clientSecret) return true;
   if (snapshot.scopes !== current.scopes) return true;
   if (snapshot.serverTypeOverride !== current.serverTypeOverride) return true;
+  if (snapshot.isolationEnabled !== current.isolationEnabled) return true;
   if (!sameKvList(snapshot.envVars, current.envVars)) return true;
   if (!sameKvList(snapshot.headerVars, current.headerVars)) return true;
   if (!sameRecord(snapshot.catalogEnvValues, current.catalogEnvValues)) return true;

--- a/src/lib/components/detail-panel-helpers.test.ts
+++ b/src/lib/components/detail-panel-helpers.test.ts
@@ -6,6 +6,8 @@ import {
   shouldShowRefreshButton,
   shouldShowReauthorizeButton,
   visibleTabs,
+  formatBytes,
+  formatCpuPercent,
   type EndpointTransport,
 } from './detail-panel-helpers';
 
@@ -285,5 +287,63 @@ describe('DetailPanel re-authorize button', () => {
   it('right-aligns the Re-authorize button using ml-auto', () => {
     expect(reauthBlock, 'expected to find the Re-authorize {#if showReauthorize} block').not.toBeNull();
     expect(reauthBlock![0]).toContain('ml-auto');
+  });
+});
+
+// ── Container-stats formatters (header metrics line) ──
+
+describe('formatBytes', () => {
+  it('formats sub-KB values as whole bytes', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(512)).toBe('512 B');
+    expect(formatBytes(1023)).toBe('1023 B');
+  });
+
+  it('formats KB/MB/GB with one decimal (base 1024)', () => {
+    expect(formatBytes(1024)).toBe('1.0 KB');
+    expect(formatBytes(1536)).toBe('1.5 KB');
+    expect(formatBytes(45.2 * 1024 * 1024)).toBe('45.2 MB');
+    expect(formatBytes(1.2 * 1024 * 1024 * 1024)).toBe('1.2 GB');
+  });
+
+  it('caps at TB for very large values', () => {
+    expect(formatBytes(2.5 * 1024 ** 4)).toBe('2.5 TB');
+    expect(formatBytes(5000 * 1024 ** 4)).toBe('5000.0 TB');
+  });
+
+  it('renders negative and non-finite inputs as 0 B', () => {
+    expect(formatBytes(-1)).toBe('0 B');
+    expect(formatBytes(NaN)).toBe('0 B');
+    expect(formatBytes(Infinity)).toBe('0 B');
+  });
+});
+
+describe('formatCpuPercent', () => {
+  it('formats with one decimal place', () => {
+    expect(formatCpuPercent(0)).toBe('0.0%');
+    expect(formatCpuPercent(1.25)).toBe('1.3%');
+    expect(formatCpuPercent(100)).toBe('100.0%');
+  });
+
+  it('renders negative and non-finite inputs as 0.0%', () => {
+    expect(formatCpuPercent(-3)).toBe('0.0%');
+    expect(formatCpuPercent(NaN)).toBe('0.0%');
+    expect(formatCpuPercent(Infinity)).toBe('0.0%');
+  });
+});
+
+// The metrics line must only render when `container_stats` is present, so
+// direct-spawn endpoints (absent/null stats) show no metrics.
+describe('DetailPanel container-stats line', () => {
+  const statsBlock = detailPanelSource.match(
+    /\{#if ep\.container_stats\}[\s\S]*?\{\/if\}/,
+  );
+
+  it('renders the metrics line under an ep.container_stats guard', () => {
+    expect(statsBlock, 'expected to find the {#if ep.container_stats} block').not.toBeNull();
+    expect(statsBlock![0]).toContain('formatCpuPercent(ep.container_stats.cpu_percent)');
+    expect(statsBlock![0]).toContain('formatBytes(ep.container_stats.mem_bytes)');
+    expect(statsBlock![0]).toContain('formatBytes(ep.container_stats.net_rx_bytes)');
+    expect(statsBlock![0]).toContain('formatBytes(ep.container_stats.net_tx_bytes)');
   });
 });

--- a/src/lib/components/detail-panel-helpers.ts
+++ b/src/lib/components/detail-panel-helpers.ts
@@ -54,3 +54,31 @@ export function shouldShowRestartButton(transport: EndpointTransport, disabled: 
 export function shouldShowRefreshButton(disabled: boolean): boolean {
   return !disabled;
 }
+
+/**
+ * Compact byte formatter for the container-stats line (base 1024).
+ * Examples: `512 B`, `1.5 KB`, `45.2 MB`, `1.2 GB`. Negative or
+ * non-finite inputs render as `0 B`.
+ */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return '0 B';
+  if (bytes < 1024) return `${Math.round(bytes)} B`;
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  let value = bytes;
+  let unit = 'B';
+  for (const u of units) {
+    if (value < 1024) break;
+    value /= 1024;
+    unit = u;
+  }
+  return `${value.toFixed(1)} ${unit}`;
+}
+
+/**
+ * CPU percentage for the container-stats line, one decimal place.
+ * Negative or non-finite inputs render as `0.0%`.
+ */
+export function formatCpuPercent(value: number): string {
+  if (!Number.isFinite(value) || value < 0) return '0.0%';
+  return `${value.toFixed(1)}%`;
+}

--- a/src/lib/components/endpoint-row-helpers.test.ts
+++ b/src/lib/components/endpoint-row-helpers.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+
+import type { IsolationState } from '$lib/types';
+import { getIsolationBadge, getIsolationDetail } from './endpoint-row-helpers';
+
+// The test env is Node (vitest.config.ts), so we exercise the pure helpers
+// shared by `EndpointRow.svelte` / `DetailPanel.svelte` (via
+// `IsolationBadge.svelte`) rather than mounting Svelte components — same
+// pattern as ToolCallRow.test.ts and detail-panel-helpers.test.ts.
+
+describe('getIsolationBadge', () => {
+  it('returns null when isolation_state is absent (older relay / non-stdio)', () => {
+    expect(getIsolationBadge(undefined)).toBeNull();
+    expect(getIsolationBadge(null)).toBeNull();
+  });
+
+  it('returns null for a normal direct spawn (configured = none, actual = direct)', () => {
+    const iso: IsolationState = { configured: 'none', actual: 'direct' };
+    expect(getIsolationBadge(iso)).toBeNull();
+  });
+
+  it('returns a container badge naming the runtime when actual = container', () => {
+    const iso: IsolationState = {
+      configured: 'container',
+      actual: 'container',
+      runtime: 'docker',
+    };
+    const badge = getIsolationBadge(iso);
+    expect(badge?.kind).toBe('container');
+    expect(badge?.label).toBe('Containerized (docker)');
+  });
+
+  it('names podman when that is the reported runtime', () => {
+    const iso: IsolationState = {
+      configured: 'container',
+      actual: 'container',
+      runtime: 'podman',
+    };
+    expect(getIsolationBadge(iso)?.label).toBe('Containerized (podman)');
+  });
+
+  it('omits the runtime suffix when the relay does not report one', () => {
+    const iso: IsolationState = { configured: 'container', actual: 'container' };
+    const badge = getIsolationBadge(iso);
+    expect(badge?.kind).toBe('container');
+    expect(badge?.label).toBe('Containerized');
+  });
+
+  it('returns a warning fallback badge when configured = container but actual = direct', () => {
+    const iso: IsolationState = { configured: 'container', actual: 'direct' };
+    const badge = getIsolationBadge(iso);
+    expect(badge?.kind).toBe('fallback');
+    expect(badge?.label).toBe('Direct (fallback)');
+    expect(badge?.title).toContain('fell back');
+  });
+});
+
+describe('getIsolationDetail', () => {
+  it('returns null when isolation_state is absent or not containerized', () => {
+    expect(getIsolationDetail(undefined)).toBeNull();
+    expect(getIsolationDetail(null)).toBeNull();
+    expect(getIsolationDetail({ configured: 'container', actual: 'direct' })).toBeNull();
+  });
+
+  it('joins image and container name when both are reported', () => {
+    const iso: IsolationState = {
+      configured: 'container',
+      actual: 'container',
+      runtime: 'docker',
+      image: 'node:20-alpine',
+      container_name: 'endara-mcp-github',
+    };
+    expect(getIsolationDetail(iso)).toBe('node:20-alpine · endara-mcp-github');
+  });
+
+  it('renders whichever of image / container name is present', () => {
+    expect(
+      getIsolationDetail({ configured: 'container', actual: 'container', image: 'node:20' }),
+    ).toBe('node:20');
+    expect(
+      getIsolationDetail({
+        configured: 'container',
+        actual: 'container',
+        container_name: 'endara-mcp-fetch',
+      }),
+    ).toBe('endara-mcp-fetch');
+  });
+
+  it('returns null when containerized but neither image nor name is reported', () => {
+    expect(getIsolationDetail({ configured: 'container', actual: 'container' })).toBeNull();
+  });
+});

--- a/src/lib/components/endpoint-row-helpers.test.ts
+++ b/src/lib/components/endpoint-row-helpers.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'vitest';
 
 import type { IsolationState } from '$lib/types';
-import { getIsolationBadge, getIsolationDetail } from './endpoint-row-helpers';
+import {
+  getIsolationBadge,
+  getCustomImage,
+  DEFAULT_CONTAINER_IMAGE,
+} from './endpoint-row-helpers';
 
 // The test env is Node (vitest.config.ts), so we exercise the pure helpers
 // shared by `EndpointRow.svelte` / `DetailPanel.svelte` (via
@@ -55,38 +59,67 @@ describe('getIsolationBadge', () => {
   });
 });
 
-describe('getIsolationDetail', () => {
+describe('getCustomImage', () => {
   it('returns null when isolation_state is absent or not containerized', () => {
-    expect(getIsolationDetail(undefined)).toBeNull();
-    expect(getIsolationDetail(null)).toBeNull();
-    expect(getIsolationDetail({ configured: 'container', actual: 'direct' })).toBeNull();
+    expect(getCustomImage(undefined)).toBeNull();
+    expect(getCustomImage(null)).toBeNull();
+    expect(getCustomImage({ configured: 'container', actual: 'direct' })).toBeNull();
   });
 
-  it('joins image and container name when both are reported', () => {
+  it('returns null when the image is the default runner image', () => {
+    const iso: IsolationState = {
+      configured: 'container',
+      actual: 'container',
+      runtime: 'docker',
+      image: DEFAULT_CONTAINER_IMAGE,
+    };
+    expect(getCustomImage(iso)).toBeNull();
+  });
+
+  it('returns the image string when a custom image is in effect', () => {
     const iso: IsolationState = {
       configured: 'container',
       actual: 'container',
       runtime: 'docker',
       image: 'node:20-alpine',
-      container_name: 'endara-mcp-github',
     };
-    expect(getIsolationDetail(iso)).toBe('node:20-alpine · endara-mcp-github');
+    expect(getCustomImage(iso)).toBe('node:20-alpine');
   });
 
-  it('renders whichever of image / container name is present', () => {
+  it('ignores container_name entirely (internal plumbing, never surfaced)', () => {
     expect(
-      getIsolationDetail({ configured: 'container', actual: 'container', image: 'node:20' }),
-    ).toBe('node:20');
-    expect(
-      getIsolationDetail({
+      getCustomImage({
         configured: 'container',
         actual: 'container',
-        container_name: 'endara-mcp-fetch',
+        container_name: 'endara-mcp-github',
       }),
-    ).toBe('endara-mcp-fetch');
+    ).toBeNull();
+    expect(
+      getCustomImage({
+        configured: 'container',
+        actual: 'container',
+        image: 'node:20',
+        container_name: 'endara-mcp-github',
+      }),
+    ).toBe('node:20');
   });
 
-  it('returns null when containerized but neither image nor name is reported', () => {
-    expect(getIsolationDetail({ configured: 'container', actual: 'container' })).toBeNull();
+  it('returns null when containerized but no image is reported', () => {
+    expect(getCustomImage({ configured: 'container', actual: 'container' })).toBeNull();
+  });
+});
+
+// Source-level guard: the isolation badge must live only in the detail-panel
+// header, never in the sidebar row. Mirrors the `?raw` source-assertion
+// pattern used in ToastFeed.test.ts since the test env doesn't mount Svelte.
+describe('sidebar / detail isolation badge placement', () => {
+  it('EndpointRow.svelte renders no IsolationBadge', async () => {
+    const src = (await import('./EndpointRow.svelte?raw')).default as string;
+    expect(src).not.toContain('IsolationBadge');
+  });
+
+  it('DetailPanel.svelte still renders the IsolationBadge in its header', async () => {
+    const src = (await import('./DetailPanel.svelte?raw')).default as string;
+    expect(src).toContain('IsolationBadge');
   });
 });

--- a/src/lib/components/endpoint-row-helpers.test.ts
+++ b/src/lib/components/endpoint-row-helpers.test.ts
@@ -31,7 +31,7 @@ describe('getIsolationBadge', () => {
     };
     const badge = getIsolationBadge(iso);
     expect(badge?.kind).toBe('container');
-    expect(badge?.label).toBe('Containerized (docker)');
+    expect(badge?.label).toBe('CONTAINERIZED (docker)');
   });
 
   it('names podman when that is the reported runtime', () => {
@@ -40,21 +40,21 @@ describe('getIsolationBadge', () => {
       actual: 'container',
       runtime: 'podman',
     };
-    expect(getIsolationBadge(iso)?.label).toBe('Containerized (podman)');
+    expect(getIsolationBadge(iso)?.label).toBe('CONTAINERIZED (podman)');
   });
 
   it('omits the runtime suffix when the relay does not report one', () => {
     const iso: IsolationState = { configured: 'container', actual: 'container' };
     const badge = getIsolationBadge(iso);
     expect(badge?.kind).toBe('container');
-    expect(badge?.label).toBe('Containerized');
+    expect(badge?.label).toBe('CONTAINERIZED');
   });
 
   it('returns a warning fallback badge when configured = container but actual = direct', () => {
     const iso: IsolationState = { configured: 'container', actual: 'direct' };
     const badge = getIsolationBadge(iso);
     expect(badge?.kind).toBe('fallback');
-    expect(badge?.label).toBe('Direct (fallback)');
+    expect(badge?.label).toBe('DIRECT (fallback)');
     expect(badge?.title).toContain('fell back');
   });
 });

--- a/src/lib/components/endpoint-row-helpers.ts
+++ b/src/lib/components/endpoint-row-helpers.ts
@@ -61,17 +61,25 @@ export function getIsolationBadge(
 }
 
 /**
- * Secondary detail line for the detail panel: container image and name for
- * an endpoint that is actually containerized (e.g. `node:20-alpine ·
- * endara-mcp-github`). `null` when not containerized or when neither field
- * is reported.
+ * Default container image the relay runs stdio servers in. When an endpoint
+ * reports this exact image, it is the out-of-the-box default and we don't
+ * surface it in the UI — only a user-supplied custom image is worth showing.
  */
-export function getIsolationDetail(
+export const DEFAULT_CONTAINER_IMAGE = 'ghcr.io/endara-ai/mcp-runner:latest';
+
+/**
+ * Custom container image for the detail panel, shown only when the endpoint
+ * is actually containerized AND a user-supplied image is in effect (i.e. it
+ * differs from {@link DEFAULT_CONTAINER_IMAGE}). Returns `null` when not
+ * containerized, when no image is reported, or when the image is the default.
+ * The internal `container_name` (e.g. `endara-mcp-<endpoint>`) is deliberately
+ * ignored — it is plumbing and never surfaced in the normal UI.
+ */
+export function getCustomImage(
   isolation: IsolationState | null | undefined,
 ): string | null {
   if (!isolation || isolation.actual !== 'container') return null;
-  const parts = [isolation.image, isolation.container_name].filter(
-    (p): p is string => !!p,
-  );
-  return parts.length > 0 ? parts.join(' · ') : null;
+  const image = isolation.image?.trim();
+  if (!image || image === DEFAULT_CONTAINER_IMAGE) return null;
+  return image;
 }

--- a/src/lib/components/endpoint-row-helpers.ts
+++ b/src/lib/components/endpoint-row-helpers.ts
@@ -1,4 +1,4 @@
-import type { Endpoint } from '$lib/types';
+import type { Endpoint, IsolationState } from '$lib/types';
 
 /**
  * Compact secondary label rendered next to the transport badge in
@@ -16,4 +16,62 @@ export function getEndpointStatusLabel(
     return 'Initializing…';
   }
   return `${endpoint.tool_count} tools`;
+}
+
+/**
+ * Badge descriptor for the relay's `isolation_state` field, shared by
+ * `EndpointRow.svelte` and `DetailPanel.svelte` (rendered via
+ * `IsolationBadge.svelte`).
+ */
+export interface IsolationBadgeInfo {
+  kind: 'container' | 'fallback';
+  label: string;
+  title: string;
+}
+
+/**
+ * Compute the isolation badge for an endpoint, or `null` when no badge
+ * should render:
+ * - actual = container → "Containerized (runtime)" badge.
+ * - configured = container but actual = direct → warning "Direct (fallback)"
+ *   badge so silent fallbacks are visible.
+ * - absent (non-stdio / older relay) or a normal direct spawn
+ *   (configured = none, actual = direct) → no badge.
+ */
+export function getIsolationBadge(
+  isolation: IsolationState | null | undefined,
+): IsolationBadgeInfo | null {
+  if (!isolation) return null;
+  if (isolation.actual === 'container') {
+    return {
+      kind: 'container',
+      label: isolation.runtime ? `Containerized (${isolation.runtime})` : 'Containerized',
+      title: 'This server runs inside an isolated container',
+    };
+  }
+  if (isolation.configured === 'container') {
+    return {
+      kind: 'fallback',
+      label: 'Direct (fallback)',
+      title:
+        'Container isolation is configured, but the server fell back to running directly on the host (no usable container runtime)',
+    };
+  }
+  return null;
+}
+
+/**
+ * Secondary detail line for the detail panel: container image and name for
+ * an endpoint that is actually containerized (e.g. `node:20-alpine ·
+ * endara-mcp-github`). `null` when not containerized or when neither field
+ * is reported.
+ */
+export function getIsolationDetail(
+  isolation: IsolationState | null | undefined,
+): string | null {
+  if (!isolation || isolation.actual !== 'container') return null;
+  const parts = [isolation.image, isolation.container_name].filter(
+    (p): p is string => !!p,
+  );
+  return parts.length > 0 ? parts.join(' · ') : null;
 }

--- a/src/lib/components/endpoint-row-helpers.ts
+++ b/src/lib/components/endpoint-row-helpers.ts
@@ -32,8 +32,8 @@ export interface IsolationBadgeInfo {
 /**
  * Compute the isolation badge for an endpoint, or `null` when no badge
  * should render:
- * - actual = container → "Containerized (runtime)" badge.
- * - configured = container but actual = direct → warning "Direct (fallback)"
+ * - actual = container → "CONTAINERIZED (runtime)" badge.
+ * - configured = container but actual = direct → warning "DIRECT (fallback)"
  *   badge so silent fallbacks are visible.
  * - absent (non-stdio / older relay) or a normal direct spawn
  *   (configured = none, actual = direct) → no badge.
@@ -45,14 +45,14 @@ export function getIsolationBadge(
   if (isolation.actual === 'container') {
     return {
       kind: 'container',
-      label: isolation.runtime ? `Containerized (${isolation.runtime})` : 'Containerized',
+      label: isolation.runtime ? `CONTAINERIZED (${isolation.runtime})` : 'CONTAINERIZED',
       title: 'This server runs inside an isolated container',
     };
   }
   if (isolation.configured === 'container') {
     return {
       kind: 'fallback',
-      label: 'Direct (fallback)',
+      label: 'DIRECT (fallback)',
       title:
         'Container isolation is configured, but the server fell back to running directly on the host (no usable container runtime)',
     };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -24,6 +24,20 @@ export interface ContainerStats {
   net_tx_bytes: number;
 }
 
+/**
+ * Isolation status reported by the relay for stdio endpoints. `configured`
+ * is what `config.toml` asked for; `actual` is what the relay actually did
+ * (it falls back to a direct spawn when no container runtime is usable).
+ * Absent for non-stdio endpoints and for older relays that predate the field.
+ */
+export interface IsolationState {
+  configured: 'container' | 'none';
+  actual: 'container' | 'direct';
+  runtime?: 'docker' | 'podman';
+  container_name?: string;
+  image?: string;
+}
+
 // Lifecycle state from the management API (GET /api/endpoints)
 export type LifecycleState = 'Initializing' | 'Ready' | 'Failed' | 'Stopped';
 
@@ -68,6 +82,11 @@ export interface Endpoint {
    * up by the desktop's 2s endpoint poll loop.
    */
   container_stats?: ContainerStats | null;
+  /**
+   * Present only for stdio endpoints on relays that report it; absent for
+   * non-stdio endpoints and older relays.
+   */
+  isolation_state?: IsolationState | null;
 }
 
 export interface Tool {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,6 +5,23 @@ export interface RelayStatus {
   uptime_seconds: number;
   endpoint_count: number;
   healthy_count: number;
+  /**
+   * Whether the relay detected a usable container runtime (Docker/Podman)
+   * on the host. Optional — older relays omit it, so only an explicit
+   * `false` should drive the "no runtime" notice in the Add Server flow.
+   */
+  container_runtime_available?: boolean;
+}
+
+/**
+ * Live resource usage polled from the container runtime for a containerized
+ * stdio endpoint. Mirrors the relay's `container_stats` management-API field.
+ */
+export interface ContainerStats {
+  cpu_percent: number;
+  mem_bytes: number;
+  net_rx_bytes: number;
+  net_tx_bytes: number;
 }
 
 // Lifecycle state from the management API (GET /api/endpoints)
@@ -45,6 +62,12 @@ export interface Endpoint {
   disabled: boolean;
   error?: string;
   lifecycle?: Lifecycle;
+  /**
+   * Present only for containerized stdio endpoints; absent/null for
+   * direct-spawn endpoints. Updated by the relay's stats poller and picked
+   * up by the desktop's 2s endpoint poll loop.
+   */
+  container_stats?: ContainerStats | null;
 }
 
 export interface Tool {


### PR DESCRIPTION
# Desktop UI for containerized stdio MCP servers

Companion to endara-ai/endara-relay#101. The relay can now run stdio MCP servers inside an isolated container (Docker/Podman) via the new `isolation` config field; this PR adds the desktop UI for that feature.

## What's included

- **Catalog containerizable flags + badges** — `CatalogServer` gains `containerizable` / `containerNote`; entries that don't suit containerization (Filesystem, Puppeteer, Memory) show a visible **"Not containerized"** badge in the add flow and are added with `isolation = "none"`. All other catalog entries default to container.
- **Isolation toggle with explicit isolation on create** — the add-endpoint modal includes an isolation toggle and always writes an explicit `isolation` value (`"container"` or `"none"`) for new stdio endpoints. Combined with the relay treating an *omitted* `isolation` as direct spawn, only new endpoints containerize by default — existing configs are untouched on upgrade.
- **Runtime-missing notice** — when `GET /api/status` reports `container_runtime_available = false`, the UI explains why isolation is off ("install Docker/Podman for isolation") instead of hard-failing.
- **Container metrics display** — the detail panel shows CPU / memory / network stats from the endpoint's `container_stats`.
- **ConfigTab isolation passthrough** — endpoint updates pass `isolation` through so the relay's PUT (which rebuilds the whole endpoint config) doesn't drop the stored value.

Also includes a small `chore:` commit syncing `package-lock.json` to the 0.1.9 version bump from #110.

## Verification

- `npm run check` — svelte-check: 0 errors, 0 warnings
- `npm run lint` — clean (no linter configured)
- `npm test` — 777 passed, 24 skipped (42 files)

## Notes

- Should merge alongside endara-ai/endara-relay#101; the UI degrades gracefully against an older relay (no `container_runtime_available` / `container_stats` fields).
- Known minor: status is fetched once at modal mount, so the no-runtime notice could be missed in the sub-second detection window right after relay startup.
