### PR TITLE
fix(logs): strip all leading whitespace and colons in text-parser fallback

### DIFF
--- a/src/lib/logParser.test.ts
+++ b/src/lib/logParser.test.ts
@@ -702,3 +702,52 @@ describe('parseLogLine — trailing event fields (defense-in-depth)', () => {
   });
 });
 
+describe('parseLogLine — leading colon cleanup after span removal', () => {
+  // A single span leaves one `: ` separator before the message text. The
+  // cleanup must drop it so users never see a leading colon on the row.
+  it('strips the leading colon left by a single endpoint span', () => {
+    const parsed = parseLogLine(
+      'info',
+      'endpoint{endpoint="github"}: MCP server process spawned',
+    );
+    expect(parsed.endpoint).toBe('github');
+    expect(parsed.message).toBe('MCP server process spawned');
+    expect(parsed.message.startsWith(':')).toBe(false);
+  });
+
+  // Nested spans (e.g. the watcher's `endpoint{…}` wrapping the adapter's
+  // `endpoint{…}`) leave `::` once both are removed. All leading colons go.
+  it('strips the double colon left by two nested endpoint spans', () => {
+    const parsed = parseLogLine(
+      'info',
+      'endpoint{endpoint="github"}:endpoint{endpoint="github"}: MCP server process spawned',
+    );
+    expect(parsed.endpoint).toBe('github');
+    expect(parsed.message).toBe('MCP server process spawned');
+    expect(parsed.message.startsWith(':')).toBe(false);
+  });
+
+  // No span at all, but a stray leading colon (e.g. left after timestamp/level
+  // stripping) must still be removed.
+  it('strips a stray leading colon when no span is present', () => {
+    const parsed = parseLogLine(
+      'info',
+      '2026-05-20T17:54:47.123Z INFO : MCP server process spawned',
+    );
+    expect(parsed.level).toBe('info');
+    expect(parsed.message).toBe('MCP server process spawned');
+    expect(parsed.message.startsWith(':')).toBe(false);
+  });
+
+  // Only leading colons are stripped — a colon inside the message body
+  // (e.g. `Reason: foo`) must be preserved.
+  it('preserves colons inside the message body', () => {
+    const parsed = parseLogLine(
+      'info',
+      'endpoint{endpoint="github"}: Reason: connection refused',
+    );
+    expect(parsed.endpoint).toBe('github');
+    expect(parsed.message).toBe('Reason: connection refused');
+  });
+});
+

--- a/src/lib/logParser.ts
+++ b/src/lib/logParser.ts
@@ -257,9 +257,11 @@ export function parseLogLine(
     }
     cleanMessage = cleanMessage.replace(full, '');
   }
-  // After span removal we may be left with leading whitespace and a stray
-  // ": " separator that preceded the message text. Collapse both.
-  cleanMessage = cleanMessage.replace(/^\s+/, '').replace(/^:\s*/, '').trim();
+  // After span removal we may be left with leading whitespace and one or more
+  // stray ":" separators (one per removed span, e.g. nested spans leave `::`)
+  // that preceded the message text. Strip every leading whitespace/colon in a
+  // single pass; in-message colons are untouched.
+  cleanMessage = cleanMessage.replace(/^[\s:]+/, '').trim();
 
   // Scan with a regex (not split-on-whitespace) so quoted multi-word values
   // such as `endpoint="Two Words"` stay intact instead of leaking the trailing


### PR DESCRIPTION
## Summary

Removes the stray leading `:` (and `::` from nested same-named spans) that the desktop's text-parser fallback was leaving on rendered log rows.

## Background

The relay emits tracing logs in three formats. The desktop sidecar forces `--log-format json` (which goes through `parseJsonLogLine`), but a few paths still flow through the text/compact-format fallback in `parseLogLine`:

- The relay running outside the sidecar in `compact` mode (e.g. `cargo run` during dev).
- Per-endpoint activity-log seeds from `GET /api/endpoints/:name/logs`.

When the relay nests two same-named spans (e.g. the watcher wraps `create_adapter` in `info_span!("endpoint", ...)` and the adapter constructs its own `info_span!("endpoint", ...)`), the compact format renders `endpoint{...}:endpoint{...}: msg`. After stripping both spans the desktop was left with `:: msg`, and the cleanup regex `^:\s*` only consumed one leading colon — so the user saw `: msg` (or `:: msg` in some cases) on rows like `MCP server process spawned`.

## Change

```diff
- cleanMessage = cleanMessage.replace(/^\s+/, '').replace(/^:\s*/, '').trim();
+ cleanMessage = cleanMessage.replace(/^[\s:]+/, '').trim();
```

One-pass strip of any leading whitespace + colon combo. In-message colons (e.g. `endara_relay::registry: Registering adapter`) are untouched — the regex is anchored at start.

## Tests

Added 4 regression tests in `logParser.test.ts`:

1. Single `endpoint{...}:` span (existing happy path — still no leading colon).
2. Two nested `endpoint{...}:endpoint{...}:` spans — no leading colon.
3. Stray leading colon with no span — stripped.
4. In-message colons (e.g. `Reason: foo`) — preserved.

The existing module-path test (`endara_relay::registry: Registering adapter`) stays green.

`pnpm test -- logParser` → 820 passed / 35 skipped.

## Companion relay PR

The underlying nested-span structure is also cleaned up on the relay side (rename of the watcher's async `endpoint` wrapper span to `endpoint_init`) in a separate PR. The desktop fix is independent and lands first because it covers every text-parser fallback path, including older relay versions.
