### PR TITLE
fix(ui): increase spacing between Transport pills and Name field

### DIFF
--- a/src/lib/components/AddEndpointModal.svelte
+++ b/src/lib/components/AddEndpointModal.svelte
@@ -966,7 +966,7 @@
           </fieldset>
         {/if}
 
-        <div>
+        <div class="mt-2">
           <label for="modal-ep-name" class="block text-xs font-medium mb-1 text-(--fg2)">Name</label>
           <input id="modal-ep-name" type="text" bind:value={name} placeholder="my-server"
             aria-invalid={!!fieldErrors.name}

--- a/src/lib/components/ConfigTab.svelte
+++ b/src/lib/components/ConfigTab.svelte
@@ -395,7 +395,7 @@
           </div>
         </fieldset>
 
-        <div>
+        <div class="mt-2">
           <label for="config-ep-name" class="block text-xs font-medium mb-1 text-(--fg2)">Name</label>
           <input id="config-ep-name" type="text" bind:value={name} placeholder="my-server"
             class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent)" />


### PR DESCRIPTION
## Summary

Increases the vertical spacing between the Transport pill row (STDIO / SSE / HTTP / OAUTH) and the **Name** field in the server configuration UI.

Both forms separate fields with `space-y-3`, so the Transport→Name gap previously matched every other field gap. This adds `mt-2` to the Name `<div>` so only that one gap grows, leaving all other field spacing unchanged.

## Changes

- `src/lib/components/ConfigTab.svelte` — `mt-2` on the Name field block (per-server Config tab).
- `src/lib/components/AddEndpointModal.svelte` — `mt-2` on the Name field block (Add Server modal, custom transport view).

## Notes

Purely additive Tailwind utility classes in markup — no logic, type, or behavior changes.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author