### PR TITLE
feat(overlay): render friendly client label on notification card

### DIFF
--- a/src/lib/overlay/OverlayCard.test.ts
+++ b/src/lib/overlay/OverlayCard.test.ts
@@ -230,6 +230,29 @@ describe('OverlayCard — caller label on row 2', () => {
     expect(callerLabel(group.client)).toBe('Claude Desktop');
   });
 
+  it('prefers the relay friendly label over the raw client.name', async () => {
+    const group = g({
+      client: {
+        name: 'local-agent-mode-Endara Relay (via mcp-remote 0.1.37)',
+        label: 'Claude Cowork',
+      },
+      serverType: 'Linear',
+    });
+    const { callerLabel } = await import('./overlay-helpers');
+    expect(callerLabel(group.client)).toBe('Claude Cowork');
+  });
+
+  it('falls back to the name when the friendly label is absent', async () => {
+    const group = g({
+      client: { name: 'local-agent-mode-Endara Relay (via mcp-remote 0.1.37)' },
+      serverType: 'Linear',
+    });
+    const { callerLabel } = await import('./overlay-helpers');
+    expect(callerLabel(group.client)).toBe(
+      'local-agent-mode-Endara Relay (via mcp-remote 0.1.37)',
+    );
+  });
+
   it('falls back to user_agent product token when name is absent', async () => {
     const group = g({
       client: { user_agent: 'claude-ai/0.1.0' },

--- a/src/lib/overlay/overlay-helpers.test.ts
+++ b/src/lib/overlay/overlay-helpers.test.ts
@@ -146,6 +146,28 @@ describe('callerLabel', () => {
     expect(callerLabel({ origin: 'https://example.com' })).toBeNull();
   });
 
+  it('prefers a non-empty client.label over the raw name / user_agent fallback', () => {
+    expect(
+      callerLabel({
+        name: 'local-agent-mode-Endara Relay (via mcp-remote 0.1.37)',
+        label: 'Claude Cowork',
+      }),
+    ).toBe('Claude Cowork');
+    // trims whitespace and wins over user_agent too
+    expect(callerLabel({ label: '  Claude Cowork  ', user_agent: 'claude-ai/0.1.0' })).toBe(
+      'Claude Cowork',
+    );
+  });
+
+  it('falls back to name / user_agent when label is absent or empty', () => {
+    // empty / whitespace-only label behaves exactly as today
+    expect(
+      callerLabel({ label: '', name: 'local-agent-mode-Endara Relay (via mcp-remote 0.1.37)' }),
+    ).toBe('local-agent-mode-Endara Relay (via mcp-remote 0.1.37)');
+    expect(callerLabel({ label: '   ', user_agent: 'claude-ai/0.1.0' })).toBe('claude-ai');
+    expect(callerLabel({ label: null, name: 'Cursor' })).toBe('Cursor');
+  });
+
   it('prefers client.name (without version) when present', () => {
     expect(callerLabel({ name: 'Claude Desktop', version: '0.7.0' })).toBe('Claude Desktop');
   });

--- a/src/lib/overlay/overlay-helpers.ts
+++ b/src/lib/overlay/overlay-helpers.ts
@@ -119,13 +119,16 @@ export const DEFAULT_OVERLAY_POSITION: OverlayPosition = 'bottom-right';
 /**
  * Resolve a short, friendly caller label for the overlay card.
  *
- * Returns `client.name` (trimmed, without version) when present; otherwise a
+ * Returns `client.label` (trimmed) when present — the relay's friendly display
+ * label; otherwise `client.name` (trimmed, without version); otherwise a
  * friendly label derived from `user_agent` (the leading product token, before
  * the first `/`); otherwise `null` when no caller signal is known. "Missing
  * key" and explicit `null`/empty values are treated identically.
  */
 export function callerLabel(client: ClientIdentity | null | undefined): string | null {
   if (!client) return null;
+  const label = typeof client.label === 'string' ? client.label.trim() : '';
+  if (label.length > 0) return label;
   const name = typeof client.name === 'string' ? client.name.trim() : '';
   if (name.length > 0) return name;
   const ua = typeof client.user_agent === 'string' ? client.user_agent.trim() : '';

--- a/src/lib/overlay/types.ts
+++ b/src/lib/overlay/types.ts
@@ -23,6 +23,10 @@ export type ClientIdentity = {
   version?: string | null;
   user_agent?: string | null;
   origin?: string | null;
+  // Friendly display label the relay serializes for the embedded `client`
+  // object (see the custom `Serialize` on `ClientIdentity` in
+  // `packages/relay/src/events.rs`); preferred over the raw `name`.
+  label?: string | null;
 };
 
 export type StartedEvent = {


### PR DESCRIPTION
## Summary

The overlay / notification card displayed the raw inbound MCP client name (e.g. "local-agent-mode-Endara Relay (via mcp-remote 0.1.37)") instead of the relay's friendly label ("Claude Cowork"). The relay already serializes a friendly **label** field on the embedded **client** object in the tool-call-event payload, and the Logs view already renders it via the flat client_name audit field — but the card's callerLabel() helper ignored it.

## Changes

- **src/lib/overlay/types.ts** — add optional **label** to the ClientIdentity type (mirrors the relay's serialized field; raw name/version/user_agent/origin unchanged).
- **src/lib/overlay/overlay-helpers.ts** — callerLabel() now prefers a non-empty trimmed client.label before the existing name -> user_agent product-token fallback. When label is missing/empty, behavior is byte-for-byte identical to before.
- **Tests** — overlay-helpers.test.ts and OverlayCard.test.ts gain label-precedence and label-absent fallback cases.

## Scope

Desktop-only, 4 files, all under src/lib/overlay/. No Logs view (ToolCallRow / tool-call-row-helpers) changes. No relay changes.

## Verification

- pnpm exec vitest run (overlay files) -> 59 passed
- pnpm run check -> 0 errors (1 pre-existing, unrelated 'node' types warning)

Independently verified by a reviewer agent: precedence and absent-fallback confirmed, card path (OverlayCard.svelte row-2 caller derived) confirmed to surface the label.