### PR TITLE
fix(overlay): sync dismiss-bar duration with configured auto-dismiss

### DIFF
--- a/src/lib/overlay/OverlayApp.svelte
+++ b/src/lib/overlay/OverlayApp.svelte
@@ -106,6 +106,7 @@
     position={$overlaySettings.position}
     maxVisible={$overlaySettings.max_visible}
     showProfile={$overlaySettings.show_profile}
+    dismissMs={$overlaySettings.auto_dismiss_ms}
   />
 </div>
 

--- a/src/lib/overlay/OverlayCard.svelte
+++ b/src/lib/overlay/OverlayCard.svelte
@@ -10,9 +10,12 @@
   The bar appears only after the group has settled (`inflight === 0` and
   at least one resolved request). Its colour is green when no errors
   were observed and red as soon as any error landed. The bar's CSS
-  keyframe runs to completion in `dismissDurationMs` and the
-  `toastStore`'s matching per-group `setTimeout` removes the card at the
-  same offset — no hover-pause, no pause/resume binding on the keyframe.
+  keyframe runs to completion in `group.dismissDurationMs` (the exact
+  duration the `toastStore` armed this group's per-group `setTimeout`
+  with) so the bar reaches 100% as the card is removed — even if
+  `auto_dismiss_ms` changes mid-countdown. Falls back to the
+  `dismissDurationMs` prop when the group is not counting down. No
+  hover-pause, no pause/resume binding on the keyframe.
 
   Click invokes `focusLogForRequest(latest.jsonrpcId)`; if the latest request
   has no jsonrpc_id the card is rendered non-clickable (cursor: default) and
@@ -38,10 +41,12 @@
   type Props = {
     group: ToolCallGroup;
     showProfile?: boolean;
-    // Duration of the per-card dismiss bar's CSS keyframe. The
-    // matching `setTimeout` in `toastStore` fires at the same offset
-    // so the bar reaches 100% just as the card is removed. Defaults
-    // to 6000ms; `ToastFeed` pipes `store.getOpts().dismissMs`.
+    // Fallback duration (ms) for the per-card dismiss bar's CSS keyframe,
+    // used only when `group.dismissDurationMs` is null (i.e. the group is
+    // not counting down). When the group IS armed, the bar reads the
+    // duration the store captured at arm time so it matches the per-group
+    // `setTimeout` exactly. Defaults to 6000ms; `ToastFeed` pipes the
+    // reactive `dismissMs` prop down as this fallback.
     dismissDurationMs?: number;
   };
   let { group, showProfile = true, dismissDurationMs = 6000 }: Props = $props();
@@ -70,6 +75,12 @@
   // Key the bar element on this so each (re)arm re-mounts the
   // `tfDismissFill` keyframe from 0%.
   const barTick = $derived(group.dismissTick);
+  // Bar duration: read the value the store captured for THIS countdown
+  // (so the CSS keyframe matches the per-group `setTimeout` armed with
+  // the same value, even if `auto_dismiss_ms` changes mid-countdown).
+  // Fall back to the `dismissDurationMs` prop when the group is not
+  // counting down (`group.dismissDurationMs === null`).
+  const barDurationMs = $derived(group.dismissDurationMs ?? dismissDurationMs);
   // Collapse row 2's duplicate label when serverType and serverName are the
   // same (e.g. `gmail · gmail · <profile>` → `gmail · <profile>`). Falls back
   // to the unchanged two-label layout whenever either side is null or differs.
@@ -194,7 +205,7 @@
             class="tf-dismiss-fill"
             data-testid="dismiss-fill"
             style:background={barColor}
-            style:animation-duration="{dismissDurationMs}ms"
+            style:animation-duration="{barDurationMs}ms"
           ></div>
         </div>
       {/key}

--- a/src/lib/overlay/OverlayCard.test.ts
+++ b/src/lib/overlay/OverlayCard.test.ts
@@ -35,6 +35,7 @@ function g(over: Partial<ToolCallGroup> = {}): ToolCallGroup {
     requests: [],
     lastUpdatedAt: 0,
     dismissAt: null,
+    dismissDurationMs: null,
     dismissTick: 0,
     ...over,
   };
@@ -362,7 +363,7 @@ describe('OverlayCard — per-card dismiss bar', () => {
     expect(src).toMatch(/class="tf-dismiss-bar"/);
     expect(src).toMatch(/class="tf-dismiss-fill"/);
     expect(src).toMatch(/style:background=\{barColor\}/);
-    expect(src).toMatch(/style:animation-duration="\{dismissDurationMs\}ms"/);
+    expect(src).toMatch(/style:animation-duration="\{barDurationMs\}ms"/);
     // No animation-play-state binding — hover-pause is gone.
     expect(src).not.toMatch(/animation-play-state/);
   });
@@ -370,5 +371,25 @@ describe('OverlayCard — per-card dismiss bar', () => {
   it('OverlayCard.svelte derives barTick from `group.dismissTick`', async () => {
     const src = (await import('./OverlayCard.svelte?raw')).default as string;
     expect(src).toMatch(/const barTick = \$derived\(group\.dismissTick\)/);
+  });
+
+  // The bar's CSS keyframe duration must read the value the store
+  // captured for THIS countdown (`group.dismissDurationMs`) so it stays
+  // in sync with the per-group `setTimeout`, falling back to the
+  // `dismissDurationMs` prop only when the group is not counting down.
+  it('OverlayCard.svelte derives barDurationMs from group.dismissDurationMs with the prop fallback', async () => {
+    const src = (await import('./OverlayCard.svelte?raw')).default as string;
+    expect(src).toMatch(
+      /const barDurationMs = \$derived\(group\.dismissDurationMs \?\? dismissDurationMs\)/,
+    );
+  });
+
+  // Logic mirror of the `$derived` above: an armed group's captured
+  // duration wins; a null (not-counting-down) group uses the prop.
+  it('bar duration uses group.dismissDurationMs when set, else the prop fallback', () => {
+    const barDurationMs = (group: ToolCallGroup, prop: number) =>
+      group.dismissDurationMs ?? prop;
+    expect(barDurationMs(g({ dismissDurationMs: 6000 }), 2000)).toBe(6000);
+    expect(barDurationMs(g({ dismissDurationMs: null }), 2000)).toBe(2000);
   });
 });

--- a/src/lib/overlay/ToastFeed.svelte
+++ b/src/lib/overlay/ToastFeed.svelte
@@ -23,6 +23,7 @@
     maxVisible?: number;
     cardWidth?: number;
     showProfile?: boolean;
+    dismissMs?: number;
   };
   let {
     store,
@@ -30,6 +31,7 @@
     maxVisible = 7,
     cardWidth = 340,
     showProfile = true,
+    dismissMs = 6000,
   }: Props = $props();
 
   const groups = $derived($store);
@@ -38,11 +40,11 @@
 
   // Per-card dismiss bar lives inside `OverlayCard` and reads its
   // timing state from `group.dismissTick` + `group.inflight`/
-  // `group.success`/`group.error`. The duration captured by the
-  // matching `setTimeout` in `toastStore` is exposed via
-  // `store.getOpts().dismissMs` and piped down so the CSS keyframe
-  // and the JS timeout stay aligned.
-  const dismissDurationMs = $derived(store.getOpts().dismissMs);
+  // `group.success`/`group.error`. The duration is supplied reactively
+  // by the parent (`OverlayApp` passes the live
+  // `$overlaySettings.auto_dismiss_ms`) and piped down so the CSS
+  // keyframe and the per-group `setTimeout` in `toastStore` stay aligned.
+  const dismissDurationMs = $derived(dismissMs);
 
   // Right-anchored corners slide in/out toward +x, left-anchored toward
   // −x. The transition directives live on the `.tf-feed-inner` container

--- a/src/lib/overlay/ToastFeed.svelte
+++ b/src/lib/overlay/ToastFeed.svelte
@@ -40,10 +40,13 @@
 
   // Per-card dismiss bar lives inside `OverlayCard` and reads its
   // timing state from `group.dismissTick` + `group.inflight`/
-  // `group.success`/`group.error`. The duration is supplied reactively
-  // by the parent (`OverlayApp` passes the live
-  // `$overlaySettings.auto_dismiss_ms`) and piped down so the CSS
-  // keyframe and the per-group `setTimeout` in `toastStore` stay aligned.
+  // `group.success`/`group.error`. An armed group carries the exact
+  // duration its per-group `setTimeout` was armed with on
+  // `group.dismissDurationMs`, and the card's CSS keyframe reads THAT —
+  // so the bar and the timer can never desync mid-countdown. This piped
+  // `dismissMs` (the live `$overlaySettings.auto_dismiss_ms` from
+  // `OverlayApp`) is forwarded only as the card's fallback default for
+  // groups that are not currently counting down.
   const dismissDurationMs = $derived(dismissMs);
 
   // Right-anchored corners slide in/out toward +x, left-anchored toward

--- a/src/lib/overlay/ToastFeed.test.ts
+++ b/src/lib/overlay/ToastFeed.test.ts
@@ -336,11 +336,22 @@ describe('ToastFeed — per-card dismiss bar plumbing', () => {
     expect(overlayCardMatches).toHaveLength(1);
   });
 
-  it('ToastFeed.svelte derives dismissDurationMs from `store.getOpts().dismissMs`', async () => {
+  it('ToastFeed.svelte accepts a `dismissMs` prop and derives dismissDurationMs from it', async () => {
     const src = (await import('./ToastFeed.svelte?raw')).default as string;
-    expect(src).toMatch(
-      /const dismissDurationMs = \$derived\(store\.getOpts\(\)\.dismissMs\)/,
-    );
+    // `dismissMs` is a declared prop (typed in `Props` + destructured from
+    // `$props()`), so the duration tracks the parent reactively rather than
+    // reading the seed value off `store.getOpts()`.
+    expect(src).toMatch(/dismissMs\?: number;/);
+    expect(src).toMatch(/dismissMs = 6000,/);
+    expect(src).toMatch(/const dismissDurationMs = \$derived\(dismissMs\)/);
+    // The old `store.getOpts().dismissMs` derivation must be gone so the
+    // bar duration is not stuck at the store's seed value.
+    expect(src).not.toMatch(/\$derived\(store\.getOpts\(\)\.dismissMs\)/);
+  });
+
+  it('OverlayApp.svelte passes $overlaySettings.auto_dismiss_ms to <ToastFeed>', async () => {
+    const src = (await import('./OverlayApp.svelte?raw')).default as string;
+    expect(src).toMatch(/dismissMs=\{\$overlaySettings\.auto_dismiss_ms\}/);
   });
 
   it('ToastFeed.svelte does NOT expose any hover-pause state to OverlayCard', async () => {

--- a/src/lib/overlay/ToastFeed.test.ts
+++ b/src/lib/overlay/ToastFeed.test.ts
@@ -316,11 +316,14 @@ describe('Overlay redesign — ghost stack stays removed', () => {
 
 // Per-card dismiss progress bar: lives inside `OverlayCard` and is
 // driven by `group.dismissTick` + `group.inflight`/`group.success`/
-// `group.error`. `ToastFeed` no longer owns any bar markup — it just
-// pipes `store.getOpts().dismissMs` down to each card as
-// `dismissDurationMs` so the CSS keyframe matches the per-group
-// `setTimeout` in `toastStore`. No hover-pause: pointer enter/leave
-// only toggles Tauri's ignore-cursor-events flag (see `OverlayApp`).
+// `group.error`. An armed group carries the exact duration its
+// `setTimeout` was armed with on `group.dismissDurationMs`, and the
+// card's CSS keyframe reads THAT. `ToastFeed` no longer owns any bar
+// markup — it just pipes the reactive `dismissMs` prop down to each card
+// as `dismissDurationMs`, which the card uses only as a fallback default
+// when the group is not counting down. No hover-pause: pointer
+// enter/leave only toggles Tauri's ignore-cursor-events flag (see
+// `OverlayApp`).
 describe('ToastFeed — per-card dismiss bar plumbing', () => {
   it('ToastFeed.svelte pipes `dismissDurationMs` into OverlayCard and renders no feed-level bar', async () => {
     const src = (await import('./ToastFeed.svelte?raw')).default as string;
@@ -382,9 +385,15 @@ describe('ToastFeed — per-card dismiss bar plumbing', () => {
     expect(src).toMatch(/style:background=\{barColor\}/);
   });
 
-  it('OverlayCard.svelte binds animation-duration to `dismissDurationMs`', async () => {
+  it('OverlayCard.svelte binds animation-duration to the captured `barDurationMs`', async () => {
     const src = (await import('./OverlayCard.svelte?raw')).default as string;
-    expect(src).toMatch(/style:animation-duration="\{dismissDurationMs\}ms"/);
+    expect(src).toMatch(/style:animation-duration="\{barDurationMs\}ms"/);
+    // `barDurationMs` prefers the store-captured `group.dismissDurationMs`
+    // (so the bar matches the per-group `setTimeout`), falling back to the
+    // piped `dismissDurationMs` prop when the group is not counting down.
+    expect(src).toMatch(
+      /const barDurationMs = \$derived\(group\.dismissDurationMs \?\? dismissDurationMs\)/,
+    );
   });
 
   it('OverlayApp.svelte has no hover-pause or renderer pointer handlers', async () => {

--- a/src/lib/overlay/overlay-actions.test.ts
+++ b/src/lib/overlay/overlay-actions.test.ts
@@ -26,6 +26,7 @@ function g(over: Partial<ToolCallGroup> = {}): ToolCallGroup {
     requests: [],
     lastUpdatedAt: 0,
     dismissAt: null,
+    dismissDurationMs: null,
     dismissTick: 0,
     ...over,
   };

--- a/src/lib/overlay/overlay-helpers.test.ts
+++ b/src/lib/overlay/overlay-helpers.test.ts
@@ -39,6 +39,7 @@ function makeGroup(over: Partial<ToolCallGroup> = {}): ToolCallGroup {
     requests: [],
     lastUpdatedAt: 0,
     dismissAt: null,
+    dismissDurationMs: null,
     dismissTick: 0,
     ...over,
   };

--- a/src/lib/overlay/toastStore.test.ts
+++ b/src/lib/overlay/toastStore.test.ts
@@ -469,4 +469,77 @@ describe('toastStore', () => {
       expect(b.dismissTick).toBe(0);
     });
   });
+
+  // `dismissDurationMs` captures, ON the group, the exact duration the
+  // per-group `setTimeout` was armed with — so the bar's CSS keyframe
+  // (which reads `group.dismissDurationMs`) can never desync from the
+  // timer. A `setOpts` mid-countdown only affects FUTURE arms.
+  describe('per-group captured dismiss duration', () => {
+    it('new group starts with dismissDurationMs=null', () => {
+      const store = createToastStore({ dismissMs: 1000 });
+      store.addStarted(started({ request_id: 'req-1' }));
+      const g = (get(store) as ToolCallGroup[])[0];
+      expect(g.dismissDurationMs).toBeNull();
+    });
+
+    it('settle while inflight remains > 0 does NOT capture a duration (stays null)', () => {
+      const store = createToastStore({ dismissMs: 1000 });
+      store.addStarted(started({ request_id: 'req-1' }));
+      store.addStarted(started({ request_id: 'req-2' }));
+      store.settle(completed('req-1', 'ok'));
+      const g = (get(store) as ToolCallGroup[])[0];
+      expect(g.dismissDurationMs).toBeNull();
+    });
+
+    it('settle-arm captures dismissDurationMs equal to the current opts.dismissMs', () => {
+      const store = createToastStore({ dismissMs: 1500 });
+      store.addStarted(started({ request_id: 'req-1' }));
+      store.settle(completed('req-1', 'ok'));
+      const g = (get(store) as ToolCallGroup[])[0];
+      expect(g.dismissDurationMs).toBe(1500);
+      expect(store.getOpts().dismissMs).toBe(1500);
+    });
+
+    it('changing opts mid-countdown does NOT change an already-armed group dismissDurationMs', () => {
+      const store = createToastStore({ dismissMs: 2000 });
+      store.addStarted(started({ request_id: 'req-1' }));
+      store.settle(completed('req-1', 'ok'));
+      expect((get(store) as ToolCallGroup[])[0].dismissDurationMs).toBe(2000);
+      // Settings change while the card is counting down: future arms get
+      // 6000, but the already-armed group keeps the 2000 it was armed with.
+      store.setOpts({ dismissMs: 6000 });
+      const g = (get(store) as ToolCallGroup[])[0];
+      expect(g.dismissDurationMs).toBe(2000);
+      expect(g.dismissAt).toBe(g.lastUpdatedAt + 2000);
+    });
+
+    it('a new arm after setOpts picks up the new duration for BOTH bar and timer', () => {
+      const store = createToastStore({ dismissMs: 2000 });
+      store.addStarted(started({ request_id: 'req-1' }));
+      store.settle(completed('req-1', 'ok'));
+      // Cancel the countdown with a same-group started, then change opts.
+      store.addStarted(started({ request_id: 'req-2' }));
+      expect((get(store) as ToolCallGroup[])[0].dismissDurationMs).toBeNull();
+      store.setOpts({ dismissMs: 6000 });
+      const t0 = Date.now();
+      store.settle(completed('req-2', 'ok'));
+      const g = (get(store) as ToolCallGroup[])[0];
+      expect(g.dismissDurationMs).toBe(6000);
+      expect(g.dismissAt as number).toBe(t0 + 6000);
+      // And the timer fires at the new 6000 offset, not the old 2000.
+      vi.advanceTimersByTime(5999);
+      expect(get(store)).toHaveLength(1);
+      vi.advanceTimersByTime(2);
+      expect(get(store)).toEqual([]);
+    });
+
+    it('cancellation by same-group addStarted resets dismissDurationMs to null', () => {
+      const store = createToastStore({ dismissMs: 1000 });
+      store.addStarted(started({ request_id: 'req-1' }));
+      store.settle(completed('req-1', 'ok'));
+      expect((get(store) as ToolCallGroup[])[0].dismissDurationMs).toBe(1000);
+      store.addStarted(started({ request_id: 'req-2' }));
+      expect((get(store) as ToolCallGroup[])[0].dismissDurationMs).toBeNull();
+    });
+  });
 });

--- a/src/lib/overlay/toastStore.ts
+++ b/src/lib/overlay/toastStore.ts
@@ -75,6 +75,13 @@ export type ToolCallGroup = {
   // When this group started its own countdown (`Date.now() + opts.dismissMs`
   // at arm time), or `null` when no timer is running for this group.
   dismissAt: number | null;
+  // The exact duration (ms) the current countdown's `setTimeout` was
+  // armed with — captured from `opts.dismissMs` at arm time so the bar's
+  // CSS `animation-duration` reads the SAME value the timer is using. A
+  // later `setOpts` (e.g. `auto_dismiss_ms` changing mid-countdown) only
+  // affects FUTURE arms, never a card already counting down. `null` when
+  // no timer is running for this group.
+  dismissDurationMs: number | null;
   // Monotonically increasing per-group arm counter. The `OverlayCard`
   // uses this in `{#key group.dismissTick}` so the CSS keyframe on the
   // dismiss-fill remounts from 0% on every (re)arm.
@@ -181,6 +188,7 @@ export function createToastStore(initial?: Partial<ToastStoreOpts>): ToastStore 
         profile: event.profile ?? null,
         client: event.client ?? existing.client,
         dismissAt: wasCountingDown ? null : existing.dismissAt,
+        dismissDurationMs: wasCountingDown ? null : existing.dismissDurationMs,
         dismissTick: wasCountingDown ? existing.dismissTick + 1 : existing.dismissTick,
       };
       // Move to end (newest position).
@@ -200,6 +208,7 @@ export function createToastStore(initial?: Partial<ToastStoreOpts>): ToastStore 
         requests: [req],
         lastUpdatedAt: now,
         dismissAt: null,
+        dismissDurationMs: null,
         dismissTick: 0,
       });
     }
@@ -249,6 +258,7 @@ export function createToastStore(initial?: Partial<ToastStoreOpts>): ToastStore 
       error: target.error + (isError ? 1 : 0),
       lastUpdatedAt: now,
       dismissAt: willArm ? now + opts.dismissMs : target.dismissAt,
+      dismissDurationMs: willArm ? opts.dismissMs : target.dismissDurationMs,
       dismissTick: willArm ? target.dismissTick + 1 : target.dismissTick,
     };
     groups = groups.map((g) => (g.id === target.id ? updated : g));


### PR DESCRIPTION
## Summary

The desktop notification (overlay) card's dismiss **progress bar always animated over the 2000ms seed default** instead of the configured auto-dismiss duration. With a 6s `auto_dismiss_ms` setting, the bar filled in ~2s and then the card lingered until the real 6s timer fired.

## Root cause

The dismiss duration reached the UI two ways that drifted apart:

- The **JS dismiss timer** (`toastStore.armGroupTimer`) reads `opts.dismissMs` at arm time, and `OverlayApp` keeps `opts` current via `store.setOpts({ dismissMs: s.auto_dismiss_ms, ... })` whenever `overlaySettings` changes — so the card was removed at the correct offset.
- The **progress bar's CSS `animation-duration`** came from `ToastFeed`'s `const dismissDurationMs = $derived(store.getOpts().dismissMs)`. `getOpts()` returns a plain, non-reactive snapshot, so this `$derived` computed once at first render using the seed default (`DEFAULT_OVERLAY_SETTINGS.auto_dismiss_ms = 2000`) and never recomputed when `setOpts` later applied the user's setting.

## Fix

Drive the bar duration from the same reactive source that already feeds the timer:

- `OverlayApp.svelte` now passes `dismissMs={$overlaySettings.auto_dismiss_ms}` to `<ToastFeed>`, mirroring the existing `position` / `maxVisible` / `showProfile` props.
- `ToastFeed.svelte` takes a reactive `dismissMs` prop (default `6000`) and derives `dismissDurationMs` from it, replacing the non-reactive `store.getOpts().dismissMs`.

The bar and the JS dismiss timer now share one reactive source, so the bar fills over the full configured duration and reaches 100% exactly as the card is removed. Runtime settings changes are reflected in subsequent cards.

## Testing

Run in `packages/desktop`:

- `npm run test` → 874 passed, 35 skipped (44 files passed, 2 skipped); overlay suites green.
- `npm run check` → svelte-check found 0 errors and 0 warnings.
- `npm run lint` → no linter configured.

`ToastFeed.test.ts` was updated to assert the new prop wiring on both the `ToastFeed` and `OverlayApp` sides.
