### PR TITLE
feat(overlay): non-activating click-catcher panel + focus-log gating

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -85,6 +85,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1116,6 +1125,7 @@ dependencies = [
 name = "endara-desktop"
 version = "0.1.9"
 dependencies = [
+ "arc-swap",
  "dirs 5.0.1",
  "hostname",
  "http-body-util",
@@ -1126,6 +1136,7 @@ dependencies = [
  "log",
  "objc2",
  "objc2-app-kit",
+ "objc2-foundation",
  "objc2-web-kit",
  "regex",
  "reqwest",
@@ -5100,7 +5111,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,7 +41,7 @@ arc-swap = "1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.4"
-objc2-app-kit = { version = "0.3.2", features = ["NSApplication", "NSPanel", "NSResponder", "NSRunningApplication", "NSView", "NSWindow"] }
+objc2-app-kit = { version = "0.3.2", features = ["NSApplication", "NSResponder", "NSRunningApplication", "NSView", "NSWindow"] }
 objc2-foundation = { version = "0.3.2", features = ["NSGeometry", "NSObjCRuntime"] }
 objc2-web-kit = { version = "0.3.2", features = ["WKNavigationDelegate", "WKNavigation", "WKWebView"] }
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,7 +41,7 @@ arc-swap = "1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.4"
-objc2-app-kit = { version = "0.3.2", features = ["NSApplication", "NSResponder", "NSRunningApplication", "NSView", "NSWindow"] }
+objc2-app-kit = { version = "0.3.2", features = ["NSApplication", "NSPanel", "NSResponder", "NSRunningApplication", "NSView", "NSWindow"] }
 objc2-foundation = { version = "0.3.2", features = ["NSGeometry", "NSObjCRuntime"] }
 objc2-web-kit = { version = "0.3.2", features = ["WKNavigationDelegate", "WKNavigation", "WKWebView"] }
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,7 +41,7 @@ arc-swap = "1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.4"
-objc2-app-kit = { version = "0.3.2", features = ["NSApplication", "NSResponder", "NSRunningApplication", "NSView", "NSWindow"] }
+objc2-app-kit = { version = "0.3.2", features = ["NSApplication", "NSColor", "NSEvent", "NSPanel", "NSResponder", "NSRunningApplication", "NSView", "NSWindow"] }
 objc2-foundation = { version = "0.3.2", features = ["NSGeometry", "NSObjCRuntime"] }
 objc2-web-kit = { version = "0.3.2", features = ["WKNavigationDelegate", "WKNavigation", "WKWebView"] }
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,10 +37,12 @@ http-body-util = "0.1"
 regex = "1.12.3"
 image = { version = "0.25.10", default-features = false, features = ["png"] }
 time = { version = "0.3.47", features = ["formatting"] }
+arc-swap = "1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.4"
-objc2-app-kit = { version = "0.3.2", features = ["NSApplication", "NSRunningApplication"] }
+objc2-app-kit = { version = "0.3.2", features = ["NSApplication", "NSResponder", "NSRunningApplication", "NSView", "NSWindow"] }
+objc2-foundation = { version = "0.3.2", features = ["NSGeometry", "NSObjCRuntime"] }
 objc2-web-kit = { version = "0.3.2", features = ["WKNavigationDelegate", "WKNavigation", "WKWebView"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1459,12 +1459,6 @@ async fn set_overlay_hit_rects(
     state: State<'_, overlay::OverlayHitState>,
     rects: Vec<overlay::HitRect>,
 ) -> Result<(), String> {
-    log::info!(
-        target: "overlay",
-        "set_overlay_hit_rects: {} rect(s); first={:?}",
-        rects.len(),
-        rects.first()
-    );
     overlay::update_hit_rects(&app, &state, rects);
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1455,6 +1455,12 @@ async fn set_overlay_hit_rects(
     state: State<'_, overlay::OverlayHitState>,
     rects: Vec<overlay::HitRect>,
 ) -> Result<(), String> {
+    log::info!(
+        target: "overlay",
+        "set_overlay_hit_rects: count={} first={:?}",
+        rects.len(),
+        rects.first()
+    );
     overlay::update_hit_rects(&app, &state, rects);
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1455,12 +1455,6 @@ async fn set_overlay_hit_rects(
     state: State<'_, overlay::OverlayHitState>,
     rects: Vec<overlay::HitRect>,
 ) -> Result<(), String> {
-    log::info!(
-        target: "overlay",
-        "set_overlay_hit_rects: count={} first={:?}",
-        rects.len(),
-        rects.first()
-    );
     overlay::update_hit_rects(&app, &state, rects);
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1455,6 +1455,12 @@ async fn set_overlay_hit_rects(
     state: State<'_, overlay::OverlayHitState>,
     rects: Vec<overlay::HitRect>,
 ) -> Result<(), String> {
+    log::info!(
+        target: "overlay",
+        "set_overlay_hit_rects: {} rect(s); first={:?}",
+        rects.len(),
+        rects.first()
+    );
     overlay::update_hit_rects(&app, &state, rects);
     Ok(())
 }
@@ -1662,6 +1668,11 @@ struct FocusLogPayload {
 /// behaviour.
 #[tauri::command]
 async fn focus_main_window_on_log(app: AppHandle, jsonrpc_id: String) -> Result<(), String> {
+    log::info!(
+        target: "overlay",
+        "focus_main_window_on_log invoked: log_id={}",
+        jsonrpc_id
+    );
     #[cfg(target_os = "macos")]
     set_macos_activation_policy(true);
     if let Some(window) = app.get_webview_window("main") {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1433,6 +1433,8 @@ async fn get_mgmt_api_socket_path() -> Result<String, String> {
 async fn show_overlay(app: AppHandle) -> Result<(), String> {
     if let Some(w) = app.get_webview_window(overlay::OVERLAY_WINDOW_LABEL) {
         w.show().map_err(|e| e.to_string())?;
+        // Bring the macOS click-catcher panel over the now-visible overlay.
+        overlay::sync_click_catcher_frame(&app);
     }
     Ok(())
 }
@@ -1441,6 +1443,8 @@ async fn show_overlay(app: AppHandle) -> Result<(), String> {
 async fn hide_overlay(app: AppHandle) -> Result<(), String> {
     if let Some(w) = app.get_webview_window(overlay::OVERLAY_WINDOW_LABEL) {
         w.hide().map_err(|e| e.to_string())?;
+        // Hide the macOS click-catcher panel alongside the overlay.
+        overlay::sync_click_catcher_frame(&app);
     }
     Ok(())
 }
@@ -1588,6 +1592,8 @@ async fn apply_overlay_settings(
                 log::warn!("[overlay] destroy on disable failed: {e}");
             }
         }
+        // Tear down the macOS click-catcher panel that mirrored the overlay.
+        overlay::destroy_click_catcher(app);
         log::info!("[overlay] settings update enabled=false applied");
     } else if enabled_changed && new_settings.enabled {
         // Enable: rebuild the overlay window. The renderer auto-invokes
@@ -1673,8 +1679,15 @@ async fn focus_main_window_on_log(app: AppHandle, jsonrpc_id: String) -> Result<
         "focus_main_window_on_log invoked: log_id={}",
         jsonrpc_id
     );
+    // `focus_main_window_on_log` is an async command that runs on a tokio
+    // worker thread. `set_macos_activation_policy` asserts it is on the main
+    // thread via `MainThreadMarker::new()`, so dispatch the AppKit work onto
+    // the main thread instead of calling it directly here.
     #[cfg(target_os = "macos")]
-    set_macos_activation_policy(true);
+    app.run_on_main_thread(|| {
+        set_macos_activation_policy(true);
+    })
+    .map_err(|e| e.to_string())?;
     if let Some(window) = app.get_webview_window("main") {
         window.show().map_err(|e| e.to_string())?;
         window.unminimize().map_err(|e| e.to_string())?;
@@ -2710,6 +2723,10 @@ pub fn run() {
             }
             RunEvent::Exit => {
                 log::info!("app exit");
+                // Release the macOS click-catcher panel while still on the main
+                // thread (the event loop has stopped, so a dispatched teardown
+                // would never run).
+                overlay::destroy_click_catcher(app);
                 // Suppress any in-flight supervisor logic so the upcoming SIGTERM
                 // is treated as an intentional shutdown, then abort a pending
                 // auto-restart task if one is sleeping out its backoff window.

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -332,8 +332,8 @@ mod macos_panel {
     use arc_swap::ArcSwap;
     use objc2::rc::Retained;
     use objc2::runtime::AnyObject;
-    use objc2::{define_class, msg_send, ClassType, DefinedClass, MainThreadMarker};
-    use objc2_app_kit::{NSAutoresizingMaskOptions, NSPanel, NSView, NSWindow, NSWindowStyleMask};
+    use objc2::{define_class, msg_send, DefinedClass, MainThreadMarker};
+    use objc2_app_kit::{NSAutoresizingMaskOptions, NSView, NSWindow, NSWindowStyleMask};
     use objc2_foundation::NSPoint;
 
     use super::{any_rect_contains, HitRect};
@@ -365,18 +365,7 @@ mod macos_panel {
                 let local = self.convertPoint_fromView(point, superview.as_deref());
                 let guard = self.ivars().rects.load();
                 let rects: &[HitRect] = &guard;
-                let inside = any_rect_contains(rects, local.x, local.y);
-                log::debug!(
-                    target: "overlay",
-                    "hitTest super=({:.1},{:.1}) local=({:.1},{:.1}) rects={} inside={}",
-                    point.x,
-                    point.y,
-                    local.x,
-                    local.y,
-                    rects.len(),
-                    inside
-                );
-                if inside {
+                if any_rect_contains(rects, local.x, local.y) {
                     // Inside a card → let NSView descend to the WKWebView.
                     unsafe { msg_send![super(self), hitTest: point] }
                 } else {
@@ -423,30 +412,14 @@ mod macos_panel {
         // `ns_window()`, only dereferenced here on the main thread.
         let ns_window: &NSWindow = unsafe { &*(ns_window_addr as *const NSWindow) };
 
-        // `NSWindowStyleMaskNonactivatingPanel` is only honored on `NSPanel`
-        // instances; Tauri builds the overlay as a plain `NSWindow`, so setting
-        // the bit alone is a no-op (a card click still activates Endara). Swap
-        // the live object's Obj-C class to `NSPanel` first via `object_setClass`.
-        // This only rewrites the isa pointer — `NSPanel` subclasses `NSWindow`,
-        // adds no ivars, and same instance size — so existing instance state
-        // (set below) and Tauri's later `msg_send` selectors (`setMovable:`,
-        // `set_ignore_cursor_events`, etc.) keep working unchanged.
-        // SAFETY: `ns_window` is the live, main-thread window; `NSPanel` is a
-        // subclass of its current `NSWindow` class with no extra ivars.
-        let overlay_obj: &AnyObject = ns_window;
-        let _prev_class = unsafe { AnyObject::set_class(overlay_obj, NSPanel::class()) };
-        log::info!(target: "overlay", "overlay window class swapped to NSPanel");
-
         // Keep the overlay anchored to its computed corner (NSWindow defaults
         // to `isMovable = true`, which would let the user drag it anywhere by
         // clicking-and-holding any part of it, including transparent regions).
-        // Applied after the class swap so it lands on the `NSPanel` instance.
         ns_window.setMovable(false);
 
         // Non-activating panel: clicking the overlay must not activate Endara
         // or raise its main window. `NSWindowStyleMaskNonactivatingPanel`
-        // (1 << 7) is the style every macOS HUD/overlay uses — now honored
-        // because the window's runtime class is `NSPanel`.
+        // (1 << 7) is the style every macOS HUD/overlay uses.
         let style = ns_window.styleMask();
         ns_window.setStyleMask(style | NSWindowStyleMask::NonactivatingPanel);
 

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -365,7 +365,18 @@ mod macos_panel {
                 let local = self.convertPoint_fromView(point, superview.as_deref());
                 let guard = self.ivars().rects.load();
                 let rects: &[HitRect] = &guard;
-                if any_rect_contains(rects, local.x, local.y) {
+                let inside = any_rect_contains(rects, local.x, local.y);
+                log::info!(
+                    target: "overlay",
+                    "hitTest super=({:.1},{:.1}) local=({:.1},{:.1}) rects={} inside={}",
+                    point.x,
+                    point.y,
+                    local.x,
+                    local.y,
+                    rects.len(),
+                    inside
+                );
+                if inside {
                     // Inside a card → let NSView descend to the WKWebView.
                     unsafe { msg_send![super(self), hitTest: point] }
                 } else {
@@ -438,6 +449,16 @@ mod macos_panel {
         // handle keeps it alive so we can re-parent it under the wrapper.
         let wrapper_view: &NSView = &wrapper;
         ns_window.setContentView(Some(wrapper_view));
+
+        let frame = wrapper.frame();
+        log::info!(
+            target: "overlay",
+            "OverlayHitTestView installed as contentView frame=({:.1},{:.1},{:.1},{:.1})",
+            frame.origin.x,
+            frame.origin.y,
+            frame.size.width,
+            frame.size.height
+        );
 
         let content_view: &NSView = &content;
         content_view.setFrame(wrapper.bounds());

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -11,6 +11,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use arc_swap::ArcSwap;
+#[cfg(target_os = "macos")]
+use objc2::MainThreadMarker;
 use serde::{Deserialize, Serialize};
 use tauri::async_runtime;
 use tauri::webview::Color;
@@ -163,12 +165,19 @@ const HIT_RECT_POLL_INTERVAL: Duration = Duration::from_millis(90);
 /// Axis-aligned card hit rect in overlay-window viewport coordinates
 /// (CSS / logical pixels), as reported by the renderer. Mirrors the
 /// `HitRect` type in `src/lib/overlay/overlay-helpers.ts`.
-#[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
+///
+/// `log_id` carries the JSON-RPC id of the request the card represents so the
+/// click-catcher's `mouseDown:` can emit `overlay:card-clicked` with the right
+/// target. `#[serde(default)]` keeps the field optional on the wire (empty
+/// string when a card has no JSON-RPC id captured yet).
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct HitRect {
     pub x: f64,
     pub y: f64,
     pub width: f64,
     pub height: f64,
+    #[serde(default)]
+    pub log_id: String,
 }
 
 impl HitRect {
@@ -207,27 +216,34 @@ pub fn cursor_to_viewport(
 }
 
 /// Tauri-managed shared state for overlay click routing. `rects` holds the
-/// renderer-reported card rects (viewport / CSS px). On macOS the overlay's
-/// `hitTest:` override reads them lock-free on the AppKit main thread; on
-/// other platforms the cursor poller reads them and `poller` holds its task
-/// handle so an empty report can abort it.
+/// renderer-reported card rects (viewport / CSS px). On macOS the
+/// click-catcher panel's `hitTest:` / `mouseDown:` read them lock-free on the
+/// AppKit main thread, and `click_catcher` holds the raw `NSPanel` address (as
+/// a `usize`, since AppKit pointers are not `Send`) so frame-sync / teardown
+/// can reach it; on other platforms the cursor poller reads the rects and
+/// `poller` holds its task handle so an empty report can abort it.
 #[derive(Default)]
 pub struct OverlayHitState {
     rects: Arc<ArcSwap<Vec<HitRect>>>,
     #[cfg(not(target_os = "macos"))]
     poller: std::sync::Mutex<Option<JoinHandle<()>>>,
+    /// Raw `NSPanel` pointer for the click-catcher, smuggled as a `usize`.
+    /// Only ever dereferenced on the AppKit main thread.
+    #[cfg(target_os = "macos")]
+    click_catcher: std::sync::Mutex<Option<usize>>,
 }
 
 /// Apply a renderer hit-rect report.
 ///
-/// On macOS the overlay's `hitTest:` override (see [`macos_panel`]) reads the
-/// rects directly on the AppKit main thread, so all this does is a single
-/// lock-free store per renderer report — no poller, no `setIgnoresMouseEvents`
-/// toggle. On other platforms it drives the cursor poller.
+/// On macOS the click-catcher panel's `hitTest:` / `mouseDown:` (see
+/// [`macos_click_catcher`]) read the rects directly on the AppKit main thread,
+/// so all this does is a single lock-free store per renderer report — no
+/// poller, no `setIgnoresMouseEvents` toggle. On other platforms it drives the
+/// cursor poller.
 pub fn update_hit_rects(app: &AppHandle, state: &OverlayHitState, rects: Vec<HitRect>) {
     #[cfg(target_os = "macos")]
     {
-        // The overlay content view's `hitTest:` override consults these rects
+        // The click-catcher panel's content view consults these rects
         // synchronously on every mouse event; storing them is the whole job.
         let _ = app;
         state.rects.store(Arc::new(rects));
@@ -319,68 +335,74 @@ async fn cursor_poll_loop(app: AppHandle, rects: Arc<ArcSwap<Vec<HitRect>>>) {
     }
 }
 
-/// macOS-native overlay click routing: a non-activating panel plus an
-/// `NSView` `hitTest:` override that consults renderer-reported card rects so
-/// clicks inside a card reach the WKWebView and clicks elsewhere pass through
-/// to whatever window is underneath. Replaces the cursor poller +
-/// `setIgnoresMouseEvents` toggle, which raced AppKit's event routing and let
-/// clicks activate Endara instead of reaching the webview.
+/// macOS-native overlay click routing: a transparent, non-activating
+/// "click-catcher" `NSPanel` layered exactly over the overlay window. Its
+/// content view's `hitTest:` consults renderer-reported card rects so clicks
+/// inside a card are captured by the panel (which never activates Endara) and
+/// forwarded to the overlay webview via an `overlay:card-clicked` Tauri event,
+/// while clicks elsewhere return `nil` and fall through to whatever window is
+/// underneath. Replaces the in-place `hitTest:` override on Tauri's overlay
+/// window, which never received `mouseDown:` because the OS gates the first
+/// click of an inactive app on activation (the click that should reach the
+/// webview is swallowed to activate Endara instead).
 #[cfg(target_os = "macos")]
-mod macos_panel {
+mod macos_click_catcher {
     use std::sync::Arc;
 
     use arc_swap::ArcSwap;
     use objc2::rc::Retained;
     use objc2::runtime::AnyObject;
     use objc2::{define_class, msg_send, DefinedClass, MainThreadMarker};
-    use objc2_app_kit::{NSAutoresizingMaskOptions, NSView, NSWindow, NSWindowStyleMask};
-    use objc2_foundation::NSPoint;
+    use objc2_app_kit::{
+        NSBackingStoreType, NSColor, NSEvent, NSPanel, NSView, NSWindow, NSWindowOrderingMode,
+        NSWindowStyleMask,
+    };
+    use objc2_foundation::{NSPoint, NSRect};
+    use serde::Serialize;
+    use tauri::{AppHandle, Emitter, Manager};
 
-    use super::{any_rect_contains, HitRect};
+    use super::{any_rect_contains, HitRect, OverlayHitState, OVERLAY_WINDOW_LABEL};
 
-    /// Instance state for [`OverlayHitTestView`]: the shared, lock-free card
-    /// rects refreshed by `set_overlay_hit_rects`.
-    pub(super) struct OverlayHitTestIvars {
+    /// Payload for the `overlay:card-clicked` event emitted to the overlay
+    /// webview when a click lands inside a reported card rect.
+    #[derive(Clone, Serialize)]
+    struct CardClickedPayload {
+        log_id: String,
+    }
+
+    /// Instance state for [`ClickCatcherView`]: the shared, lock-free card
+    /// rects refreshed by `set_overlay_hit_rects`, plus an `AppHandle` so
+    /// `mouseDown:` can emit the forward event to the overlay webview.
+    pub(super) struct ClickCatcherIvars {
         rects: Arc<ArcSwap<Vec<HitRect>>>,
+        app: AppHandle,
     }
 
     define_class!(
-        /// Thin wrapper installed as the overlay window's content view.
-        /// `hitTest:` consults the renderer-reported card rects so clicks
-        /// inside a card reach the WKWebView while clicks elsewhere return
-        /// `nil` and pass through to whatever window is underneath.
+        /// Transparent content view of the click-catcher panel. `hitTest:`
+        /// captures clicks inside a reported card rect (returns `self`) and
+        /// lets every other click fall through (`nil`); `mouseDown:` forwards
+        /// the captured click to the overlay webview.
         #[unsafe(super(NSView))]
-        #[ivars = OverlayHitTestIvars]
-        pub(super) struct OverlayHitTestView;
+        #[ivars = ClickCatcherIvars]
+        pub(super) struct ClickCatcherView;
 
-        impl OverlayHitTestView {
+        impl ClickCatcherView {
             /// `point` arrives in the superview's coordinate system; convert it
             /// into our local (flipped, top-left) space so it lines up with the
-            /// renderer's CSS-pixel rects, then route the click.
+            /// renderer's CSS-pixel rects. Inside a card → capture (return
+            /// self); otherwise → `nil` so the click falls through.
             #[unsafe(method(hitTest:))]
             fn hit_test(&self, point: NSPoint) -> *mut NSView {
-                // SAFETY: `superview` returns a borrowed view we use only for
-                // the immediately-following coordinate conversion.
+                // SAFETY: `superview` returns a borrowed view used only for the
+                // immediately-following coordinate conversion.
                 let superview = unsafe { self.superview() };
                 let local = self.convertPoint_fromView(point, superview.as_deref());
                 let guard = self.ivars().rects.load();
-                let rects: &[HitRect] = &guard;
-                let inside = any_rect_contains(rects, local.x, local.y);
-                log::info!(
-                    target: "overlay",
-                    "hitTest super=({:.1},{:.1}) local=({:.1},{:.1}) rects={} inside={}",
-                    point.x,
-                    point.y,
-                    local.x,
-                    local.y,
-                    rects.len(),
-                    inside
-                );
-                if inside {
-                    // Inside a card → let NSView descend to the WKWebView.
-                    unsafe { msg_send![super(self), hitTest: point] }
+                if any_rect_contains(&guard, local.x, local.y) {
+                    let this: *const ClickCatcherView = self;
+                    this as *mut NSView
                 } else {
-                    // Outside every card → pass the click through.
                     std::ptr::null_mut()
                 }
             }
@@ -398,79 +420,223 @@ mod macos_panel {
             fn accepts_first_mouse(&self, _event: *mut AnyObject) -> bool {
                 true
             }
+
+            /// Forward a captured click to the overlay webview. `hitTest:` only
+            /// returns self inside a card, so this normally lands inside a rect;
+            /// the passthrough branch is defensive against a rect list that
+            /// changed between hit-test and mouse-down.
+            #[unsafe(method(mouseDown:))]
+            fn mouse_down(&self, event: *mut NSEvent) {
+                // SAFETY: AppKit hands us a valid event for the call duration.
+                let window_point = unsafe { (*event).locationInWindow() };
+                // `nil` source view → convert from window base coords into our
+                // local (flipped, top-left) space.
+                let local = self.convertPoint_fromView(window_point, None);
+                let ivars = self.ivars();
+                let guard = ivars.rects.load();
+                match guard.iter().find(|r| r.contains(local.x, local.y)) {
+                    Some(rect) => {
+                        log::info!(
+                            target: "overlay",
+                            "click-catcher click forwarded log_id={}",
+                            rect.log_id
+                        );
+                        if let Err(e) = ivars.app.emit_to(
+                            OVERLAY_WINDOW_LABEL,
+                            "overlay:card-clicked",
+                            CardClickedPayload {
+                                log_id: rect.log_id.clone(),
+                            },
+                        ) {
+                            log::warn!(target: "overlay", "emit overlay:card-clicked failed: {e}");
+                        }
+                    }
+                    None => {
+                        log::info!(
+                            target: "overlay",
+                            "click-catcher click passthrough at x={:.1},y={:.1}",
+                            local.x,
+                            local.y
+                        );
+                    }
+                }
+            }
         }
     );
 
-    impl OverlayHitTestView {
-        fn new(mtm: MainThreadMarker, rects: Arc<ArcSwap<Vec<HitRect>>>) -> Retained<Self> {
+    impl ClickCatcherView {
+        fn new(
+            mtm: MainThreadMarker,
+            rects: Arc<ArcSwap<Vec<HitRect>>>,
+            app: AppHandle,
+        ) -> Retained<Self> {
             let this = mtm
-                .alloc::<OverlayHitTestView>()
-                .set_ivars(OverlayHitTestIvars { rects });
+                .alloc::<ClickCatcherView>()
+                .set_ivars(ClickCatcherIvars { rects, app });
             unsafe { msg_send![super(this), init] }
         }
     }
 
-    /// Convert the overlay window into a non-activating panel and wrap its
-    /// content view with [`OverlayHitTestView`]. Must run on the AppKit main
-    /// thread. `ns_window_addr` is the live `NSWindow` pointer smuggled across
-    /// the closure boundary as a `usize` (raw pointers are not `Send`).
-    pub(super) fn configure(ns_window_addr: usize, rects: Arc<ArcSwap<Vec<HitRect>>>) {
+    /// Create the click-catcher panel + content view and store its address on
+    /// [`OverlayHitState`]. Runs on the AppKit main thread. `ns_window_addr` is
+    /// the live overlay `NSWindow` pointer smuggled across the closure boundary
+    /// as a `usize` (raw pointers are not `Send`).
+    fn create_and_store(app: &AppHandle, ns_window_addr: usize, rects: Arc<ArcSwap<Vec<HitRect>>>) {
         let Some(mtm) = MainThreadMarker::new() else {
-            log::warn!(target: "overlay", "overlay panel setup skipped: not on the main thread");
+            log::warn!(target: "overlay", "click-catcher setup skipped: not on the main thread");
             return;
         };
-        // SAFETY: `ns_window_addr` is the live `NSWindow` returned by
-        // `ns_window()`, only dereferenced here on the main thread.
-        let ns_window: &NSWindow = unsafe { &*(ns_window_addr as *const NSWindow) };
+        // SAFETY: live overlay `NSWindow`, only dereferenced on the main thread.
+        let overlay_ns: &NSWindow = unsafe { &*(ns_window_addr as *const NSWindow) };
 
-        // Keep the overlay anchored to its computed corner (NSWindow defaults
-        // to `isMovable = true`, which would let the user drag it anywhere by
-        // clicking-and-holding any part of it, including transparent regions).
-        ns_window.setMovable(false);
-
-        // Non-activating panel: clicking the overlay must not activate Endara
-        // or raise its main window. `NSWindowStyleMaskNonactivatingPanel`
-        // (1 << 7) is the style every macOS HUD/overlay uses.
-        let style = ns_window.styleMask();
-        ns_window.setStyleMask(style | NSWindowStyleMask::NonactivatingPanel);
-
-        let Some(content) = ns_window.contentView() else {
-            log::warn!(target: "overlay", "overlay panel setup: window has no content view to wrap");
-            return;
+        let frame = overlay_ns.frame();
+        // Borderless + non-activating: clicks must not activate Endara, and the
+        // panel carries no title bar / chrome of its own.
+        let style = NSWindowStyleMask::NonactivatingPanel | NSWindowStyleMask::Borderless;
+        // SAFETY: standard `NSPanel` designated initializer on a fresh alloc.
+        let panel: Retained<NSPanel> = unsafe {
+            let alloc = mtm.alloc::<NSPanel>();
+            msg_send![
+                alloc,
+                initWithContentRect: frame,
+                styleMask: style,
+                backing: NSBackingStoreType::Buffered,
+                defer: false,
+            ]
         };
 
-        let wrapper = OverlayHitTestView::new(mtm, rects);
-        wrapper.setFrame(content.frame());
-        let resize = NSAutoresizingMaskOptions::ViewWidthSizable
-            | NSAutoresizingMaskOptions::ViewHeightSizable;
-        wrapper.setAutoresizingMask(resize);
+        // Transparent, shadowless, click-receiving panel pinned just above the
+        // overlay window and sharing its space-collection behavior so it tracks
+        // the overlay across Spaces / full-screen.
+        panel.setOpaque(false);
+        panel.setBackgroundColor(Some(&NSColor::clearColor()));
+        panel.setHasShadow(false);
+        panel.setIgnoresMouseEvents(false);
+        panel.setLevel(overlay_ns.level() + 1);
+        panel.setCollectionBehavior(overlay_ns.collectionBehavior());
 
-        // `setContentView:` detaches `content` from the window; our retained
-        // handle keeps it alive so we can re-parent it under the wrapper.
-        let wrapper_view: &NSView = &wrapper;
-        ns_window.setContentView(Some(wrapper_view));
+        let view = ClickCatcherView::new(mtm, rects, app.clone());
+        view.setFrame(NSRect::new(NSPoint::new(0.0, 0.0), frame.size));
+        let panel_view: &NSView = &view;
+        panel.setContentView(Some(panel_view));
 
-        let frame = wrapper.frame();
-        log::info!(
-            target: "overlay",
-            "OverlayHitTestView installed as contentView frame=({:.1},{:.1},{:.1},{:.1})",
-            frame.origin.x,
-            frame.origin.y,
-            frame.size.width,
-            frame.size.height
-        );
+        let addr = Retained::into_raw(panel) as usize;
+        let state = app.state::<OverlayHitState>();
+        if let Ok(mut guard) = state.click_catcher.lock() {
+            if let Some(old) = guard.replace(addr) {
+                // SAFETY: reclaim the previously-stored panel and release it.
+                if let Some(old_panel) = unsafe { Retained::from_raw(old as *mut NSPanel) } {
+                    old_panel.orderOut(None);
+                }
+            }
+        }
+        log::info!(target: "overlay", "click-catcher NSPanel created");
+        sync(app);
+    }
 
-        let content_view: &NSView = &content;
-        content_view.setFrame(wrapper.bounds());
-        content_view.setAutoresizingMask(resize);
-        wrapper.addSubview(content_view);
+    /// Mirror the overlay window's frame onto the click-catcher panel and match
+    /// its visibility (order above the overlay when visible, `orderOut:` when
+    /// hidden). Must run on the AppKit main thread.
+    pub(super) fn sync(app: &AppHandle) {
+        if MainThreadMarker::new().is_none() {
+            return;
+        }
+        let state = app.state::<OverlayHitState>();
+        let Some(addr) = state.click_catcher.lock().ok().and_then(|g| *g) else {
+            return;
+        };
+        // SAFETY: stored panel pointer, only dereferenced on the main thread.
+        let panel: &NSPanel = unsafe { &*(addr as *const NSPanel) };
 
-        log::info!(
-            target: "overlay",
-            "overlay configured as non-activating panel with hitTest passthrough"
-        );
+        let Some(overlay_win) = app.get_webview_window(OVERLAY_WINDOW_LABEL) else {
+            panel.orderOut(None);
+            return;
+        };
+        let ns_ptr = match overlay_win.ns_window() {
+            Ok(p) if !p.is_null() => p,
+            _ => return,
+        };
+        // SAFETY: live overlay `NSWindow`, only dereferenced on the main thread.
+        let overlay_ns: &NSWindow = unsafe { &*(ns_ptr as *const NSWindow) };
+        panel.setFrame_display(overlay_ns.frame(), true);
+
+        if overlay_win.is_visible().unwrap_or(false) {
+            // Order directly above the overlay window so z-order is correct.
+            panel.orderWindow_relativeTo(NSWindowOrderingMode::Above, overlay_ns.windowNumber());
+        } else {
+            panel.orderOut(None);
+        }
+    }
+
+    /// Reclaim and release the click-catcher panel (overlay disabled / app
+    /// exit). Must run on the AppKit main thread.
+    pub(super) fn destroy(app: &AppHandle) {
+        if MainThreadMarker::new().is_none() {
+            return;
+        }
+        let state = app.state::<OverlayHitState>();
+        let Ok(mut guard) = state.click_catcher.lock() else {
+            return;
+        };
+        if let Some(addr) = guard.take() {
+            // SAFETY: reclaim the stored panel; dropping the `Retained` releases it.
+            if let Some(panel) = unsafe { Retained::from_raw(addr as *mut NSPanel) } {
+                panel.orderOut(None);
+            }
+            log::info!(target: "overlay", "click-catcher NSPanel destroyed");
+        }
+    }
+
+    /// Entry point from `build_overlay_window`: capture the overlay `NSWindow`
+    /// address and dispatch panel creation onto the AppKit main thread.
+    pub(super) fn setup(app: &AppHandle, ns_window_addr: usize, rects: Arc<ArcSwap<Vec<HitRect>>>) {
+        let app2 = app.clone();
+        if let Err(e) = app.run_on_main_thread(move || {
+            create_and_store(&app2, ns_window_addr, rects);
+        }) {
+            log::warn!(target: "overlay", "click-catcher setup dispatch failed: {e}");
+        }
     }
 }
+
+/// Mirror the overlay window's frame + visibility onto the macOS click-catcher
+/// panel. Runs the work inline when already on the AppKit main thread,
+/// otherwise dispatches onto it. No-op on non-macOS and when no click-catcher
+/// has been created yet.
+#[cfg(target_os = "macos")]
+pub fn sync_click_catcher_frame(app: &AppHandle) {
+    if MainThreadMarker::new().is_some() {
+        macos_click_catcher::sync(app);
+    } else {
+        let app2 = app.clone();
+        if let Err(e) = app.run_on_main_thread(move || macos_click_catcher::sync(&app2)) {
+            log::warn!(target: "overlay", "sync_click_catcher_frame dispatch failed: {e}");
+        }
+    }
+}
+
+/// No-op on non-macOS: click routing there uses the cursor poller.
+#[cfg(not(target_os = "macos"))]
+pub fn sync_click_catcher_frame(_app: &AppHandle) {}
+
+/// Tear down the macOS click-catcher panel (overlay disabled / app exit). Runs
+/// inline when already on the AppKit main thread (e.g. the `RunEvent::Exit`
+/// callback) so teardown is not lost to a dispatch that never runs.
+#[cfg(target_os = "macos")]
+pub fn destroy_click_catcher(app: &AppHandle) {
+    if MainThreadMarker::new().is_some() {
+        macos_click_catcher::destroy(app);
+    } else {
+        let app2 = app.clone();
+        if let Err(e) = app.run_on_main_thread(move || macos_click_catcher::destroy(&app2)) {
+            log::warn!(target: "overlay", "destroy_click_catcher dispatch failed: {e}");
+        }
+    }
+}
+
+/// No-op on non-macOS.
+#[cfg(not(target_os = "macos"))]
+pub fn destroy_click_catcher(_app: &AppHandle) {}
 
 /// Resolve the overlay's effective settings on startup, writing migration
 /// state to disk on first run / first upgrade.
@@ -759,19 +925,18 @@ pub fn build_overlay_window(
 
     let window = builder.build()?;
 
-    // On macOS, convert the overlay into a non-activating panel and wrap its
-    // content view with an `NSView` `hitTest:` override (see `macos_panel`):
-    // clicks inside a renderer-reported card rect reach the WKWebView, clicks
-    // elsewhere pass through to the window underneath, and the overlay never
-    // activates Endara. This also pins the window in place (`setMovable:
-    // false`) so it can't be dragged off its computed corner. Dispatch onto
-    // the macOS main thread because `build_overlay_window` can be invoked from
-    // a Tauri command worker thread (`set_overlay_settings` → enable overlay
-    // from Settings) where calling AppKit selectors directly aborts the
-    // process. The window is built hidden (`visible(false)` above) and only
-    // revealed via the `overlay-render-ready` event / 500ms safety net below,
-    // both of which themselves go through the main thread, so this lands before
-    // the window can appear.
+    // On macOS, create a transparent, non-activating "click-catcher" `NSPanel`
+    // layered exactly over the overlay window (see `macos_click_catcher`):
+    // clicks inside a renderer-reported card rect are captured by the panel and
+    // forwarded to the overlay webview via `overlay:card-clicked`, clicks
+    // elsewhere pass through to whatever window is underneath, and the panel
+    // never activates Endara. The overlay `NSWindow` itself is left untouched.
+    // Dispatch onto the macOS main thread because `build_overlay_window` can be
+    // invoked from a Tauri command worker thread (`set_overlay_settings` →
+    // enable overlay from Settings) where calling AppKit selectors directly
+    // aborts the process. The window is built hidden (`visible(false)` above)
+    // and only revealed via the `overlay-render-ready` event / 500ms safety net
+    // below, both of which sync the click-catcher's frame + visibility.
     #[cfg(target_os = "macos")]
     {
         let rects = Arc::clone(&app.state::<OverlayHitState>().rects);
@@ -780,22 +945,15 @@ pub fn build_overlay_window(
                 // Raw pointers are not `Send`; smuggle the `NSWindow`
                 // address across the closure boundary as a `usize`.
                 let ns_window_addr = ptr as usize;
-                if let Err(e) = app.run_on_main_thread(move || {
-                    macos_panel::configure(ns_window_addr, rects);
-                }) {
-                    log::warn!(
-                        target: "overlay",
-                        "run_on_main_thread for overlay panel setup failed: {e}; overlay stays a plain activating window"
-                    );
-                }
+                macos_click_catcher::setup(app, ns_window_addr, rects);
             }
             Ok(_) => log::warn!(
                 target: "overlay",
-                "ns_window() returned null; overlay panel setup skipped"
+                "ns_window() returned null; click-catcher setup skipped"
             ),
             Err(e) => log::warn!(
                 target: "overlay",
-                "ns_window() failed: {e}; overlay panel setup skipped"
+                "ns_window() failed: {e}; click-catcher setup skipped"
             ),
         }
     }
@@ -806,8 +964,8 @@ pub fn build_overlay_window(
     // skip the global click-through so the overlay window is fully interactive
     // and right-click → Inspect works from devtools; production builds keep the
     // click-through behaviour so the overlay never steals input from the user's
-    // other windows. macOS routes clicks via the panel + `hitTest:` override
-    // installed above and never toggles `set_ignore_cursor_events`.
+    // other windows. macOS routes clicks via the click-catcher panel installed
+    // above and never toggles `set_ignore_cursor_events`.
     #[cfg(not(target_os = "macos"))]
     {
         if cfg!(debug_assertions) {
@@ -832,6 +990,8 @@ pub fn build_overlay_window(
         if let Err(e) = ready_target.show() {
             log::warn!("[overlay] show on render-ready failed: {e}");
         }
+        // Bring the click-catcher over the now-visible overlay (no-op off macOS).
+        sync_click_catcher_frame(ready_target.app_handle());
     });
 
     // Safety net: if the renderer never emits `overlay-render-ready`
@@ -852,6 +1012,8 @@ pub fn build_overlay_window(
         if let Err(e) = safety.show() {
             log::warn!("[overlay] safety-net show failed: {e}");
         }
+        // Keep the click-catcher in lock-step with the (now shown) overlay.
+        sync_click_catcher_frame(safety.app_handle());
     });
 
     Ok(window)
@@ -886,6 +1048,9 @@ pub fn reposition_overlay_window(app: &AppHandle, position: OverlayPosition) -> 
         window.set_size(size)?;
         window.set_position(pos)?;
     }
+    // Mirror the new frame onto the click-catcher panel (no-op off macOS). This
+    // is the move/resize/display-reconfiguration entry point for the overlay.
+    sync_click_catcher_frame(app);
     Ok(())
 }
 
@@ -1133,6 +1298,7 @@ mod tests {
             y: 100.0,
             width: 340.0,
             height: 72.0,
+            log_id: String::new(),
         };
         assert!(r.contains(20.0, 100.0), "top-left corner is inclusive");
         assert!(r.contains(189.0, 135.0), "interior point");
@@ -1150,12 +1316,14 @@ mod tests {
                 y: 0.0,
                 width: 10.0,
                 height: 10.0,
+                log_id: String::new(),
             },
             HitRect {
                 x: 100.0,
                 y: 100.0,
                 width: 10.0,
                 height: 10.0,
+                log_id: String::new(),
             },
         ];
         assert!(any_rect_contains(&rects, 5.0, 5.0));
@@ -1166,10 +1334,10 @@ mod tests {
 
     #[test]
     fn hit_test_passthrough_matches_card_rects_in_local_coords() {
-        // Decision logic of the macOS `hitTest:` override: the wrapper view is
-        // flipped (top-left origin), so renderer rects compare directly against
-        // the view-local point with no Y inversion. Inside a card → capture
-        // (return super.hitTest); outside every card → pass through (return
+        // Decision logic of the macOS click-catcher `hitTest:`: the content
+        // view is flipped (top-left origin), so renderer rects compare directly
+        // against the view-local point with no Y inversion. Inside a card →
+        // capture (return self); outside every card → pass through (return
         // nil). Coordinates mirror a real diagnostic-log report.
         let cards = [
             HitRect {
@@ -1177,12 +1345,14 @@ mod tests {
                 y: 1032.0,
                 width: 340.0,
                 height: 100.0,
+                log_id: String::new(),
             },
             HitRect {
                 x: 40.0,
                 y: 900.0,
                 width: 340.0,
                 height: 100.0,
+                log_id: String::new(),
             },
         ];
         // Point inside the first card → captured.
@@ -1230,7 +1400,7 @@ mod tests {
 
     #[test]
     fn hit_rect_deserializes_from_renderer_shape() {
-        let json = r#"{"x":20.5,"y":100.0,"width":340.0,"height":72.25}"#;
+        let json = r#"{"x":20.5,"y":100.0,"width":340.0,"height":72.25,"log_id":"req-7"}"#;
         let r: HitRect = serde_json::from_str(json).unwrap();
         assert_eq!(
             r,
@@ -1239,8 +1409,17 @@ mod tests {
                 y: 100.0,
                 width: 340.0,
                 height: 72.25,
+                log_id: "req-7".to_string(),
             }
         );
+    }
+
+    #[test]
+    fn hit_rect_defaults_log_id_when_absent() {
+        // `#[serde(default)]` keeps older payloads (no `log_id`) decodable.
+        let json = r#"{"x":1.0,"y":2.0,"width":3.0,"height":4.0}"#;
+        let r: HitRect = serde_json::from_str(json).unwrap();
+        assert_eq!(r.log_id, "");
     }
 
     #[test]

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -332,8 +332,8 @@ mod macos_panel {
     use arc_swap::ArcSwap;
     use objc2::rc::Retained;
     use objc2::runtime::AnyObject;
-    use objc2::{define_class, msg_send, DefinedClass, MainThreadMarker};
-    use objc2_app_kit::{NSAutoresizingMaskOptions, NSView, NSWindow, NSWindowStyleMask};
+    use objc2::{define_class, msg_send, ClassType, DefinedClass, MainThreadMarker};
+    use objc2_app_kit::{NSAutoresizingMaskOptions, NSPanel, NSView, NSWindow, NSWindowStyleMask};
     use objc2_foundation::NSPoint;
 
     use super::{any_rect_contains, HitRect};
@@ -365,7 +365,18 @@ mod macos_panel {
                 let local = self.convertPoint_fromView(point, superview.as_deref());
                 let guard = self.ivars().rects.load();
                 let rects: &[HitRect] = &guard;
-                if any_rect_contains(rects, local.x, local.y) {
+                let inside = any_rect_contains(rects, local.x, local.y);
+                log::debug!(
+                    target: "overlay",
+                    "hitTest super=({:.1},{:.1}) local=({:.1},{:.1}) rects={} inside={}",
+                    point.x,
+                    point.y,
+                    local.x,
+                    local.y,
+                    rects.len(),
+                    inside
+                );
+                if inside {
                     // Inside a card → let NSView descend to the WKWebView.
                     unsafe { msg_send![super(self), hitTest: point] }
                 } else {
@@ -412,14 +423,30 @@ mod macos_panel {
         // `ns_window()`, only dereferenced here on the main thread.
         let ns_window: &NSWindow = unsafe { &*(ns_window_addr as *const NSWindow) };
 
+        // `NSWindowStyleMaskNonactivatingPanel` is only honored on `NSPanel`
+        // instances; Tauri builds the overlay as a plain `NSWindow`, so setting
+        // the bit alone is a no-op (a card click still activates Endara). Swap
+        // the live object's Obj-C class to `NSPanel` first via `object_setClass`.
+        // This only rewrites the isa pointer — `NSPanel` subclasses `NSWindow`,
+        // adds no ivars, and same instance size — so existing instance state
+        // (set below) and Tauri's later `msg_send` selectors (`setMovable:`,
+        // `set_ignore_cursor_events`, etc.) keep working unchanged.
+        // SAFETY: `ns_window` is the live, main-thread window; `NSPanel` is a
+        // subclass of its current `NSWindow` class with no extra ivars.
+        let overlay_obj: &AnyObject = ns_window;
+        let _prev_class = unsafe { AnyObject::set_class(overlay_obj, NSPanel::class()) };
+        log::info!(target: "overlay", "overlay window class swapped to NSPanel");
+
         // Keep the overlay anchored to its computed corner (NSWindow defaults
         // to `isMovable = true`, which would let the user drag it anywhere by
         // clicking-and-holding any part of it, including transparent regions).
+        // Applied after the class swap so it lands on the `NSPanel` instance.
         ns_window.setMovable(false);
 
         // Non-activating panel: clicking the overlay must not activate Endara
         // or raise its main window. `NSWindowStyleMaskNonactivatingPanel`
-        // (1 << 7) is the style every macOS HUD/overlay uses.
+        // (1 << 7) is the style every macOS HUD/overlay uses — now honored
+        // because the window's runtime class is `NSPanel`.
         let style = ns_window.styleMask();
         ns_window.setStyleMask(style | NSWindowStyleMask::NonactivatingPanel);
 

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
+use arc_swap::ArcSwap;
 use serde::{Deserialize, Serialize};
 use tauri::async_runtime;
 use tauri::webview::Color;
@@ -156,6 +157,7 @@ pub struct OverlaySubscriberState {
 
 /// Poll interval for the cursor poller while hit rects are present. Fast
 /// enough that hover feels immediate, slow enough to be negligible CPU.
+#[cfg(not(target_os = "macos"))]
 const HIT_RECT_POLL_INTERVAL: Duration = Duration::from_millis(90);
 
 /// Axis-aligned card hit rect in overlay-window viewport coordinates
@@ -187,6 +189,7 @@ pub fn any_rect_contains(rects: &[HitRect], x: f64, y: f64) -> bool {
 /// overlay window is undecorated, so its outer position IS the viewport
 /// origin. A non-positive scale factor (defensive; never expected from
 /// Tauri) falls back to 1.0 rather than dividing by zero.
+#[cfg_attr(target_os = "macos", allow(dead_code))]
 pub fn cursor_to_viewport(
     cursor: PhysicalPosition<f64>,
     window_pos: PhysicalPosition<i32>,
@@ -203,29 +206,53 @@ pub fn cursor_to_viewport(
     )
 }
 
-/// Tauri-managed state for the cursor poller. `rects` is shared with the
-/// running poller task (refreshed in place on every renderer report);
-/// `poller` holds the task handle so an empty report can abort it.
+/// Tauri-managed shared state for overlay click routing. `rects` holds the
+/// renderer-reported card rects (viewport / CSS px). On macOS the overlay's
+/// `hitTest:` override reads them lock-free on the AppKit main thread; on
+/// other platforms the cursor poller reads them and `poller` holds its task
+/// handle so an empty report can abort it.
 #[derive(Default)]
 pub struct OverlayHitState {
-    rects: Arc<std::sync::Mutex<Vec<HitRect>>>,
+    rects: Arc<ArcSwap<Vec<HitRect>>>,
+    #[cfg(not(target_os = "macos"))]
     poller: std::sync::Mutex<Option<JoinHandle<()>>>,
 }
 
-/// Apply a renderer hit-rect report: store the rects, then start or stop the
-/// poller as needed. Empty report → abort the poller and restore
+/// Apply a renderer hit-rect report.
+///
+/// On macOS the overlay's `hitTest:` override (see [`macos_panel`]) reads the
+/// rects directly on the AppKit main thread, so all this does is a single
+/// lock-free store per renderer report — no poller, no `setIgnoresMouseEvents`
+/// toggle. On other platforms it drives the cursor poller.
+pub fn update_hit_rects(app: &AppHandle, state: &OverlayHitState, rects: Vec<HitRect>) {
+    #[cfg(target_os = "macos")]
+    {
+        // The overlay content view's `hitTest:` override consults these rects
+        // synchronously on every mouse event; storing them is the whole job.
+        let _ = app;
+        state.rects.store(Arc::new(rects));
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        update_hit_rects_polled(app, state, rects);
+    }
+}
+
+/// Cursor-poller variant of [`update_hit_rects`] for platforms without the
+/// macOS `hitTest:` override. Empty report → abort the poller and restore
 /// click-through (covers "last card dismissed while hovered"). Non-empty →
 /// ensure exactly one poller task is running.
 ///
 /// Debug builds are a no-op: `build_overlay_window` never enables
 /// click-through there (the window stays fully interactive for devtools), so
 /// a poller toggling the ignore flag would only break that.
-pub fn update_hit_rects(app: &AppHandle, state: &OverlayHitState, rects: Vec<HitRect>) {
+#[cfg(not(target_os = "macos"))]
+fn update_hit_rects_polled(app: &AppHandle, state: &OverlayHitState, rects: Vec<HitRect>) {
     if cfg!(debug_assertions) {
         return;
     }
     let empty = rects.is_empty();
-    *state.rects.lock().expect("hit-rect mutex poisoned") = rects;
+    state.rects.store(Arc::new(rects));
 
     let mut poller = state.poller.lock().expect("poller mutex poisoned");
     if empty {
@@ -258,7 +285,8 @@ pub fn update_hit_rects(app: &AppHandle, state: &OverlayHitState, rects: Vec<Hit
 /// transitions only (the underlying OS call is not free). Exits when the
 /// overlay window is gone (overlay disabled); `update_hit_rects` aborts it
 /// when the rect list empties.
-async fn cursor_poll_loop(app: AppHandle, rects: Arc<std::sync::Mutex<Vec<HitRect>>>) {
+#[cfg(not(target_os = "macos"))]
+async fn cursor_poll_loop(app: AppHandle, rects: Arc<ArcSwap<Vec<HitRect>>>) {
     let mut hovering = false;
     loop {
         tokio::time::sleep(HIT_RECT_POLL_INTERVAL).await;
@@ -273,7 +301,7 @@ async fn cursor_poll_loop(app: AppHandle, rects: Arc<std::sync::Mutex<Vec<HitRec
             (Ok(cursor), Ok(pos)) => {
                 let scale = window.scale_factor().unwrap_or(1.0);
                 let (x, y) = cursor_to_viewport(cursor, pos, scale);
-                let rects = rects.lock().expect("hit-rect mutex poisoned");
+                let rects = rects.load();
                 any_rect_contains(&rects, x, y)
             }
             _ => false,
@@ -288,6 +316,138 @@ async fn cursor_poll_loop(app: AppHandle, rects: Arc<std::sync::Mutex<Vec<HitRec
             }
             hovering = inside;
         }
+    }
+}
+
+/// macOS-native overlay click routing: a non-activating panel plus an
+/// `NSView` `hitTest:` override that consults renderer-reported card rects so
+/// clicks inside a card reach the WKWebView and clicks elsewhere pass through
+/// to whatever window is underneath. Replaces the cursor poller +
+/// `setIgnoresMouseEvents` toggle, which raced AppKit's event routing and let
+/// clicks activate Endara instead of reaching the webview.
+#[cfg(target_os = "macos")]
+mod macos_panel {
+    use std::sync::Arc;
+
+    use arc_swap::ArcSwap;
+    use objc2::rc::Retained;
+    use objc2::runtime::AnyObject;
+    use objc2::{define_class, msg_send, DefinedClass, MainThreadMarker};
+    use objc2_app_kit::{NSAutoresizingMaskOptions, NSView, NSWindow, NSWindowStyleMask};
+    use objc2_foundation::NSPoint;
+
+    use super::{any_rect_contains, HitRect};
+
+    /// Instance state for [`OverlayHitTestView`]: the shared, lock-free card
+    /// rects refreshed by `set_overlay_hit_rects`.
+    pub(super) struct OverlayHitTestIvars {
+        rects: Arc<ArcSwap<Vec<HitRect>>>,
+    }
+
+    define_class!(
+        /// Thin wrapper installed as the overlay window's content view.
+        /// `hitTest:` consults the renderer-reported card rects so clicks
+        /// inside a card reach the WKWebView while clicks elsewhere return
+        /// `nil` and pass through to whatever window is underneath.
+        #[unsafe(super(NSView))]
+        #[ivars = OverlayHitTestIvars]
+        pub(super) struct OverlayHitTestView;
+
+        impl OverlayHitTestView {
+            /// `point` arrives in the superview's coordinate system; convert it
+            /// into our local (flipped, top-left) space so it lines up with the
+            /// renderer's CSS-pixel rects, then route the click.
+            #[unsafe(method(hitTest:))]
+            fn hit_test(&self, point: NSPoint) -> *mut NSView {
+                // SAFETY: `superview` returns a borrowed view we use only for
+                // the immediately-following coordinate conversion.
+                let superview = unsafe { self.superview() };
+                let local = self.convertPoint_fromView(point, superview.as_deref());
+                let guard = self.ivars().rects.load();
+                let rects: &[HitRect] = &guard;
+                if any_rect_contains(rects, local.x, local.y) {
+                    // Inside a card → let NSView descend to the WKWebView.
+                    unsafe { msg_send![super(self), hitTest: point] }
+                } else {
+                    // Outside every card → pass the click through.
+                    std::ptr::null_mut()
+                }
+            }
+
+            /// Top-left origin so local coordinates match the renderer's
+            /// `getBoundingClientRect` values (CSS px, top-left) with no Y flip.
+            #[unsafe(method(isFlipped))]
+            fn is_flipped(&self) -> bool {
+                true
+            }
+
+            /// Deliver the very first click immediately even when the panel was
+            /// not previously key — no separate activation click.
+            #[unsafe(method(acceptsFirstMouse:))]
+            fn accepts_first_mouse(&self, _event: *mut AnyObject) -> bool {
+                true
+            }
+        }
+    );
+
+    impl OverlayHitTestView {
+        fn new(mtm: MainThreadMarker, rects: Arc<ArcSwap<Vec<HitRect>>>) -> Retained<Self> {
+            let this = mtm
+                .alloc::<OverlayHitTestView>()
+                .set_ivars(OverlayHitTestIvars { rects });
+            unsafe { msg_send![super(this), init] }
+        }
+    }
+
+    /// Convert the overlay window into a non-activating panel and wrap its
+    /// content view with [`OverlayHitTestView`]. Must run on the AppKit main
+    /// thread. `ns_window_addr` is the live `NSWindow` pointer smuggled across
+    /// the closure boundary as a `usize` (raw pointers are not `Send`).
+    pub(super) fn configure(ns_window_addr: usize, rects: Arc<ArcSwap<Vec<HitRect>>>) {
+        let Some(mtm) = MainThreadMarker::new() else {
+            log::warn!(target: "overlay", "overlay panel setup skipped: not on the main thread");
+            return;
+        };
+        // SAFETY: `ns_window_addr` is the live `NSWindow` returned by
+        // `ns_window()`, only dereferenced here on the main thread.
+        let ns_window: &NSWindow = unsafe { &*(ns_window_addr as *const NSWindow) };
+
+        // Keep the overlay anchored to its computed corner (NSWindow defaults
+        // to `isMovable = true`, which would let the user drag it anywhere by
+        // clicking-and-holding any part of it, including transparent regions).
+        ns_window.setMovable(false);
+
+        // Non-activating panel: clicking the overlay must not activate Endara
+        // or raise its main window. `NSWindowStyleMaskNonactivatingPanel`
+        // (1 << 7) is the style every macOS HUD/overlay uses.
+        let style = ns_window.styleMask();
+        ns_window.setStyleMask(style | NSWindowStyleMask::NonactivatingPanel);
+
+        let Some(content) = ns_window.contentView() else {
+            log::warn!(target: "overlay", "overlay panel setup: window has no content view to wrap");
+            return;
+        };
+
+        let wrapper = OverlayHitTestView::new(mtm, rects);
+        wrapper.setFrame(content.frame());
+        let resize = NSAutoresizingMaskOptions::ViewWidthSizable
+            | NSAutoresizingMaskOptions::ViewHeightSizable;
+        wrapper.setAutoresizingMask(resize);
+
+        // `setContentView:` detaches `content` from the window; our retained
+        // handle keeps it alive so we can re-parent it under the wrapper.
+        let wrapper_view: &NSView = &wrapper;
+        ns_window.setContentView(Some(wrapper_view));
+
+        let content_view: &NSView = &content;
+        content_view.setFrame(wrapper.bounds());
+        content_view.setAutoresizingMask(resize);
+        wrapper.addSubview(content_view);
+
+        log::info!(
+            target: "overlay",
+            "overlay configured as non-activating panel with hitTest passthrough"
+        );
     }
 }
 
@@ -578,71 +738,65 @@ pub fn build_overlay_window(
 
     let window = builder.build()?;
 
-    // Disable native window dragging on macOS. `NSWindow` defaults to
-    // `isMovable = true`, which lets the user drag the entire overlay
-    // window by clicking-and-holding anywhere on it (including
-    // transparent regions) — wrong for an overlay that must stay
-    // anchored to its computed corner. Tauri 2's `WebviewWindowBuilder`
-    // does not expose this knob, so call `setMovable:` on the
-    // underlying `NSWindow` directly. Dispatch onto the macOS main
-    // thread because `build_overlay_window` can be invoked from a
-    // Tauri command worker thread (`set_overlay_settings` → enable
-    // overlay from Settings) where calling AppKit selectors directly
-    // aborts the process. The window is built hidden (`visible(false)`
-    // above) and only revealed via the `overlay-render-ready` event /
-    // 500ms safety net below, both of which themselves go through the
-    // main thread, so the `setMovable:` message lands before the
-    // window can appear in a draggable state.
+    // On macOS, convert the overlay into a non-activating panel and wrap its
+    // content view with an `NSView` `hitTest:` override (see `macos_panel`):
+    // clicks inside a renderer-reported card rect reach the WKWebView, clicks
+    // elsewhere pass through to the window underneath, and the overlay never
+    // activates Endara. This also pins the window in place (`setMovable:
+    // false`) so it can't be dragged off its computed corner. Dispatch onto
+    // the macOS main thread because `build_overlay_window` can be invoked from
+    // a Tauri command worker thread (`set_overlay_settings` → enable overlay
+    // from Settings) where calling AppKit selectors directly aborts the
+    // process. The window is built hidden (`visible(false)` above) and only
+    // revealed via the `overlay-render-ready` event / 500ms safety net below,
+    // both of which themselves go through the main thread, so this lands before
+    // the window can appear.
     #[cfg(target_os = "macos")]
     {
-        use objc2::msg_send;
-        use objc2::runtime::AnyObject;
+        let rects = Arc::clone(&app.state::<OverlayHitState>().rects);
         match window.ns_window() {
             Ok(ptr) if !ptr.is_null() => {
                 // Raw pointers are not `Send`; smuggle the `NSWindow`
                 // address across the closure boundary as a `usize`.
                 let ns_window_addr = ptr as usize;
                 if let Err(e) = app.run_on_main_thread(move || {
-                    let ns_window = ns_window_addr as *mut AnyObject;
-                    // SAFETY: `ns_window()` returned the live
-                    // `NSWindow` pointer owned by AppKit; we only
-                    // borrow it for a single Obj-C message send,
-                    // dispatched on the macOS main thread.
-                    unsafe {
-                        let _: () = msg_send![&*ns_window, setMovable: false];
-                    }
+                    macos_panel::configure(ns_window_addr, rects);
                 }) {
                     log::warn!(
                         target: "overlay",
-                        "run_on_main_thread for setMovable failed: {e}; overlay window remains draggable"
+                        "run_on_main_thread for overlay panel setup failed: {e}; overlay stays a plain activating window"
                     );
                 }
             }
             Ok(_) => log::warn!(
                 target: "overlay",
-                "ns_window() returned null; overlay window remains draggable"
+                "ns_window() returned null; overlay panel setup skipped"
             ),
             Err(e) => log::warn!(
                 target: "overlay",
-                "ns_window() failed: {e}; overlay window remains draggable"
+                "ns_window() failed: {e}; overlay panel setup skipped"
             ),
         }
     }
 
-    // Click-through by default — the Rust-side cursor poller (see
+    // Non-macOS: click-through by default — the Rust-side cursor poller (see
     // `update_hit_rects` / `cursor_poll_loop` above) flips this while the
-    // global cursor is over a renderer-reported card rect. In debug builds
-    // we skip the global click-through so the overlay window is fully
-    // interactive and right-click → Inspect works from devtools; production
-    // builds keep the original click-through behaviour so the overlay never
-    // steals input from the user's other windows.
-    if cfg!(debug_assertions) {
-        log::info!(
-            target: "overlay",
-            "debug build: overlay window is interactive (set_ignore_cursor_events skipped); right-click → Inspect to open devtools"
-        );
-    } else if let Err(e) = window.set_ignore_cursor_events(true) {
-        log::warn!("[overlay] set_ignore_cursor_events failed: {e}");
+    // global cursor is over a renderer-reported card rect. In debug builds we
+    // skip the global click-through so the overlay window is fully interactive
+    // and right-click → Inspect works from devtools; production builds keep the
+    // click-through behaviour so the overlay never steals input from the user's
+    // other windows. macOS routes clicks via the panel + `hitTest:` override
+    // installed above and never toggles `set_ignore_cursor_events`.
+    #[cfg(not(target_os = "macos"))]
+    {
+        if cfg!(debug_assertions) {
+            log::info!(
+                target: "overlay",
+                "debug build: overlay window is interactive (set_ignore_cursor_events skipped); right-click → Inspect to open devtools"
+            );
+        } else if let Err(e) = window.set_ignore_cursor_events(true) {
+            log::warn!("[overlay] set_ignore_cursor_events failed: {e}");
+        }
     }
 
     // Primary reveal path: the renderer emits `overlay-render-ready` after a
@@ -987,6 +1141,37 @@ mod tests {
         assert!(any_rect_contains(&rects, 105.0, 105.0));
         assert!(!any_rect_contains(&rects, 50.0, 50.0));
         assert!(!any_rect_contains(&[], 5.0, 5.0));
+    }
+
+    #[test]
+    fn hit_test_passthrough_matches_card_rects_in_local_coords() {
+        // Decision logic of the macOS `hitTest:` override: the wrapper view is
+        // flipped (top-left origin), so renderer rects compare directly against
+        // the view-local point with no Y inversion. Inside a card → capture
+        // (return super.hitTest); outside every card → pass through (return
+        // nil). Coordinates mirror a real diagnostic-log report.
+        let cards = [
+            HitRect {
+                x: 40.0,
+                y: 1032.0,
+                width: 340.0,
+                height: 100.0,
+            },
+            HitRect {
+                x: 40.0,
+                y: 900.0,
+                width: 340.0,
+                height: 100.0,
+            },
+        ];
+        // Point inside the first card → captured.
+        assert!(any_rect_contains(&cards, 47.3, 1060.6));
+        // Gap between the two cards → passed through.
+        assert!(!any_rect_contains(&cards, 200.0, 1010.0));
+        // Transparent strip left of the cards → passed through.
+        assert!(!any_rect_contains(&cards, 10.0, 1060.0));
+        // No cards at all → everything passes through.
+        assert!(!any_rect_contains(&[], 47.3, 1060.6));
     }
 
     #[test]

--- a/src/lib/components/RelayLogs.svelte
+++ b/src/lib/components/RelayLogs.svelte
@@ -6,7 +6,14 @@
   import { isAtBottom } from '$lib/scrollUtils';
   import LogFilterBar from './LogFilterBar.svelte';
   import LogRow from './LogRow.svelte';
-  import { resolvePendingHighlight, toggleEndpointFilter } from './relay-logs-helpers';
+  import {
+    resolvePendingHighlight,
+    toggleEndpointFilter,
+    waitForVisibleContainer,
+  } from './relay-logs-helpers';
+
+  /** Resolve after the browser has scheduled a paint (one animation frame). */
+  const nextFrame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 
   /** Duration the matched row stays highlighted after an overlay:focus-log event. */
   const HIGHLIGHT_DURATION_MS = 2000;
@@ -30,6 +37,9 @@
   // Cancels any in-flight pending-highlight poll (overlay click before the
   // target row has rendered). Replaced on each new click, cleared on destroy.
   let cancelPendingHighlight: (() => void) | null = null;
+  // Bumped on every overlay:focus-log click so a stale visibility wait from an
+  // earlier click bails instead of highlighting after a newer click superseded it.
+  let highlightGeneration = 0;
 
   // Filter state — local, not persisted (engineering spec §2.2).
   let activeLevels = $state<Set<LogLevel>>(new Set(['error', 'warn', 'info', 'debug', 'trace']));
@@ -191,11 +201,18 @@
   // the target row can take a moment to mount/populate. When it is not found
   // synchronously we hold a short-lived pending highlight and poll until the
   // row appears or a ~2s budget elapses, instead of giving up after one pass.
+  //
+  // The relay-logs tab is rendered with `style:display:none` until activated,
+  // so when the click arrives from another tab the container has no layout yet.
+  // We await two animation frames (a layout + paint pass) and then poll its
+  // dimensions before highlighting, otherwise the `forwards` CSS animation
+  // finishes while the tab is hidden and the pulse is never seen.
   onMount(() => {
     let unlisten: UnlistenFn | undefined;
     listen<{ jsonrpcId: string }>('overlay:focus-log', async (event) => {
       const { jsonrpcId } = event.payload;
       if (!jsonrpcId) return;
+      const generation = ++highlightGeneration;
       activeTopLevelTab.set('relay-logs');
       // Disable auto-scroll so scrollIntoView is not immediately undone by
       // the bottom-pin effect when new log lines arrive mid-flight.
@@ -204,6 +221,17 @@
       cancelPendingHighlight?.();
       cancelPendingHighlight = null;
       await tick();
+      // Two animation frames so the just-toggled tab gets a display:none→block
+      // layout pass and a paint before we check its dimensions.
+      await nextFrame();
+      await nextFrame();
+      if (generation !== highlightGeneration) return;
+      const visible = await waitForVisibleContainer(() => scrollContainer, HIGHLIGHT_DURATION_MS);
+      if (generation !== highlightGeneration) return;
+      if (!visible) {
+        console.warn(`[overlay] relay-logs tab never became visible for jsonrpcId=${jsonrpcId}`);
+        return;
+      }
       cancelPendingHighlight = resolvePendingHighlight({
         jsonrpcId,
         getLines: () => filteredLines,

--- a/src/lib/components/RelayLogs.svelte
+++ b/src/lib/components/RelayLogs.svelte
@@ -237,8 +237,13 @@
         getLines: () => filteredLines,
         onFound: (idx) => {
           // Wait one tick in case the row mounted on the same store update
-          // that satisfied the poll, then scroll + highlight.
-          tick().then(() => highlightRow(jsonrpcId, idx));
+          // that satisfied the poll, then scroll + highlight. Re-check the
+          // generation after the tick so a newer click that arrived in the
+          // meantime is not clobbered by this now-stale highlight.
+          tick().then(() => {
+            if (generation !== highlightGeneration) return;
+            highlightRow(jsonrpcId, idx);
+          });
         },
         onTimeout: () => {
           console.warn(`[overlay] no log row found for jsonrpcId=${jsonrpcId}`);

--- a/src/lib/components/RelayLogs.svelte
+++ b/src/lib/components/RelayLogs.svelte
@@ -6,7 +6,7 @@
   import { isAtBottom } from '$lib/scrollUtils';
   import LogFilterBar from './LogFilterBar.svelte';
   import LogRow from './LogRow.svelte';
-  import { findRequestRowIndex, toggleEndpointFilter } from './relay-logs-helpers';
+  import { resolvePendingHighlight, toggleEndpointFilter } from './relay-logs-helpers';
 
   /** Duration the matched row stays highlighted after an overlay:focus-log event. */
   const HIGHLIGHT_DURATION_MS = 2000;
@@ -27,6 +27,9 @@
   // Set by the overlay:focus-log handler; cleared after HIGHLIGHT_DURATION_MS.
   let highlightedRequestId = $state<string | null>(null);
   let highlightTimer: ReturnType<typeof setTimeout> | null = null;
+  // Cancels any in-flight pending-highlight poll (overlay click before the
+  // target row has rendered). Replaced on each new click, cleared on destroy.
+  let cancelPendingHighlight: (() => void) | null = null;
 
   // Filter state — local, not persisted (engineering spec §2.2).
   let activeLevels = $state<Set<LogLevel>>(new Set(['error', 'warn', 'info', 'debug', 'trace']));
@@ -155,6 +158,28 @@
     };
   });
 
+  // Scroll the row at `idx` (within filteredLines) into view and paint the
+  // fade-out highlight. The DOM query falls back to the last matching row if
+  // the :nth-of-type selector did not resolve.
+  function highlightRow(jsonrpcId: string, idx: number) {
+    const container = scrollContainer;
+    if (!container) return;
+    const row = container.querySelector<HTMLElement>(
+      `[data-request-id="${CSS.escape(jsonrpcId)}"]:nth-of-type(${idx + 1})`,
+    );
+    const rows = container.querySelectorAll<HTMLElement>(
+      `[data-request-id="${CSS.escape(jsonrpcId)}"]`,
+    );
+    const target = row ?? rows[rows.length - 1];
+    target?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    highlightedRequestId = jsonrpcId;
+    if (highlightTimer) clearTimeout(highlightTimer);
+    highlightTimer = setTimeout(() => {
+      highlightedRequestId = null;
+      highlightTimer = null;
+    }, HIGHLIGHT_DURATION_MS);
+  }
+
   // Handle the overlay:focus-log window event. The host (Rust) emits this
   // from `focus_main_window_on_log` after focusing the main window. We:
   //   1. switch to the relay-logs tab,
@@ -162,9 +187,10 @@
   //   3. find the latest row whose `requestId === jsonrpcId`,
   //   4. scroll it into view (centered) and paint the fade-out highlight.
   //
-  // If the matching row is filtered out, scrollIntoView is a no-op — the
-  // user can clear filters and the toast can still be clicked again. We
-  // log a warning to surface the dropped target in dev-tools.
+  // The window may have just been brought back from a hidden/closed state, so
+  // the target row can take a moment to mount/populate. When it is not found
+  // synchronously we hold a short-lived pending highlight and poll until the
+  // row appears or a ~2s budget elapses, instead of giving up after one pass.
   onMount(() => {
     let unlisten: UnlistenFn | undefined;
     listen<{ jsonrpcId: string }>('overlay:focus-log', async (event) => {
@@ -174,36 +200,30 @@
       // Disable auto-scroll so scrollIntoView is not immediately undone by
       // the bottom-pin effect when new log lines arrive mid-flight.
       autoScroll = false;
+      // A newer click supersedes any unresolved pending highlight.
+      cancelPendingHighlight?.();
+      cancelPendingHighlight = null;
       await tick();
-      const idx = findRequestRowIndex(filteredLines, jsonrpcId);
-      if (idx === -1) {
-        console.warn(`[overlay] no log row found for jsonrpcId=${jsonrpcId}`);
-        return;
-      }
-      const container = scrollContainer;
-      if (!container) return;
-      const row = container.querySelector<HTMLElement>(
-        `[data-request-id="${CSS.escape(jsonrpcId)}"]:nth-of-type(${idx + 1})`,
-      );
-      // Fall back to the last matching row if :nth-of-type selector did not
-      // resolve (e.g. siblings other than the row grid intermixed). The
-      // helper already guarantees the newest occurrence is at `idx`.
-      const rows = container.querySelectorAll<HTMLElement>(
-        `[data-request-id="${CSS.escape(jsonrpcId)}"]`,
-      );
-      const target = row ?? rows[rows.length - 1];
-      target?.scrollIntoView({ block: 'center', behavior: 'smooth' });
-      highlightedRequestId = jsonrpcId;
-      if (highlightTimer) clearTimeout(highlightTimer);
-      highlightTimer = setTimeout(() => {
-        highlightedRequestId = null;
-        highlightTimer = null;
-      }, HIGHLIGHT_DURATION_MS);
+      cancelPendingHighlight = resolvePendingHighlight({
+        jsonrpcId,
+        getLines: () => filteredLines,
+        onFound: (idx) => {
+          // Wait one tick in case the row mounted on the same store update
+          // that satisfied the poll, then scroll + highlight.
+          tick().then(() => highlightRow(jsonrpcId, idx));
+        },
+        onTimeout: () => {
+          console.warn(`[overlay] no log row found for jsonrpcId=${jsonrpcId}`);
+        },
+        budgetMs: HIGHLIGHT_DURATION_MS,
+      });
     }).then((fn) => {
       unlisten = fn;
     });
     return () => {
       unlisten?.();
+      cancelPendingHighlight?.();
+      cancelPendingHighlight = null;
       if (highlightTimer) clearTimeout(highlightTimer);
     };
   });

--- a/src/lib/components/relay-logs-helpers.test.ts
+++ b/src/lib/components/relay-logs-helpers.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-import { findRequestRowIndex, toggleEndpointFilter } from './relay-logs-helpers';
+import {
+  findRequestRowIndex,
+  resolvePendingHighlight,
+  toggleEndpointFilter,
+} from './relay-logs-helpers';
 
 describe('toggleEndpointFilter', () => {
   it('selects an endpoint when nothing is selected', () => {
@@ -44,5 +48,83 @@ describe('findRequestRowIndex', () => {
   it('ignores rows whose requestId is undefined', () => {
     const lines = [{}, { requestId: '42' }, {}];
     expect(findRequestRowIndex(lines, '42')).toBe(1);
+  });
+});
+
+describe('resolvePendingHighlight', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resolves synchronously when the row is already present', () => {
+    const onFound = vi.fn();
+    const onTimeout = vi.fn();
+    const lines = [{ requestId: 'a' }, { requestId: '7' }];
+    resolvePendingHighlight({ jsonrpcId: '7', getLines: () => lines, onFound, onTimeout });
+    expect(onFound).toHaveBeenCalledExactlyOnceWith(1);
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it('resolves once a matching row is pushed in before the budget elapses', () => {
+    const onFound = vi.fn();
+    const onTimeout = vi.fn();
+    let lines: { requestId?: string }[] = [];
+    resolvePendingHighlight({
+      jsonrpcId: '7',
+      getLines: () => lines,
+      onFound,
+      onTimeout,
+      budgetMs: 2000,
+      intervalMs: 100,
+    });
+    expect(onFound).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(300);
+    expect(onFound).not.toHaveBeenCalled();
+
+    lines = [{ requestId: 'other' }, { requestId: '7' }];
+    vi.advanceTimersByTime(100);
+    expect(onFound).toHaveBeenCalledExactlyOnceWith(1);
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it('calls onTimeout when no row appears within the budget', () => {
+    const onFound = vi.fn();
+    const onTimeout = vi.fn();
+    resolvePendingHighlight({
+      jsonrpcId: 'missing',
+      getLines: () => [{ requestId: 'a' }],
+      onFound,
+      onTimeout,
+      budgetMs: 2000,
+      intervalMs: 100,
+    });
+
+    vi.advanceTimersByTime(2000);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+    expect(onFound).not.toHaveBeenCalled();
+  });
+
+  it('stops polling after cancel and never fires the callbacks', () => {
+    const onFound = vi.fn();
+    const onTimeout = vi.fn();
+    let lines: { requestId?: string }[] = [];
+    const cancel = resolvePendingHighlight({
+      jsonrpcId: '7',
+      getLines: () => lines,
+      onFound,
+      onTimeout,
+      budgetMs: 2000,
+      intervalMs: 100,
+    });
+
+    cancel();
+    lines = [{ requestId: '7' }];
+    vi.advanceTimersByTime(5000);
+    expect(onFound).not.toHaveBeenCalled();
+    expect(onTimeout).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/components/relay-logs-helpers.test.ts
+++ b/src/lib/components/relay-logs-helpers.test.ts
@@ -4,7 +4,12 @@ import {
   findRequestRowIndex,
   resolvePendingHighlight,
   toggleEndpointFilter,
+  waitForVisibleContainer,
 } from './relay-logs-helpers';
+
+function rectEl(getRect: () => { width: number; height: number }) {
+  return { getBoundingClientRect: getRect };
+}
 
 describe('toggleEndpointFilter', () => {
   it('selects an endpoint when nothing is selected', () => {
@@ -126,5 +131,40 @@ describe('resolvePendingHighlight', () => {
     vi.advanceTimersByTime(5000);
     expect(onFound).not.toHaveBeenCalled();
     expect(onTimeout).not.toHaveBeenCalled();
+  });
+});
+
+describe('waitForVisibleContainer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resolves true immediately when the container already has layout', async () => {
+    const el = rectEl(() => ({ width: 800, height: 600 }));
+    await expect(waitForVisibleContainer(() => el, 2000, 16)).resolves.toBe(true);
+  });
+
+  it('resolves true once the container gains dimensions within the budget', async () => {
+    let frames = 0;
+    const el = rectEl(() => (frames++ < 3 ? { width: 0, height: 0 } : { width: 800, height: 600 }));
+    const promise = waitForVisibleContainer(() => el, 2000, 16);
+    await vi.advanceTimersByTimeAsync(64);
+    await expect(promise).resolves.toBe(true);
+  });
+
+  it('resolves false after the deadline when the container stays hidden', async () => {
+    const el = rectEl(() => ({ width: 0, height: 0 }));
+    const promise = waitForVisibleContainer(() => el, 200, 16);
+    await vi.advanceTimersByTimeAsync(400);
+    await expect(promise).resolves.toBe(false);
+  });
+
+  it('resolves false when the element is missing for the whole budget', async () => {
+    const promise = waitForVisibleContainer(() => null, 200, 16);
+    await vi.advanceTimersByTimeAsync(400);
+    await expect(promise).resolves.toBe(false);
   });
 });

--- a/src/lib/components/relay-logs-helpers.ts
+++ b/src/lib/components/relay-logs-helpers.ts
@@ -109,3 +109,37 @@ export function resolvePendingHighlight<T extends { requestId?: string }>(opts: 
   }, intervalMs);
   return cancel;
 }
+
+/**
+ * Wait until the scroll container reports real layout (a non-zero
+ * `getBoundingClientRect()`), i.e. the relay-logs tab has actually been
+ * painted after its `style:display:none` → `block` toggle.
+ *
+ * The overlay:focus-log handler switches tabs and then runs `scrollIntoView`
+ * plus the `highlight-row-fade` CSS animation. Because that animation uses
+ * `forwards`, if it starts while the tab is still hidden it finishes at the
+ * transparent end state and the user never sees the pulse. Gating the
+ * highlight on real container dimensions guarantees the animation starts on a
+ * visible row.
+ *
+ * Resolves `true` as soon as the element has non-zero dimensions (immediately
+ * when already visible, so the working same-tab case adds no delay), or
+ * `false` once `deadlineMs` elapses without the tab becoming visible (e.g. the
+ * user navigated away again before resolution).
+ */
+export async function waitForVisibleContainer(
+  getEl: () => { getBoundingClientRect: () => { width: number; height: number } } | null | undefined,
+  deadlineMs = 2000,
+  intervalMs = 16,
+): Promise<boolean> {
+  const deadline = Date.now() + deadlineMs;
+  for (;;) {
+    const el = getEl();
+    if (el) {
+      const rect = el.getBoundingClientRect();
+      if (rect.width > 0 && rect.height > 0) return true;
+    }
+    if (Date.now() >= deadline) return false;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+}

--- a/src/lib/components/relay-logs-helpers.ts
+++ b/src/lib/components/relay-logs-helpers.ts
@@ -56,3 +56,56 @@ export function findRequestRowIndex<T extends { requestId?: string }>(
   }
   return -1;
 }
+
+/**
+ * Resolve an overlay highlight target that may not be rendered yet.
+ *
+ * When the main window is brought back from a hidden/closed state, the
+ * relay-log rows can take a moment to mount/populate, so the row for
+ * `jsonrpcId` is not in `getLines()` on the first synchronous pass. Rather
+ * than warn-and-give-up, this polls `getLines()` until a matching row appears
+ * (firing `onFound` with its index) or the `budgetMs` budget elapses (firing
+ * `onTimeout`). If a matching row is already present it resolves synchronously.
+ *
+ * Returns a cancel function — call it to abort an in-flight poll (e.g. when a
+ * newer overlay click supersedes this one, or on component destroy). The cancel
+ * is idempotent.
+ */
+export function resolvePendingHighlight<T extends { requestId?: string }>(opts: {
+  jsonrpcId: string;
+  getLines: () => readonly T[];
+  onFound: (idx: number) => void;
+  onTimeout: () => void;
+  budgetMs?: number;
+  intervalMs?: number;
+}): () => void {
+  const { jsonrpcId, getLines, onFound, onTimeout, budgetMs = 2000, intervalMs = 100 } = opts;
+
+  const immediate = findRequestRowIndex(getLines(), jsonrpcId);
+  if (immediate !== -1) {
+    onFound(immediate);
+    return () => {};
+  }
+
+  const deadline = Date.now() + budgetMs;
+  let interval: ReturnType<typeof setInterval> | null = null;
+  const cancel = () => {
+    if (interval !== null) {
+      clearInterval(interval);
+      interval = null;
+    }
+  };
+  interval = setInterval(() => {
+    const idx = findRequestRowIndex(getLines(), jsonrpcId);
+    if (idx !== -1) {
+      cancel();
+      onFound(idx);
+      return;
+    }
+    if (Date.now() >= deadline) {
+      cancel();
+      onTimeout();
+    }
+  }, intervalMs);
+  return cancel;
+}

--- a/src/lib/overlay/OverlayApp.svelte
+++ b/src/lib/overlay/OverlayApp.svelte
@@ -14,9 +14,10 @@
 -->
 <script lang="ts">
   import { onMount } from 'svelte';
-  import type { UnlistenFn } from '@tauri-apps/api/event';
+  import { listen, type UnlistenFn } from '@tauri-apps/api/event';
   import { theme } from '$lib/stores';
   import { attachOverlayBridge } from './eventBridge';
+  import { focusLogForRequest } from './focusLog';
   import { createToastStore } from './toastStore';
   import { emitRenderReady } from './emitRenderReady';
   import {
@@ -80,6 +81,20 @@
       disposer = d;
     });
 
+    // Primary card-click path on macOS: the native click-catcher panel
+    // (see `src-tauri/src/overlay.rs`) emits `overlay:card-clicked` with the
+    // card's `log_id` when a click lands inside a reported rect. Route it
+    // through the same handler the DOM `onclick` uses. The DOM handler stays
+    // in place as a defensive fallback on platforms without the panel.
+    let cardClickUnlisten: UnlistenFn | null = null;
+    listen<{ log_id: string }>('overlay:card-clicked', (event) => {
+      const logId = event.payload?.log_id || null;
+      console.info('[overlay] overlay:card-clicked received', { logId });
+      void focusLogForRequest(logId);
+    })
+      .then((un) => { cardClickUnlisten = un; })
+      .catch((e) => console.warn('[overlay] card-clicked subscribe failed:', e));
+
     // Signal Rust that the renderer has actually painted a frame so the
     // window can be revealed without the brief white flash that the
     // `on_page_load` reveal produced. See `emitRenderReady.ts` for the
@@ -90,6 +105,7 @@
       unsubTheme();
       unsubSettings();
       if (settingsUnlisten) settingsUnlisten();
+      if (cardClickUnlisten) cardClickUnlisten();
       if (disposer) disposer().catch((e) => console.warn('[overlay] disposer failed:', e));
     };
   });

--- a/src/lib/overlay/OverlayApp.svelte
+++ b/src/lib/overlay/OverlayApp.svelte
@@ -89,7 +89,6 @@
     let cardClickUnlisten: UnlistenFn | null = null;
     listen<{ log_id: string }>('overlay:card-clicked', (event) => {
       const logId = event.payload?.log_id || null;
-      console.info('[overlay] overlay:card-clicked received', { logId });
       void focusLogForRequest(logId);
     })
       .then((un) => { cardClickUnlisten = un; })

--- a/src/lib/overlay/OverlayCard.svelte
+++ b/src/lib/overlay/OverlayCard.svelte
@@ -28,6 +28,7 @@
     hintsForAnnotations,
     isDestructive,
     isStacked,
+    latestRequest,
   } from './overlay-helpers';
   import { serverIconFor } from './icons';
   import { cardClick } from './overlay-actions';
@@ -90,7 +91,9 @@
   // When null we fall back to the unchanged server-type-only rendering.
   const caller = $derived(callerLabel(group.client));
 
-  async function onClick() {
+  async function onClick(ev: MouseEvent) {
+    const logId = latestRequest(group)?.jsonrpcId ?? null;
+    console.info('[overlay] card clicked', { logId, x: ev.clientX, y: ev.clientY });
     await cardClick(group);
   }
 </script>

--- a/src/lib/overlay/OverlayCard.svelte
+++ b/src/lib/overlay/OverlayCard.svelte
@@ -28,7 +28,6 @@
     hintsForAnnotations,
     isDestructive,
     isStacked,
-    latestRequest,
   } from './overlay-helpers';
   import { serverIconFor } from './icons';
   import { cardClick } from './overlay-actions';
@@ -91,9 +90,7 @@
   // When null we fall back to the unchanged server-type-only rendering.
   const caller = $derived(callerLabel(group.client));
 
-  async function onClick(ev: MouseEvent) {
-    const logId = latestRequest(group)?.jsonrpcId ?? null;
-    console.info('[overlay] card clicked', { logId, x: ev.clientX, y: ev.clientY });
+  async function onClick() {
     await cardClick(group);
   }
 </script>

--- a/src/lib/overlay/ToastFeed.svelte
+++ b/src/lib/overlay/ToastFeed.svelte
@@ -9,6 +9,7 @@
   import {
     collectHitRects,
     hiddenGroupCount,
+    latestRequest,
     visibleGroups,
     type OverlayPosition,
   } from './overlay-helpers';
@@ -142,7 +143,11 @@
         <div class="tf-more" data-testid="more-earlier">+{hidden} earlier</div>
       {/if}
       {#each visible as g (g.id)}
-        <div class="tf-card-slot" in:fade={{ duration: 120 }}>
+        <div
+          class="tf-card-slot"
+          data-log-id={latestRequest(g)?.jsonrpcId ?? ''}
+          in:fade={{ duration: 120 }}
+        >
           <OverlayCard group={g} {showProfile} {dismissDurationMs} />
         </div>
       {/each}

--- a/src/lib/overlay/ToastFeed.test.ts
+++ b/src/lib/overlay/ToastFeed.test.ts
@@ -140,8 +140,11 @@ describe('ToastFeed — group-level slide direction + container gate', () => {
 
   it('per-card slot uses a short in:fade only (no per-card outro)', async () => {
     const src = (await import('./ToastFeed.svelte?raw')).default as string;
-    // `.tf-card-slot` wrapper carries an `in:fade` for the 1 → N fade-in.
-    expect(src).toMatch(/<div class="tf-card-slot" in:fade=\{\{ duration: 120 \}\}>/);
+    // `.tf-card-slot` wrapper carries an `in:fade` for the 1 → N fade-in and
+    // a `data-log-id` so the native click-catcher can resolve the target row.
+    expect(src).toMatch(/class="tf-card-slot"/);
+    expect(src).toMatch(/data-log-id=\{latestRequest\(g\)\?\.jsonrpcId \?\? ''\}/);
+    expect(src).toMatch(/in:fade=\{\{ duration: 120 \}\}/);
     // No `out:` transition on the per-card slot — the outro is feed-level.
     const slotIdx = src.indexOf('class="tf-card-slot"');
     const eachEndIdx = src.indexOf('{/each}', slotIdx);

--- a/src/lib/overlay/focusLog.ts
+++ b/src/lib/overlay/focusLog.ts
@@ -24,7 +24,8 @@ export async function focusLogForRequest(jsonrpcId: string | null): Promise<void
   }
   try {
     await invoke('focus_main_window_on_log', { jsonrpcId });
+    console.info('[overlay] invoke focus_main_window_on_log resolved');
   } catch (e) {
-    console.error('[overlay] focus_main_window_on_log failed:', e);
+    console.error('[overlay] invoke failed', e);
   }
 }

--- a/src/lib/overlay/focusLog.ts
+++ b/src/lib/overlay/focusLog.ts
@@ -24,7 +24,6 @@ export async function focusLogForRequest(jsonrpcId: string | null): Promise<void
   }
   try {
     await invoke('focus_main_window_on_log', { jsonrpcId });
-    console.info('[overlay] invoke focus_main_window_on_log resolved');
   } catch (e) {
     console.error('[overlay] invoke failed', e);
   }

--- a/src/lib/overlay/overlay-actions.test.ts
+++ b/src/lib/overlay/overlay-actions.test.ts
@@ -78,7 +78,7 @@ describe('reportOverlayHitRects', () => {
   it('invokes set_overlay_hit_rects with the measured rects', async () => {
     const mockInvoke = vi.mocked(invoke);
     mockInvoke.mockResolvedValue(undefined);
-    const rects = [{ x: 20, y: 100, width: 340, height: 72 }];
+    const rects = [{ x: 20, y: 100, width: 340, height: 72, log_id: 'req-1' }];
     await reportOverlayHitRects(rects);
     expect(mockInvoke).toHaveBeenCalledWith('set_overlay_hit_rects', { rects });
   });

--- a/src/lib/overlay/overlay-helpers.test.ts
+++ b/src/lib/overlay/overlay-helpers.test.ts
@@ -190,14 +190,21 @@ describe('visibleGroups / hiddenGroupCount', () => {
 });
 
 describe('collectHitRects', () => {
-  const el = (x: number, y: number, width: number, height: number) => ({
+  const el = (x: number, y: number, width: number, height: number, logId?: string) => ({
     getBoundingClientRect: () => ({ x, y, width, height }),
+    dataset: { logId },
   });
 
-  it('maps elements to their bounding rects in order', () => {
-    expect(collectHitRects([el(20, 100, 340, 72), el(20, 184, 340, 64)])).toEqual([
-      { x: 20, y: 100, width: 340, height: 72 },
-      { x: 20, y: 184, width: 340, height: 64 },
+  it('maps elements to their bounding rects in order, tagging log_id', () => {
+    expect(collectHitRects([el(20, 100, 340, 72, 'a'), el(20, 184, 340, 64, 'b')])).toEqual([
+      { x: 20, y: 100, width: 340, height: 72, log_id: 'a' },
+      { x: 20, y: 184, width: 340, height: 64, log_id: 'b' },
+    ]);
+  });
+
+  it('defaults log_id to empty string when the slot has no data-log-id', () => {
+    expect(collectHitRects([el(20, 100, 340, 72)])).toEqual([
+      { x: 20, y: 100, width: 340, height: 72, log_id: '' },
     ]);
   });
 
@@ -206,15 +213,15 @@ describe('collectHitRects', () => {
   });
 
   it('skips null/undefined entries', () => {
-    expect(collectHitRects([null, el(1, 2, 3, 4), undefined])).toEqual([
-      { x: 1, y: 2, width: 3, height: 4 },
+    expect(collectHitRects([null, el(1, 2, 3, 4, 'x'), undefined])).toEqual([
+      { x: 1, y: 2, width: 3, height: 4, log_id: 'x' },
     ]);
   });
 
   it('drops zero-area rects (collapsed / not yet laid out elements)', () => {
     expect(
-      collectHitRects([el(0, 0, 0, 50), el(0, 0, 50, 0), el(5, 5, 10, 10)]),
-    ).toEqual([{ x: 5, y: 5, width: 10, height: 10 }]);
+      collectHitRects([el(0, 0, 0, 50), el(0, 0, 50, 0), el(5, 5, 10, 10, 'k')]),
+    ).toEqual([{ x: 5, y: 5, width: 10, height: 10, log_id: 'k' }]);
   });
 
   it('accepts any iterable (e.g. a NodeList-like)', () => {

--- a/src/lib/overlay/overlay-helpers.ts
+++ b/src/lib/overlay/overlay-helpers.ts
@@ -85,20 +85,25 @@ export function isDestructive(g: ToolCallGroup): boolean {
 
 /**
  * Axis-aligned card hit rect in overlay-window viewport coordinates (CSS /
- * logical pixels). Mirrors the `HitRect` struct in `src-tauri/src/overlay.rs`
- * consumed by the Rust-side cursor poller.
+ * logical pixels). Mirrors the `HitRect` struct in `src-tauri/src/overlay.rs`.
+ * `log_id` carries the card's JSON-RPC id so the macOS click-catcher can emit
+ * `overlay:card-clicked` with the right target (empty string when the card has
+ * no JSON-RPC id captured yet). The snake_case key matches the wire shape serde
+ * deserializes on the Rust side.
  */
-export type HitRect = { x: number; y: number; width: number; height: number };
+export type HitRect = { x: number; y: number; width: number; height: number; log_id: string };
 
 /** Minimal element shape needed to measure a hit rect (testable without jsdom). */
 type Measurable = {
   getBoundingClientRect(): { x: number; y: number; width: number; height: number };
+  dataset?: { logId?: string };
 };
 
 /**
- * Measure the bounding rects of the visible card elements. Zero-area rects
- * (display:none, not yet laid out) are dropped so the Rust poller never
- * treats a collapsed element as a hover target.
+ * Measure the bounding rects of the visible card elements, tagging each with
+ * the `data-log-id` the renderer stamped on the slot. Zero-area rects
+ * (display:none, not yet laid out) are dropped so the Rust side never treats a
+ * collapsed element as a click target.
  */
 export function collectHitRects(elements: Iterable<Measurable | null | undefined>): HitRect[] {
   const out: HitRect[] = [];
@@ -106,7 +111,7 @@ export function collectHitRects(elements: Iterable<Measurable | null | undefined
     if (!el) continue;
     const r = el.getBoundingClientRect();
     if (!(r.width > 0) || !(r.height > 0)) continue;
-    out.push({ x: r.x, y: r.y, width: r.width, height: r.height });
+    out.push({ x: r.x, y: r.y, width: r.width, height: r.height, log_id: el.dataset?.logId ?? '' });
   }
   return out;
 }


### PR DESCRIPTION
## Problem

In production builds, clicking an overlay notification card did nothing the first time — AppKit was intercepting clicks for app activation rather than routing them to the overlay's WebView. Even after activation, the focus-log handoff to the main window had two race-conditions:

1. The pulse-highlight ran before the target tab finished its layout pass, so the row was scrolled off-screen and the animation never fired.
2. The Tauri AppKit calls were dispatched off the main thread, causing intermittent panics.

## Fix — “Path C-cover”

**Native click-catcher panel (`src-tauri/src/overlay.rs`)**

- Swap the overlay window's `NSWindow` to a transparent, non-activating `NSPanel` (`ClickCatcherPanel`) that captures clicks via `hitTest:` without triggering app activation.
- A Rust cursor poller maintains live hit-rects for each visible card and routes clicks to the appropriate JS handler via a Tauri command.
- Cards become click-through where there's no hit-rect, so overlay clicks never block clicks to underlying apps.

**Main-thread dispatch (`src-tauri/src/lib.rs`)**

- All AppKit calls (`focus_main_window_on_log` + helpers) now dispatch via `AppHandle::run_on_main_thread` to avoid panic-on-wrong-thread.

**Focus-log gating (`RelayLogs.svelte`)**

- Wait for the Relay Logs tab to be visible (double-`requestAnimationFrame` + container-visibility check) before scrolling/highlighting the matched row.
- Retry the highlight when the row isn't yet rendered (e.g. virtual-scroll backlog) up to a 2-second budget.
- Pulse animation only fires once layout is confirmed.

## Verification

- `pnpm svelte-check` ✅
- `pnpm test` ✅ (vitest)
- From `src-tauri/`: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` ✅
- End-to-end smoke (single-monitor Retina, production relay on :9400):
  - Scenario A (main window not focused) — click card → window comes forward, lands on Relay Logs, row pulses. ✅
  - Scenario B (already on Relay Logs) — immediate highlight, no delay. ✅
  - Scenario C (main window hidden) — window appears, lands on Relay Logs, row pulses. ✅

## Notes for the reviewer

- One commit-pair is a revert (`e8f23d4` ← `eacb3b1`) — an early NSPanel approach that didn't work; left in the history for traceability. The squash-merge will collapse cleanly.
- A `chore` commit with temporary diagnostics (`252eca8`) was kept on the branch for tactical reasons; the squash commit will drop the diagnostic logs in the final form (please use the squashed summary above as the commit body when merging).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author