### PR TITLE
refactor(overlay): rename jsonrpcId → logId; drop deprecated wire field

### DIFF
--- a/src/lib/components/RelayLogs.svelte
+++ b/src/lib/components/RelayLogs.svelte
@@ -171,18 +171,18 @@
   // Scroll the row at `idx` (within filteredLines) into view and paint the
   // fade-out highlight. The DOM query falls back to the last matching row if
   // the :nth-of-type selector did not resolve.
-  function highlightRow(jsonrpcId: string, idx: number) {
+  function highlightRow(logId: string, idx: number) {
     const container = scrollContainer;
     if (!container) return;
     const row = container.querySelector<HTMLElement>(
-      `[data-request-id="${CSS.escape(jsonrpcId)}"]:nth-of-type(${idx + 1})`,
+      `[data-request-id="${CSS.escape(logId)}"]:nth-of-type(${idx + 1})`,
     );
     const rows = container.querySelectorAll<HTMLElement>(
-      `[data-request-id="${CSS.escape(jsonrpcId)}"]`,
+      `[data-request-id="${CSS.escape(logId)}"]`,
     );
     const target = row ?? rows[rows.length - 1];
     target?.scrollIntoView({ block: 'center', behavior: 'smooth' });
-    highlightedRequestId = jsonrpcId;
+    highlightedRequestId = logId;
     if (highlightTimer) clearTimeout(highlightTimer);
     highlightTimer = setTimeout(() => {
       highlightedRequestId = null;
@@ -233,7 +233,7 @@
         return;
       }
       cancelPendingHighlight = resolvePendingHighlight({
-        jsonrpcId: logId,
+        logId,
         getLines: () => filteredLines,
         onFound: (idx) => {
           // Wait one tick in case the row mounted on the same store update

--- a/src/lib/components/relay-logs-helpers.test.ts
+++ b/src/lib/components/relay-logs-helpers.test.ts
@@ -68,7 +68,7 @@ describe('resolvePendingHighlight', () => {
     const onFound = vi.fn();
     const onTimeout = vi.fn();
     const lines = [{ requestId: 'a' }, { requestId: '7' }];
-    resolvePendingHighlight({ jsonrpcId: '7', getLines: () => lines, onFound, onTimeout });
+    resolvePendingHighlight({ logId: '7', getLines: () => lines, onFound, onTimeout });
     expect(onFound).toHaveBeenCalledExactlyOnceWith(1);
     expect(onTimeout).not.toHaveBeenCalled();
   });
@@ -78,7 +78,7 @@ describe('resolvePendingHighlight', () => {
     const onTimeout = vi.fn();
     let lines: { requestId?: string }[] = [];
     resolvePendingHighlight({
-      jsonrpcId: '7',
+      logId: '7',
       getLines: () => lines,
       onFound,
       onTimeout,
@@ -100,7 +100,7 @@ describe('resolvePendingHighlight', () => {
     const onFound = vi.fn();
     const onTimeout = vi.fn();
     resolvePendingHighlight({
-      jsonrpcId: 'missing',
+      logId: 'missing',
       getLines: () => [{ requestId: 'a' }],
       onFound,
       onTimeout,
@@ -118,7 +118,7 @@ describe('resolvePendingHighlight', () => {
     const onTimeout = vi.fn();
     let lines: { requestId?: string }[] = [];
     const cancel = resolvePendingHighlight({
-      jsonrpcId: '7',
+      logId: '7',
       getLines: () => lines,
       onFound,
       onTimeout,

--- a/src/lib/components/relay-logs-helpers.ts
+++ b/src/lib/components/relay-logs-helpers.ts
@@ -37,7 +37,7 @@ export function applyGoToEndpoint(name: string): void {
 
 /**
  * Find the index of the latest log row whose request span's `request_uid`
- * (the canonical relay-minted UUID) matches `jsonrpcId`. Collision-free
+ * (the canonical relay-minted UUID) matches `logId`. Collision-free
  * across multiple MCP clients sending the same JSON-RPC id concurrently.
  * Used by the RelayLogs view to scroll to and highlight the row that the
  * overlay card click selected.
@@ -51,10 +51,10 @@ export function applyGoToEndpoint(name: string): void {
  */
 export function findRequestRowIndex<T extends { requestId?: string }>(
   lines: readonly T[],
-  jsonrpcId: string,
+  logId: string,
 ): number {
   for (let i = lines.length - 1; i >= 0; i--) {
-    if (lines[i].requestId === jsonrpcId) return i;
+    if (lines[i].requestId === logId) return i;
   }
   return -1;
 }
@@ -64,7 +64,7 @@ export function findRequestRowIndex<T extends { requestId?: string }>(
  *
  * When the main window is brought back from a hidden/closed state, the
  * relay-log rows can take a moment to mount/populate, so the row for
- * `jsonrpcId` is not in `getLines()` on the first synchronous pass. Rather
+ * `logId` is not in `getLines()` on the first synchronous pass. Rather
  * than warn-and-give-up, this polls `getLines()` until a matching row appears
  * (firing `onFound` with its index) or the `budgetMs` budget elapses (firing
  * `onTimeout`). If a matching row is already present it resolves synchronously.
@@ -74,16 +74,16 @@ export function findRequestRowIndex<T extends { requestId?: string }>(
  * is idempotent.
  */
 export function resolvePendingHighlight<T extends { requestId?: string }>(opts: {
-  jsonrpcId: string;
+  logId: string;
   getLines: () => readonly T[];
   onFound: (idx: number) => void;
   onTimeout: () => void;
   budgetMs?: number;
   intervalMs?: number;
 }): () => void {
-  const { jsonrpcId, getLines, onFound, onTimeout, budgetMs = 2000, intervalMs = 100 } = opts;
+  const { logId, getLines, onFound, onTimeout, budgetMs = 2000, intervalMs = 100 } = opts;
 
-  const immediate = findRequestRowIndex(getLines(), jsonrpcId);
+  const immediate = findRequestRowIndex(getLines(), logId);
   if (immediate !== -1) {
     onFound(immediate);
     return () => {};
@@ -98,7 +98,7 @@ export function resolvePendingHighlight<T extends { requestId?: string }>(opts: 
     }
   };
   interval = setInterval(() => {
-    const idx = findRequestRowIndex(getLines(), jsonrpcId);
+    const idx = findRequestRowIndex(getLines(), logId);
     if (idx !== -1) {
       cancel();
       onFound(idx);

--- a/src/lib/overlay/OverlayCard.svelte
+++ b/src/lib/overlay/OverlayCard.svelte
@@ -17,8 +17,8 @@
   `dismissDurationMs` prop when the group is not counting down. No
   hover-pause, no pause/resume binding on the keyframe.
 
-  Click invokes `focusLogForRequest(latest.jsonrpcId)`; if the latest request
-  has no jsonrpc_id the card is rendered non-clickable (cursor: default) and
+  Click invokes `focusLogForRequest(latest.logId)`; if the latest request
+  has no logId the card is rendered non-clickable (cursor: default) and
   the click is a soft no-op.
 -->
 <script lang="ts">

--- a/src/lib/overlay/OverlayCard.test.ts
+++ b/src/lib/overlay/OverlayCard.test.ts
@@ -17,7 +17,7 @@ import { cardClick } from './overlay-actions';
 import type { ToolCallGroup, ToolCallRequest } from './toastStore';
 
 function req(over: Partial<ToolCallRequest> = {}): ToolCallRequest {
-  return { requestId: 'r-1', ts: 'ts', status: 'inflight', jsonrpcId: null, ...over };
+  return { requestId: 'r-1', ts: 'ts', status: 'inflight', logId: null, ...over };
 }
 
 function g(over: Partial<ToolCallGroup> = {}): ToolCallGroup {
@@ -131,14 +131,14 @@ describe('OverlayCard — hint pills', () => {
 describe('OverlayCard — click handler', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('invokes focus_main_window_on_log with the latest request jsonrpcId', async () => {
+  it('invokes focus_main_window_on_log with the latest request logId', async () => {
     const mockInvoke = vi.mocked(invoke);
     mockInvoke.mockResolvedValue(undefined);
 
     const group = g({
       requests: [
-        req({ requestId: 'a', status: 'success', durationMs: 12, jsonrpcId: 'rpc-1' }),
-        req({ requestId: 'b', status: 'success', durationMs: 14, jsonrpcId: 'rpc-2' }),
+        req({ requestId: 'a', status: 'success', durationMs: 12, logId: 'rpc-1' }),
+        req({ requestId: 'b', status: 'success', durationMs: 14, logId: 'rpc-2' }),
       ],
       success: 2,
     });
@@ -150,12 +150,12 @@ describe('OverlayCard — click handler', () => {
     });
   });
 
-  it('is a soft no-op when the latest request has null jsonrpcId', async () => {
+  it('is a soft no-op when the latest request has null logId', async () => {
     const mockInvoke = vi.mocked(invoke);
     mockInvoke.mockResolvedValue(undefined);
 
     const group = g({
-      requests: [req({ jsonrpcId: null })],
+      requests: [req({ logId: null })],
       inflight: 1,
     });
     expect(canFocusLog(group)).toBe(false);

--- a/src/lib/overlay/ToastFeed.svelte
+++ b/src/lib/overlay/ToastFeed.svelte
@@ -150,7 +150,7 @@
       {#each visible as g (g.id)}
         <div
           class="tf-card-slot"
-          data-log-id={latestRequest(g)?.jsonrpcId ?? ''}
+          data-log-id={latestRequest(g)?.logId ?? ''}
           in:fade={{ duration: 120 }}
         >
           <OverlayCard group={g} {showProfile} {dismissDurationMs} />

--- a/src/lib/overlay/ToastFeed.test.ts
+++ b/src/lib/overlay/ToastFeed.test.ts
@@ -144,7 +144,7 @@ describe('ToastFeed — group-level slide direction + container gate', () => {
     // `.tf-card-slot` wrapper carries an `in:fade` for the 1 → N fade-in and
     // a `data-log-id` so the native click-catcher can resolve the target row.
     expect(src).toMatch(/class="tf-card-slot"/);
-    expect(src).toMatch(/data-log-id=\{latestRequest\(g\)\?\.jsonrpcId \?\? ''\}/);
+    expect(src).toMatch(/data-log-id=\{latestRequest\(g\)\?\.logId \?\? ''\}/);
     expect(src).toMatch(/in:fade=\{\{ duration: 120 \}\}/);
     // No `out:` transition on the per-card slot — the outro is feed-level.
     const slotIdx = src.indexOf('class="tf-card-slot"');

--- a/src/lib/overlay/overlay-actions.test.ts
+++ b/src/lib/overlay/overlay-actions.test.ts
@@ -8,7 +8,7 @@ import { cardClick, reportOverlayHitRects } from './overlay-actions';
 import type { ToolCallGroup, ToolCallRequest } from './toastStore';
 
 function req(over: Partial<ToolCallRequest> = {}): ToolCallRequest {
-  return { requestId: 'r-1', ts: 'ts', status: 'inflight', jsonrpcId: null, ...over };
+  return { requestId: 'r-1', ts: 'ts', status: 'inflight', logId: null, ...over };
 }
 
 function g(over: Partial<ToolCallGroup> = {}): ToolCallGroup {
@@ -35,15 +35,15 @@ function g(over: Partial<ToolCallGroup> = {}): ToolCallGroup {
 describe('cardClick', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('invokes focus_main_window_on_log when the latest request has a jsonrpcId', async () => {
+  it('invokes focus_main_window_on_log when the latest request has a logId', async () => {
     const mockInvoke = vi.mocked(invoke);
     mockInvoke.mockResolvedValue(undefined);
 
     await cardClick(
       g({
         requests: [
-          req({ requestId: 'a', status: 'success', durationMs: 5, jsonrpcId: 'rpc-1' }),
-          req({ requestId: 'b', status: 'success', durationMs: 7, jsonrpcId: 'rpc-7' }),
+          req({ requestId: 'a', status: 'success', durationMs: 5, logId: 'rpc-1' }),
+          req({ requestId: 'b', status: 'success', durationMs: 7, logId: 'rpc-7' }),
         ],
         success: 2,
       }),
@@ -54,7 +54,7 @@ describe('cardClick', () => {
     });
   });
 
-  it('is a soft no-op when the latest request has no jsonrpcId', async () => {
+  it('is a soft no-op when the latest request has no logId', async () => {
     const mockInvoke = vi.mocked(invoke);
     mockInvoke.mockResolvedValue(undefined);
 

--- a/src/lib/overlay/overlay-actions.ts
+++ b/src/lib/overlay/overlay-actions.ts
@@ -9,13 +9,13 @@ import { focusLogForRequest } from './focusLog';
 
 /**
  * Card click: focus the matching log row in the main window when the
- * group's latest request carries a jsonrpc_id. Otherwise no-op (the card
+ * group's latest request carries a logId. Otherwise no-op (the card
  * is also rendered non-clickable in the UI).
  */
 export async function cardClick(group: ToolCallGroup): Promise<void> {
   if (!canFocusLog(group)) return;
   const last = latestRequest(group);
-  await focusLogForRequest(last?.jsonrpcId ?? null);
+  await focusLogForRequest(last?.logId ?? null);
 }
 
 /**

--- a/src/lib/overlay/overlay-helpers.test.ts
+++ b/src/lib/overlay/overlay-helpers.test.ts
@@ -19,7 +19,7 @@ function req(overrides: Partial<ToolCallRequest> = {}): ToolCallRequest {
     requestId: 'r-1',
     ts: 'ts',
     status: 'inflight',
-    jsonrpcId: null,
+    logId: null,
     ...overrides,
   };
 }
@@ -119,11 +119,11 @@ describe('latestRequest', () => {
 });
 
 describe('canFocusLog', () => {
-  it('false when latest request has null jsonrpcId', () => {
-    expect(canFocusLog(makeGroup({ requests: [req({ jsonrpcId: null })] }))).toBe(false);
+  it('false when latest request has null logId', () => {
+    expect(canFocusLog(makeGroup({ requests: [req({ logId: null })] }))).toBe(false);
   });
-  it('true when latest request has a jsonrpcId', () => {
-    expect(canFocusLog(makeGroup({ requests: [req({ jsonrpcId: '7' })] }))).toBe(true);
+  it('true when latest request has a logId', () => {
+    expect(canFocusLog(makeGroup({ requests: [req({ logId: '7' })] }))).toBe(true);
   });
 });
 

--- a/src/lib/overlay/overlay-helpers.ts
+++ b/src/lib/overlay/overlay-helpers.ts
@@ -75,7 +75,7 @@ export function hiddenGroupCount(total: number, maxVisible: number): number {
 /** Whether the card click should attempt to focus a log row. */
 export function canFocusLog(g: ToolCallGroup): boolean {
   const last = latestRequest(g);
-  return !!last && last.jsonrpcId != null;
+  return !!last && last.logId != null;
 }
 
 /** Normalize the prototype's destructive flag onto the typed annotation. */

--- a/src/lib/overlay/overlay-helpers.ts
+++ b/src/lib/overlay/overlay-helpers.ts
@@ -86,10 +86,11 @@ export function isDestructive(g: ToolCallGroup): boolean {
 /**
  * Axis-aligned card hit rect in overlay-window viewport coordinates (CSS /
  * logical pixels). Mirrors the `HitRect` struct in `src-tauri/src/overlay.rs`.
- * `log_id` carries the card's JSON-RPC id so the macOS click-catcher can emit
- * `overlay:card-clicked` with the right target (empty string when the card has
- * no JSON-RPC id captured yet). The snake_case key matches the wire shape serde
- * deserializes on the Rust side.
+ * `log_id` carries the relay-minted `request_uid` (surfaced to the desktop side
+ * as `logId`) so the macOS click-catcher can emit `overlay:card-clicked` with
+ * the right target (empty string when the card has no `request_uid` captured
+ * yet). The snake_case key matches the wire shape serde deserializes on the
+ * Rust side.
  */
 export type HitRect = { x: number; y: number; width: number; height: number; log_id: string };
 

--- a/src/lib/overlay/toastStore.test.ts
+++ b/src/lib/overlay/toastStore.test.ts
@@ -196,19 +196,19 @@ describe('toastStore', () => {
     expect(labels).toContain('Cursor');
   });
 
-  it('sources jsonrpcId from the started event request_uid', () => {
+  it('sources logId from the started event request_uid', () => {
     const store = createToastStore();
     store.addStarted(started({ request_id: 'req-1', request_uid: 'uid-abc' }));
     const groups = get(store) as ToolCallGroup[];
-    expect(groups[0].requests[0].jsonrpcId).toBe('uid-abc');
+    expect(groups[0].requests[0].logId).toBe('uid-abc');
   });
 
-  it('settle propagates the request_uid-sourced jsonrpcId unchanged', () => {
+  it('settle propagates the request_uid-sourced logId unchanged', () => {
     const store = createToastStore();
     store.addStarted(started({ request_id: 'req-1', request_uid: 'uid-abc' }));
     store.settle(completed('req-1'));
     const groups = get(store) as ToolCallGroup[];
-    expect(groups[0].requests[0].jsonrpcId).toBe('uid-abc');
+    expect(groups[0].requests[0].logId).toBe('uid-abc');
   });
 
   // Regression for the Phase 4 grouping bug: `OverlayCard` is keyed by

--- a/src/lib/overlay/toastStore.ts
+++ b/src/lib/overlay/toastStore.ts
@@ -51,9 +51,9 @@ export type ToolCallRequest = {
   // Canonical log-row key sourced from the originating event's `request_uid`
   // (the relay-minted per-HTTP-request UUID). Surfaced on each request so the
   // overlay card click handler can emit it to the main window to scroll the
-  // matching log row into view. (Field name retained for minimal touch surface;
-  // a future cleanup pass can rename to `logId`.)
-  jsonrpcId: string | null;
+  // matching log row into view. Named `logId` to reflect its generic
+  // semantic — it is the relay-minted UUID, not a JSON-RPC id.
+  logId: string | null;
 };
 
 export type ToolCallGroup = {
@@ -164,7 +164,7 @@ export function createToastStore(initial?: Partial<ToastStoreOpts>): ToastStore 
       requestId: event.request_id,
       ts: event.ts,
       status: 'inflight',
-      jsonrpcId: event.request_uid,
+      logId: event.request_uid,
     };
     if (existing) {
       // If this group was counting down (inflight had been 0), a new
@@ -229,14 +229,14 @@ export function createToastStore(initial?: Partial<ToastStoreOpts>): ToastStore 
     if (!existingReq || existingReq.status !== 'inflight') return;
     const isError = event.kind === 'failed' || event.status === 'error';
     // Build a fresh ToolCallRequest with the settled fields. The relay always
-    // populates `request_uid` on Started, so `jsonrpcId` is already set on the
+    // populates `request_uid` on Started, so `logId` is already set on the
     // existing request — just propagate it forward unchanged.
     const settledReq: ToolCallRequest = {
       ...existingReq,
       status: isError ? 'error' : 'success',
       durationMs: event.duration_ms,
       ...(event.kind === 'failed' ? { errorMessage: event.error_message } : {}),
-      jsonrpcId: existingReq.jsonrpcId,
+      logId: existingReq.logId,
     };
     const newInflight = Math.max(0, target.inflight - 1);
     const willArm = newInflight === 0;

--- a/src/lib/overlay/types.ts
+++ b/src/lib/overlay/types.ts
@@ -46,9 +46,6 @@ export type StartedEvent = {
   // collision-free across multiple MCP clients sending the same JSON-RPC id
   // concurrently. The relay always emits it on Started events.
   request_uid: string;
-  // JSON-RPC envelope id captured from the surrounding `request` span. Retained
-  // on the wire for diagnostic context only; no longer used as the row/card key.
-  jsonrpc_id?: string | null;
   tool: string;
   annotations?: ToolCallAnnotations;
   // Identity of the calling MCP client. Omitted by the relay when no caller
@@ -62,7 +59,6 @@ export type CompletedEvent = {
   ts: string;
   duration_ms: number;
   status: 'ok' | 'error';
-  jsonrpc_id?: string | null;
 };
 
 export type FailedEvent = {
@@ -72,7 +68,6 @@ export type FailedEvent = {
   duration_ms: number;
   status: 'error';
   error_message?: string;
-  jsonrpc_id?: string | null;
 };
 
 export type ToolCallEvent = StartedEvent | CompletedEvent | FailedEvent;


### PR DESCRIPTION
## Problem

Since #125 (rc.6) re-sourced log row / overlay card keys from the relay-minted `request_uid`, the internal field name `jsonrpcId` is misleading (it's not a JSON-RPC id anymore — it's the relay-minted UUID). The Tauri command param `logId` was already renamed in #125; this PR completes the rename internally and drops the now-deprecated `jsonrpc_id?` optional field from the inbound event types.

## Changes

14 files, +50/-55 lines, single commit:

- `src/lib/overlay/types.ts` — dropped `jsonrpc_id?` from `StartedEvent` / `CompletedEvent` / `FailedEvent` (`request_uid: string` retained as the canonical key).
- `src/lib/overlay/toastStore.ts` — renamed `ToolCallRequest.jsonrpcId` → `logId`; updated all reads/writes.
- `overlay-actions.ts`, `overlay-helpers.ts`, `OverlayCard.svelte`, `ToastFeed.svelte` — renamed field accesses + doc comments.
- `RelayLogs.svelte` + `relay-logs-helpers.ts` — renamed local var/param `jsonrpcId` → `logId` (DOM selector `data-request-id` kept as-is per existing contract).
- Test files updated: `toastStore.test.ts`, `overlay-helpers.test.ts`, `overlay-actions.test.ts`, `OverlayCard.test.ts`, `ToastFeed.test.ts`, `relay-logs-helpers.test.ts`.

Out of scope (kept unchanged): Tauri command name `focus_main_window_on_log`, DOM data attributes `data-log-id` and `data-request-id`.

## Verification

- `pnpm svelte-check` ✅ (0 errors)
- `pnpm test` ✅ (895 passed, ≥ 886 main baseline)
- From `src-tauri/`: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (115 passed) ✅
- `grep -rn "jsonrpcId\|jsonrpc_id" src/` → no references ✅

## Merge sequencing

Companion PR: `endara-ai/endara-relay#108` (removes `jsonrpc_id` from the wire). They MUST merge bundled in the same rc cycle — desktop drops the inbound type, relay drops the field. Cross-link both PR numbers after creation.
