### PR TITLE
feat(oauth): add-time OAuth escalation prompt + reauthorize-bar debounce

### DIFF
--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -431,5 +431,52 @@ describe('api', () => {
       expect(callBody.body).not.toHaveProperty('server_type_override');
     });
   });
+
+  describe('oauthProbe', () => {
+    // The add-server flow relies on this probe being non-blocking: any
+    // failure/timeout/non-2xx must resolve to `{ oauth_supported: false }`
+    // (never throw) so the plain HTTP add can proceed silently.
+    it('POSTs the url to /api/oauth/probe and returns the parsed result', async () => {
+      const { oauthProbe } = await import('./api');
+      mockOk({
+        oauth_supported: true,
+        authorization_server: 'https://auth.example.com',
+        scopes_supported: ['read', 'write'],
+      });
+
+      const result = await oauthProbe('https://mcp.example.com/mcp');
+      expect(result).toEqual({
+        oauth_supported: true,
+        authorization_server: 'https://auth.example.com',
+        scopes_supported: ['read', 'write'],
+      });
+      expect(invoke).toHaveBeenCalledWith(
+        'mgmt_api_request',
+        expect.objectContaining({
+          method: 'POST',
+          path: '/api/oauth/probe',
+          body: { url: 'https://mcp.example.com/mcp' },
+        }),
+      );
+    });
+
+    it('resolves to oauth_supported:false on a non-2xx status without throwing', async () => {
+      const { oauthProbe } = await import('./api');
+      mockHttpError(500, 'Internal Server Error');
+
+      const result = await oauthProbe('https://mcp.example.com/mcp');
+      expect(result).toEqual({ oauth_supported: false });
+    });
+
+    it('resolves to oauth_supported:false on a transport error without retrying', async () => {
+      const { oauthProbe } = await import('./api');
+      vi.mocked(invoke).mockRejectedValue(new Error('socket connect failed'));
+
+      const result = await oauthProbe('https://mcp.example.com/mcp');
+      expect(result).toEqual({ oauth_supported: false });
+      // Best-effort: a single attempt, no retry loop.
+      expect(invoke).toHaveBeenCalledTimes(1);
+    });
+  });
 });
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import type { RelayStatus, Endpoint, Tool, EndpointLogs, CatalogEntry, OAuthStatus, OAuthStartResult, OAuthSetupResponse, OAuthSetupStatusResponse } from './types';
+import type { RelayStatus, Endpoint, Tool, EndpointLogs, CatalogEntry, OAuthStatus, OAuthStartResult, OAuthSetupResponse, OAuthSetupStatusResponse, OAuthProbeResult } from './types';
 
 const MAX_RETRIES = 2;
 const RETRY_DELAY = 1000;
@@ -479,6 +479,31 @@ export async function oauthSetupCancel(sessionId: string): Promise<void> {
       // body not JSON
     }
     throw new Error(detail || `HTTP ${res.status}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// OAuth capability probe (add-time)
+// ---------------------------------------------------------------------------
+
+/**
+ * Best-effort probe of whether an MCP server supports OAuth, used by the
+ * add-server flow to offer escalation into the OAuth setup wizard. This is
+ * deliberately non-blocking: any transport error, non-2xx status, or
+ * unparseable body resolves to `{ oauth_supported: false }` so the caller can
+ * silently fall back to a plain (non-OAuth) add. It never throws and never
+ * retries — the relay already backstops slow/unreachable probes with a 15s
+ * timeout.
+ */
+export async function oauthProbe(url: string): Promise<OAuthProbeResult> {
+  try {
+    const res = await mgmtRequest('POST', '/oauth/probe', { url });
+    if (res.status < 200 || res.status >= 300) {
+      return { oauth_supported: false };
+    }
+    return (res.body ? JSON.parse(res.body) : { oauth_supported: false }) as OAuthProbeResult;
+  } catch {
+    return { oauth_supported: false };
   }
 }
 

--- a/src/lib/components/AddEndpointModal.svelte
+++ b/src/lib/components/AddEndpointModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { addEndpoint, getEndpoints, getStatus, testConnection, oauthSetup, oauthSetupStatus, oauthSetupCredentials, oauthSetupCommit, oauthSetupCancel, reloadConfig, type AddEndpointParams, type TestConnectionParams, type OAuthSetupParams } from '$lib/api';
+  import { addEndpoint, getEndpoints, getStatus, testConnection, oauthProbe, oauthSetup, oauthSetupStatus, oauthSetupCredentials, oauthSetupCommit, oauthSetupCancel, reloadConfig, type AddEndpointParams, type TestConnectionParams, type OAuthSetupParams } from '$lib/api';
+  import type { OAuthProbeResult } from '$lib/types';
   import { endpoints, selectedEndpoint } from '$lib/stores';
   import { toast } from 'svelte-sonner';
   import { CATALOG_SERVERS, type CatalogServer } from '$lib/catalog';
@@ -71,6 +72,11 @@
   let pendingSetupSessionId: string | null = $state(null);
   let setupAuthCancelled = $state(false);
   let cancelHint = $state('');
+  // Add-time OAuth detection (http/sse only). When the probe reports the
+  // server supports OAuth, this opt-out prompt offers to escalate into the
+  // existing OAuth wizard; declining proceeds with a plain unauthenticated add.
+  let showOAuthEscalation = $state(false);
+  let oauthProbeData: { authorization_server?: string; scopes_supported?: string[] } | null = $state(null);
   // Optional override that replaces the upstream-reported server name in the
   // relay's connected-servers advertisement. Pre-populated from the catalog
   // entry's `serverTypeOverride` default when one exists.
@@ -438,7 +444,7 @@
     }
   }
 
-  async function handleSubmit() {
+  async function handleSubmit(opts?: { skipProbe?: boolean }) {
     error = '';
     cancelHint = '';
     const errs = validateAddEndpointForm({ transport, name, command, url });
@@ -447,6 +453,32 @@
       error = firstAddEndpointFieldError(errs);
       return;
     }
+
+    // Add-time OAuth detection (http/sse only). Best-effort + non-blocking:
+    // probe the entered URL and, if the server advertises OAuth, surface the
+    // opt-out escalation prompt instead of adding. Any probe failure / timeout
+    // / `oauth_supported:false` silently falls through to the plain add below.
+    if (!opts?.skipProbe && (transport === 'http' || transport === 'sse')) {
+      submitting = true;
+      let probe: OAuthProbeResult = { oauth_supported: false };
+      try {
+        probe = await oauthProbe(url.trim());
+      } catch {
+        // oauthProbe never throws, but stay defensive — fall through to add.
+      }
+      if (probe.oauth_supported) {
+        submitting = false;
+        oauthProbeData = {
+          authorization_server: probe.authorization_server,
+          scopes_supported: probe.scopes_supported,
+        };
+        showOAuthEscalation = true;
+        return;
+      }
+      // Not OAuth-capable — keep `submitting` true and proceed with the plain
+      // add below; its own `finally` resets the flag.
+    }
+
     const trimmedName = name.trim();
     const defaultPrefix = sanitizeName(trimmedName);
 
@@ -566,6 +598,31 @@
     } finally {
       submitting = false;
     }
+  }
+
+  // Accept the escalation: switch the form to the OAuth transport (the server
+  // URL the user already entered carries over in `url`) and kick off the
+  // existing OAuth setup wizard.
+  function acceptOAuthEscalation() {
+    showOAuthEscalation = false;
+    oauthProbeData = null;
+    transport = 'oauth';
+    void handleOAuthSubmit();
+  }
+
+  // Decline the escalation: add the endpoint as a plain unauthenticated
+  // http/sse server exactly as before. `skipProbe` avoids re-probing.
+  function declineOAuthEscalation() {
+    showOAuthEscalation = false;
+    oauthProbeData = null;
+    void handleSubmit({ skipProbe: true });
+  }
+
+  // Dismiss the prompt without choosing (Escape / backdrop) — return to the
+  // form untouched so the user can adjust the URL or decide later.
+  function dismissOAuthEscalation() {
+    showOAuthEscalation = false;
+    oauthProbeData = null;
   }
 
   async function handleOAuthSubmit() {
@@ -1425,7 +1482,7 @@
           </button>
           <button
             class="px-3 py-1.5 text-sm rounded-lg bg-(--accent) text-white hover:bg-(--accent-hover) transition-colors disabled:opacity-50"
-            onclick={transport === 'oauth' ? handleOAuthSubmit : handleSubmit}
+            onclick={transport === 'oauth' ? handleOAuthSubmit : () => handleSubmit()}
             disabled={submitting}
           >
             {#if submitting}
@@ -1443,6 +1500,43 @@
     {/if}
   </div>
 </div>
+
+{#if showOAuthEscalation}
+  <div class="fixed inset-0 z-[60] flex items-center justify-center bg-black/40" role="presentation" onclick={dismissOAuthEscalation}>
+    <div
+      class="bg-(--surface) rounded-xl shadow-xl border border-(--border) p-6 w-[28rem] max-w-[90vw]"
+      role="dialog"
+      aria-modal="true"
+      aria-label="This server supports OAuth"
+      tabindex="-1"
+      use:focusTrap={{ onEscape: dismissOAuthEscalation }}
+      onclick={(e) => e.stopPropagation()}
+      onkeydown={(e) => e.stopPropagation()}
+    >
+      <h3 class="text-base font-semibold mb-2 text-(--fg1)">This server supports OAuth</h3>
+      <p class="text-sm text-(--fg2) mb-5">
+        <strong>{name.trim() || 'This server'}</strong> advertises OAuth authentication. Set up
+        OAuth now for an authenticated connection, or keep it as a plain unauthenticated endpoint.
+      </p>
+      <div class="flex justify-end gap-2">
+        <button
+          type="button"
+          class="px-3 py-1.5 text-sm rounded-lg border border-(--border) hover:bg-(--surface-hover) transition-colors"
+          onclick={declineOAuthEscalation}
+        >
+          Keep unauthenticated
+        </button>
+        <button
+          type="button"
+          class="px-3 py-1.5 text-sm rounded-lg bg-(--accent) text-white hover:bg-(--accent-hover) transition-colors"
+          onclick={acceptOAuthEscalation}
+        >
+          Set up OAuth
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}
 
 {#if showDiscardConfirm}
   <ConfirmModal

--- a/src/lib/components/DetailPanel.svelte
+++ b/src/lib/components/DetailPanel.svelte
@@ -19,6 +19,8 @@
     shouldShowRestartButton,
     shouldShowRefreshButton,
     shouldShowReauthorizeButton,
+    createReauthGateState,
+    evaluateReauthGate,
     visibleTabs,
     formatBytes,
     formatCpuPercent,
@@ -30,14 +32,31 @@
   let toggling = $state(false);
   let reauthInProgress = $state(false);
 
-  let oauthStatus = $derived(
-    $selectedEndpointData ? $oauthStatuses.get($selectedEndpointData.name)?.status ?? null : null
-  );
-  let showReauthorize = $derived(
-    $selectedEndpointData
-      ? shouldShowReauthorizeButton($selectedEndpointData.transport, oauthStatus)
-      : false
-  );
+  // Stability gate for the reauthorize bar: a freshly-built OAuth adapter
+  // reports a transient `needs_login` for ~1-2s before its just-stored token
+  // loads and it flips to `authenticated`. Only surface the bar once that
+  // status is stable (>=2 consecutive polls or past a short grace window) so
+  // the post-add / restart transient doesn't flash a misleading bar. Kept as a
+  // plain (non-reactive) variable so writing it from the effect below doesn't
+  // re-trigger the effect; the global 2s poll re-emits `oauthStatuses` each
+  // cycle, which drives re-evaluation.
+  let reauthGate = createReauthGateState();
+  let showReauthorize = $state(false);
+
+  $effect(() => {
+    const statuses = $oauthStatuses;
+    const ep = $selectedEndpointData;
+    const name = ep?.name ?? null;
+    const status = name ? statuses.get(name)?.status ?? null : null;
+    const reauthNeeded = ep ? shouldShowReauthorizeButton(ep.transport, status) : false;
+    const result = evaluateReauthGate(reauthGate, {
+      endpointName: name,
+      reauthNeeded,
+      now: Date.now(),
+    });
+    reauthGate = result.state;
+    showReauthorize = result.showBar;
+  });
 
   let tabs = $derived(
     $selectedEndpointData

--- a/src/lib/components/detail-panel-helpers.test.ts
+++ b/src/lib/components/detail-panel-helpers.test.ts
@@ -5,10 +5,14 @@ import {
   shouldShowRestartButton,
   shouldShowRefreshButton,
   shouldShowReauthorizeButton,
+  createReauthGateState,
+  evaluateReauthGate,
+  REAUTH_GATE_GRACE_MS,
   visibleTabs,
   formatBytes,
   formatCpuPercent,
   type EndpointTransport,
+  type ReauthGateState,
 } from './detail-panel-helpers';
 
 describe('shouldShowRestartButton', () => {
@@ -267,6 +271,88 @@ describe('shouldShowReauthorizeButton', () => {
       expect(shouldShowReauthorizeButton(t, 'auth_required')).toBe(false);
     });
   }
+});
+
+// ── Reauthorize-bar stability gate (anti-flash) ──
+//
+// A freshly-added/restarted OAuth server reports a transient `needs_login`
+// for ~1-2s (one 2s poll) before its just-stored token loads and it flips to
+// `authenticated`. The gate must swallow that single transient yet still
+// surface a genuinely-persistent reauth need within a few seconds.
+describe('evaluateReauthGate', () => {
+  // Simulate consecutive poll cycles 2s apart, returning showBar per poll.
+  function runPolls(needs: boolean[], endpointName = 'srv', startNow = 1000): boolean[] {
+    let state: ReauthGateState = createReauthGateState();
+    const shown: boolean[] = [];
+    needs.forEach((reauthNeeded, i) => {
+      const result = evaluateReauthGate(state, {
+        endpointName,
+        reauthNeeded,
+        now: startNow + i * 2000,
+      });
+      state = result.state;
+      shown.push(result.showBar);
+    });
+    return shown;
+  }
+
+  it('does NOT show the bar on a single transient needs_login', () => {
+    // poll 1: needs_login (transient), poll 2: authenticated.
+    expect(runPolls([true, false])).toEqual([false, false]);
+  });
+
+  it('shows the bar once needs_login persists across >=2 consecutive polls', () => {
+    expect(runPolls([true, true])).toEqual([false, true]);
+  });
+
+  it('never shows the bar while authenticated', () => {
+    expect(runPolls([false, false, false])).toEqual([false, false, false]);
+  });
+
+  it('resets the gate on needs_login -> authenticated -> needs_login (no early flash on the new need)', () => {
+    // First need persists (shows), recovers (reset), then a single new
+    // transient must NOT immediately re-show — the gate restarts clean.
+    expect(runPolls([true, true, false, true])).toEqual([false, true, false, false]);
+  });
+
+  it('shows again after a reset once the new need persists', () => {
+    expect(runPolls([true, true, false, true, true])).toEqual([false, true, false, false, true]);
+  });
+
+  it('shows via the grace window even if only a single (slow) poll has elapsed past it', () => {
+    // One evaluation, but the time gap already exceeds the grace window.
+    const first = evaluateReauthGate(createReauthGateState(), {
+      endpointName: 'srv',
+      reauthNeeded: true,
+      now: 1000,
+    });
+    expect(first.showBar).toBe(false);
+    const later = evaluateReauthGate(first.state, {
+      endpointName: 'srv',
+      reauthNeeded: true,
+      now: 1000 + REAUTH_GATE_GRACE_MS + 1,
+    });
+    expect(later.showBar).toBe(true);
+  });
+
+  it('resets accumulated state when the selected endpoint changes', () => {
+    let result = evaluateReauthGate(createReauthGateState(), {
+      endpointName: 'srv-a',
+      reauthNeeded: true,
+      now: 1000,
+    });
+    expect(result.showBar).toBe(false);
+    // Switching to a different endpoint that also needs reauth must start a
+    // fresh window — not inherit srv-a's count and immediately flash.
+    result = evaluateReauthGate(result.state, {
+      endpointName: 'srv-b',
+      reauthNeeded: true,
+      now: 3000,
+    });
+    expect(result.showBar).toBe(false);
+    expect(result.state.endpointName).toBe('srv-b');
+    expect(result.state.consecutiveCount).toBe(1);
+  });
 });
 
 // ── Re-authorize button source-inspection (mirrors the toggle a11y pattern) ──

--- a/src/lib/components/detail-panel-helpers.ts
+++ b/src/lib/components/detail-panel-helpers.ts
@@ -17,6 +17,76 @@ export function shouldShowReauthorizeButton(
   return REAUTH_NEEDED_STATUSES.includes(oauthStatus);
 }
 
+/**
+ * Stability gate for the reauthorize bar.
+ *
+ * A freshly-built OAuth adapter reports a transient `needs_login` for ~1-2s
+ * (one poll) before its just-stored token loads and it flips to
+ * `authenticated`. Showing the bar on that first transient produces a
+ * misleading 1-2s flash on add / app restart / endpoint restart.
+ *
+ * This gate only lets the bar appear once a reauth-needed status is STABLE:
+ * observed across >= REAUTH_GATE_MIN_CONSECUTIVE consecutive polls OR
+ * persisting beyond REAUTH_GATE_GRACE_MS. The gate resets the moment the
+ * endpoint is authenticated (so a later genuine reauth need isn't suppressed)
+ * and whenever the selected endpoint changes.
+ */
+export const REAUTH_GATE_MIN_CONSECUTIVE = 2;
+export const REAUTH_GATE_GRACE_MS = 4000;
+
+export interface ReauthGateState {
+  endpointName: string | null;
+  consecutiveCount: number;
+  firstSeenAt: number | null;
+}
+
+export interface ReauthGateInput {
+  endpointName: string | null;
+  reauthNeeded: boolean;
+  now: number;
+}
+
+export interface ReauthGateResult {
+  state: ReauthGateState;
+  showBar: boolean;
+}
+
+export function createReauthGateState(): ReauthGateState {
+  return { endpointName: null, consecutiveCount: 0, firstSeenAt: null };
+}
+
+export function evaluateReauthGate(
+  prev: ReauthGateState,
+  input: ReauthGateInput,
+): ReauthGateResult {
+  const { endpointName, reauthNeeded, now } = input;
+
+  // Endpoint changed -> drop any accumulated gate state for the old endpoint.
+  const base: ReauthGateState =
+    prev.endpointName === endpointName
+      ? prev
+      : { endpointName, consecutiveCount: 0, firstSeenAt: null };
+
+  // Not reauth-needed (e.g. authenticated/refreshing) -> reset the gate so a
+  // later genuine reauth need starts a fresh stability window.
+  if (!reauthNeeded) {
+    return {
+      state: { endpointName, consecutiveCount: 0, firstSeenAt: null },
+      showBar: false,
+    };
+  }
+
+  const consecutiveCount = base.consecutiveCount + 1;
+  const firstSeenAt = base.firstSeenAt ?? now;
+  const stableByCount = consecutiveCount >= REAUTH_GATE_MIN_CONSECUTIVE;
+  const stableByTime = now - firstSeenAt >= REAUTH_GATE_GRACE_MS;
+
+  return {
+    state: { endpointName, consecutiveCount, firstSeenAt },
+    showBar: stableByCount || stableByTime,
+  };
+}
+
 export type DetailTabId = 'tools' | 'logs' | 'config' | 'auth' | 'profiles';
 
 export interface DetailTab {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -171,6 +171,18 @@ export interface OAuthSetupStatusResponse {
   url: string;
 }
 
+/**
+ * Result of the add-time OAuth capability probe (POST /api/oauth/probe).
+ * `authorization_server` and `scopes_supported` are present only when
+ * `oauth_supported` is `true`. Any probe failure/timeout is reported by the
+ * relay (and by the desktop client) as `{ oauth_supported: false }`.
+ */
+export interface OAuthProbeResult {
+  oauth_supported: boolean;
+  authorization_server?: string;
+  scopes_supported?: string[];
+}
+
 export type Theme = 'light' | 'dark' | 'system';
 
 // Re-export the parsed relay log type so components can import it from


### PR DESCRIPTION
## Summary

Desktop counterpart to the relay JIT upstream-OAuth work (endara-ai/endara-relay#109).

- **Add-time OAuth escalation** — when adding a plain `http` endpoint, the wizard calls the relay's `POST /api/oauth/probe` to detect whether the server advertises OAuth (RFC 9728/8414). If so, it surfaces an **opt-out** prompt offering to escalate the endpoint into the existing OAuth setup wizard; declining saves the plain `http` endpoint unchanged. This is what lets dual-mode servers (e.g. ones that also accept a bearer token) be added without OAuth.
- **Reauthorize-bar debounce** — a freshly-built OAuth adapter reports a transient `needs_login` for ~1–2s before its just-stored token loads and it transitions to `authenticated`, which made the red “Authorization required” bar flash on add / app-restart / endpoint-restart. A new pure, unit-tested stability gate (`evaluateReauthGate`) only shows the bar once a reauth-needed status is **stable** (≥2 consecutive polls, or persisting past a 4s grace window; poll interval is 2s). The gate resets on `authenticated` and on endpoint switch, so a genuine reauth need still surfaces within a couple seconds and the Re-authorize button is unchanged.

## Verification

- `pnpm check` — 0 errors.
- `pnpm test` — 905 passed (+7 new for the stability gate; +escalation tests in `api.test.ts`).

Merge order: this can merge alongside the relay PR; the monorepo submodule bump (Phase 2) follows once both are on `main`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author