### PR TITLE
fix(overlay): set_ignore_cursor_events on macOS WebView; click-catcher panel is the only interactive layer

### DIFF
--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -156,6 +156,14 @@ pub struct OverlaySubscriberState {
 // Rust-side poller compares the global cursor position against them, flipping
 // the ignore flag on inside/outside transitions. With no rects there is
 // nothing to hover, so the poller is stopped entirely (zero idle cost).
+//
+// On macOS the overlay WebView is permanently click-through in production — it
+// never toggles `set_ignore_cursor_events` back off. The interactive layer is
+// the click-catcher NSPanel installed ABOVE the WebView; the macOS poller flips
+// that panel's `setIgnoresMouseEvents` over the reported card rects only, and
+// the panel forwards clicks to the renderer via IPC (`overlay:card-clicked`).
+// macOS production invariant: the overlay window is always
+// ignore-cursor-events; the click-catcher panel is the toggle.
 
 /// Poll interval for the cursor poller while hit rects are present. Fast
 /// enough that hover feels immediate, slow enough to be negligible CPU.
@@ -1111,24 +1119,26 @@ pub fn build_overlay_window(
         }
     }
 
-    // Non-macOS: click-through by default — the Rust-side cursor poller (see
-    // `update_hit_rects` / `cursor_poll_loop` above) flips this while the
-    // global cursor is over a renderer-reported card rect. In debug builds we
-    // skip the global click-through so the overlay window is fully interactive
-    // and right-click → Inspect works from devtools; production builds keep the
-    // click-through behaviour so the overlay never steals input from the user's
-    // other windows. macOS routes clicks via the click-catcher panel installed
-    // above and never toggles `set_ignore_cursor_events`.
-    #[cfg(not(target_os = "macos"))]
-    {
-        if cfg!(debug_assertions) {
-            log::info!(
-                target: "overlay",
-                "debug build: overlay window is interactive (set_ignore_cursor_events skipped); right-click → Inspect to open devtools"
-            );
-        } else if let Err(e) = window.set_ignore_cursor_events(true) {
-            log::warn!("[overlay] set_ignore_cursor_events failed: {e}");
-        }
+    // Production builds keep the overlay window in `set_ignore_cursor_events(true)`
+    // so it never catches input. On non-macOS the Rust-side cursor poller (see
+    // `update_hit_rects` / `cursor_poll_loop` above) flips this flag back off
+    // while the global cursor is over a renderer-reported card rect. On macOS the
+    // click-catcher NSPanel above the WebView is the only interactive layer — its
+    // `setIgnoresMouseEvents` toggle (driven by the cursor poller in
+    // `click_catcher_poll_loop`) opens click pass-through over the exact reported
+    // card rects only, and the renderer never needs DOM mouse events because the
+    // panel handles every click via IPC (`overlay:card-clicked`). Without this
+    // call on macOS, right-clicks outside a card hit the WebView and open the
+    // Tauri devtools context menu instead of falling through to the desktop. In
+    // debug builds we skip the global click-through on every platform so the
+    // overlay window is fully interactive and right-click → Inspect works.
+    if cfg!(debug_assertions) {
+        log::info!(
+            target: "overlay",
+            "debug build: overlay window is interactive (set_ignore_cursor_events skipped); right-click → Inspect to open devtools"
+        );
+    } else if let Err(e) = window.set_ignore_cursor_events(true) {
+        log::warn!("[overlay] set_ignore_cursor_events failed: {e}");
     }
 
     // Primary reveal path: the renderer emits `overlay-render-ready` after a

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -1027,6 +1027,24 @@ impl Default for ReconnectBackoff {
     }
 }
 
+/// Operator-facing error message logged when the macOS overlay window is about
+/// to be made click-through (`set_ignore_cursor_events(true)`) but the
+/// click-catcher panel setup was never dispatched (e.g. `ns_window()` returned
+/// null/err). In that state the WebView is permanently click-through *and* there
+/// is no panel on top, so cards render but never receive input. Returns `None`
+/// when setup was dispatched (the normal path), `Some(msg)` otherwise — kept as
+/// a pure function so it is unit-testable without an AppKit window.
+#[cfg(target_os = "macos")]
+fn click_catcher_absent_warning(setup_dispatched: bool) -> Option<&'static str> {
+    if setup_dispatched {
+        None
+    } else {
+        Some(
+            "click-catcher panel was not installed; overlay window will be set click-through but no card-click layer exists — cards will be visible but never receive input",
+        )
+    }
+}
+
 /// Build the overlay `WebviewWindow`. Caller must check `cfg.enabled` —
 /// this function unconditionally builds; the call site decides whether to
 /// invoke it.
@@ -1101,7 +1119,7 @@ pub fn build_overlay_window(
     // and only revealed via the `overlay-render-ready` event / 500ms safety net
     // below, both of which sync the click-catcher's frame + visibility.
     #[cfg(target_os = "macos")]
-    {
+    let click_catcher_dispatched = {
         let rects = Arc::clone(&app.state::<OverlayHitState>().rects);
         match window.ns_window() {
             Ok(ptr) if !ptr.is_null() => {
@@ -1109,23 +1127,31 @@ pub fn build_overlay_window(
                 // address across the closure boundary as a `usize`.
                 let ns_window_addr = ptr as usize;
                 macos_click_catcher::setup(app, ns_window_addr, rects);
+                true
             }
-            Ok(_) => log::warn!(
-                target: "overlay",
-                "ns_window() returned null; click-catcher setup skipped"
-            ),
-            Err(e) => log::warn!(
-                target: "overlay",
-                "ns_window() failed: {e}; click-catcher setup skipped"
-            ),
+            Ok(_) => {
+                log::warn!(
+                    target: "overlay",
+                    "ns_window() returned null; click-catcher setup skipped"
+                );
+                false
+            }
+            Err(e) => {
+                log::warn!(
+                    target: "overlay",
+                    "ns_window() failed: {e}; click-catcher setup skipped"
+                );
+                false
+            }
         }
-    }
+    };
 
     // Production builds keep the overlay window in `set_ignore_cursor_events(true)`
-    // so it never catches input. On non-macOS the Rust-side cursor poller (see
-    // `update_hit_rects` / `cursor_poll_loop` above) flips this flag back off
-    // while the global cursor is over a renderer-reported card rect. On macOS the
-    // click-catcher NSPanel above the WebView is the only interactive layer — its
+    // so it is click-through by default. On non-macOS the Rust-side cursor poller
+    // (see `update_hit_rects` / `cursor_poll_loop` above) flips this flag back off
+    // while the global cursor is over a renderer-reported card rect, so the window
+    // only catches input over reported card rects. On macOS the click-catcher
+    // NSPanel above the WebView is the only interactive layer — its
     // `setIgnoresMouseEvents` toggle (driven by the cursor poller in
     // `click_catcher_poll_loop`) opens click pass-through over the exact reported
     // card rects only, and the renderer never needs DOM mouse events because the
@@ -1140,6 +1166,14 @@ pub fn build_overlay_window(
         // card fall through to the desktop instead of opening the Tauri
         // devtools context menu. Lose right-click → Inspect on overlay cards
         // in dev as a result; main-window devtools are unaffected.
+        //
+        // If the click-catcher setup was never dispatched (e.g. `ns_window()`
+        // returned null/err above), the WebView is still set click-through here
+        // but no panel sits on top — cards render with no interactive layer at
+        // all. Surface that dead-clicks state to operators before the call.
+        if let Some(msg) = click_catcher_absent_warning(click_catcher_dispatched) {
+            log::error!(target: "overlay", "{msg}");
+        }
         if let Err(e) = window.set_ignore_cursor_events(true) {
             log::warn!("[overlay] set_ignore_cursor_events failed: {e}");
         }
@@ -1613,6 +1647,19 @@ mod tests {
                 log_id: "req-7".to_string(),
             }
         );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn click_catcher_absent_warning_only_when_setup_skipped() {
+        // Panel setup dispatched (normal path): no operator warning.
+        assert!(click_catcher_absent_warning(true).is_none());
+        // Panel setup skipped (e.g. `ns_window()` null/err): warn that the
+        // overlay will be click-through with no card-click layer.
+        let msg = click_catcher_absent_warning(false)
+            .expect("absent panel must surface an operator-facing warning");
+        assert!(msg.contains("click-catcher panel was not installed"));
+        assert!(msg.contains("never receive input"));
     }
 
     #[test]

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -163,7 +163,9 @@ pub struct OverlaySubscriberState {
 // that panel's `setIgnoresMouseEvents` over the reported card rects only, and
 // the panel forwards clicks to the renderer via IPC (`overlay:card-clicked`).
 // macOS production invariant: the overlay window is always
-// ignore-cursor-events; the click-catcher panel is the toggle.
+// ignore-cursor-events; the click-catcher panel is the toggle. On macOS this
+// also holds in debug builds (so dev smoke-tests reflect production); only the
+// non-macOS path skips the global click-through in debug for devtools access.
 
 /// Poll interval for the cursor poller while hit rects are present. Fast
 /// enough that hover feels immediate, slow enough to be negligible CPU.
@@ -1129,16 +1131,31 @@ pub fn build_overlay_window(
     // card rects only, and the renderer never needs DOM mouse events because the
     // panel handles every click via IPC (`overlay:card-clicked`). Without this
     // call on macOS, right-clicks outside a card hit the WebView and open the
-    // Tauri devtools context menu instead of falling through to the desktop. In
-    // debug builds we skip the global click-through on every platform so the
-    // overlay window is fully interactive and right-click → Inspect works.
-    if cfg!(debug_assertions) {
-        log::info!(
-            target: "overlay",
-            "debug build: overlay window is interactive (set_ignore_cursor_events skipped); right-click → Inspect to open devtools"
-        );
-    } else if let Err(e) = window.set_ignore_cursor_events(true) {
-        log::warn!("[overlay] set_ignore_cursor_events failed: {e}");
+    // Tauri devtools context menu instead of falling through to the desktop.
+    #[cfg(target_os = "macos")]
+    {
+        // macOS: the click-catcher NSPanel above the WebView is the only
+        // interactive layer in both debug and release builds. The WebView
+        // itself is permanently click-through, so right-clicks outside a
+        // card fall through to the desktop instead of opening the Tauri
+        // devtools context menu. Lose right-click → Inspect on overlay cards
+        // in dev as a result; main-window devtools are unaffected.
+        if let Err(e) = window.set_ignore_cursor_events(true) {
+            log::warn!("[overlay] set_ignore_cursor_events failed: {e}");
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        // In debug builds we skip the global click-through so the overlay
+        // window is fully interactive and right-click → Inspect works.
+        if cfg!(debug_assertions) {
+            log::info!(
+                target: "overlay",
+                "debug build: overlay window is interactive (set_ignore_cursor_events skipped); right-click → Inspect to open devtools"
+            );
+        } else if let Err(e) = window.set_ignore_cursor_events(true) {
+            log::warn!("[overlay] set_ignore_cursor_events failed: {e}");
+        }
     }
 
     // Primary reveal path: the renderer emits `overlay-render-ready` after a


### PR DESCRIPTION
## rc.7 follow-up

After rc.7 (#125, #126), a user reported that on macOS **right-clicking on an
empty area where the overlay region sits still opens the Tauri WebView context
menu** ("Reload" / "Inspect Element") instead of falling through to the macOS
desktop / underlying app. The click was reaching the overlay WebView — not the
desktop.

## Root cause

In `src-tauri/src/overlay.rs`, the `build_overlay_window` finalization
intentionally **excluded macOS** from the production-build
`set_ignore_cursor_events(true)` call (`#[cfg(not(target_os = "macos"))]`).

The assumption was that the rc.7 click-catcher NSPanel above the WebView
captures all clicks, so the WebView underneath didn't need to be click-through.
That's wrong: rc.7 correctly defaults the click-catcher panel to
`setIgnoresMouseEvents(true)` so clicks fall *through* it — but with the WebView
left interactive, the click then lands on the WebView underneath instead of the
desktop, opening the devtools context menu.

## Fix

Remove the `#[cfg(not(target_os = "macos"))]` gate so the overlay window enters
`set_ignore_cursor_events(true)` in production on **all** platforms, macOS
included. The click-catcher NSPanel above the WebView remains the only
interactive layer on macOS — the cursor poller (`click_catcher_poll_loop`) flips
its `setIgnoresMouseEvents` interactive **only** over reported card rects via the
existing `macos_click_catcher` path, and the panel forwards each click to the
renderer via IPC (`overlay:card-clicked`). The renderer doesn't need DOM mouse
events on macOS.

Debug builds still skip the global click-through on every platform so the
overlay window stays fully interactive and right-click → Inspect works.

Also updated the surrounding inline comment and the file-level architectural
comment to document the new macOS production invariant: the overlay window is
always ignore-cursor-events; the click-catcher panel is the toggle.

### Scope

- Only the macOS production path changed (gate removed). Non-macOS behavior is
  unchanged.
- Click-catcher panel logic (rc.7 poller-driven `setIgnoresMouseEvents` toggle)
  untouched.
- No renderer (`src/lib/overlay/`) changes.
- No versioning changes.

## Verification gates (all clean)

Run from `packages/desktop`:

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 116 passed
- `pnpm svelte-check` — 0 errors / 0 warnings
- `pnpm test` — 905 passed, 35 skipped

## Notes

- References rc.7 PRs #125 and #126 for context.
- Manual smoke covers the end-to-end behavior; no new automated test required
  (the new invariant is documented in the architectural comment).
