### PR TITLE
feat: enable refresh & re-auth for connection_failed OAuth servers

### DIFF
--- a/src/lib/components/AuthTab.svelte
+++ b/src/lib/components/AuthTab.svelte
@@ -1,13 +1,16 @@
 <script lang="ts">
   import type { OAuthStatus, OAuthStatusValue } from '$lib/types';
   import { selectedEndpoint, oauthStatuses } from '$lib/stores';
-  import { getOAuthStatus, refreshOAuth } from '$lib/api';
+  import { getOAuthStatus, refreshOAuth, startOAuth } from '$lib/api';
+  import { openUrl } from '@tauri-apps/plugin-opener';
+  import { canReauthorize, reauthorize } from '$lib/oauth/actions';
   import { toast } from 'svelte-sonner';
 
   let status = $state<OAuthStatus | null>(null);
   let loading = $state(true);
   let error = $state('');
   let actionInProgress = $state(false);
+  let reauthInProgress = $state(false);
 
   const statusColors: Record<OAuthStatusValue, string> = {
     authenticated: 'bg-(--healthy)',
@@ -85,7 +88,29 @@
     actionInProgress = false;
   }
 
-  let canRefresh = $derived(status !== null && status.has_refresh_token && ['authenticated'].includes(status.status));
+  async function handleReauthorize() {
+    const name = $selectedEndpoint;
+    if (!name || reauthInProgress) return;
+    reauthInProgress = true;
+    try {
+      await reauthorize(name, {
+        startOAuth,
+        openUrl,
+        onSuccess: toast.success,
+        onError: toast.error,
+      });
+    } catch {
+      toast.error('Failed to start OAuth flow');
+    }
+    reauthInProgress = false;
+  }
+
+  let canRefresh = $derived(
+    status !== null &&
+      status.has_refresh_token &&
+      (['authenticated', 'connection_failed'] as OAuthStatusValue[]).includes(status.status),
+  );
+  let canReauth = $derived(status !== null && canReauthorize(status.status));
 </script>
 
 <div class="h-full overflow-y-auto p-4 space-y-4">
@@ -146,13 +171,24 @@
     </div>
 
     <!-- Actions -->
-    {#if canRefresh}
+    {#if canRefresh || canReauth}
       <div class="flex gap-2">
-        <button
-          class="btn-sec"
-          onclick={handleRefresh}
-          disabled={actionInProgress}
-        >Refresh Now</button>
+        {#if canRefresh}
+          <button
+            class="btn-sec"
+            onclick={handleRefresh}
+            disabled={actionInProgress}
+          >Refresh Now</button>
+        {/if}
+        {#if canReauth}
+          <button
+            class="btn-pri"
+            onclick={handleReauthorize}
+            disabled={reauthInProgress}
+            title="Open the browser to sign in again"
+            aria-label="Re-authenticate"
+          >Re-authenticate</button>
+        {/if}
       </div>
     {/if}
   {/if}

--- a/src/lib/components/AuthTab.test.ts
+++ b/src/lib/components/AuthTab.test.ts
@@ -23,8 +23,10 @@ function formatCountdown(seconds: number | null): string {
 
 // Pure mirror of the `canRefresh` derivation in AuthTab.svelte. Kept in sync
 // with the component so we can unit-test which OAuth statuses surface the
-// "Refresh Now" button. `auth_required` is intentionally excluded — once the
-// token is expired the user must re-authorize, not silently refresh.
+// "Refresh Now" button. `connection_failed` is included because the relay
+// accepts a refresh from that state when a refresh token exists; `auth_required`
+// stays excluded — once the token is fully expired the user must re-authorize,
+// not silently refresh.
 type OAuthStatusValue =
   | 'authenticated'
   | 'needs_login'
@@ -42,7 +44,20 @@ function canRefresh(status: MinimalOAuthStatus | null): boolean {
   return (
     status !== null &&
     status.has_refresh_token &&
-    (['authenticated'] as OAuthStatusValue[]).includes(status.status)
+    (['authenticated', 'connection_failed'] as OAuthStatusValue[]).includes(status.status)
+  );
+}
+
+// Pure mirror of the `canReauth` derivation in AuthTab.svelte, which delegates
+// to `canReauthorize()` from $lib/oauth/actions. Kept in sync with that helper's
+// REAUTHORIZE_STATUSES so we can unit-test which statuses surface the
+// "Re-authenticate" button.
+function canReauth(status: MinimalOAuthStatus | null): boolean {
+  return (
+    status !== null &&
+    (['disconnected', 'auth_required', 'needs_login', 'connection_failed'] as OAuthStatusValue[]).includes(
+      status.status,
+    )
   );
 }
 
@@ -135,8 +150,47 @@ describe('canRefresh', () => {
     expect(canRefresh({ status: 'disconnected', has_refresh_token: true })).toBe(false);
   });
 
+  it('returns true for connection_failed when a refresh token is present', () => {
+    expect(canRefresh({ status: 'connection_failed', has_refresh_token: true })).toBe(true);
+  });
+
+  it('returns false for connection_failed when no refresh token is present', () => {
+    expect(canRefresh({ status: 'connection_failed', has_refresh_token: false })).toBe(false);
+  });
+
   it('returns false when status is null', () => {
     expect(canRefresh(null)).toBe(false);
+  });
+});
+
+describe('canReauth', () => {
+  it('returns true for connection_failed (with or without a refresh token)', () => {
+    expect(canReauth({ status: 'connection_failed', has_refresh_token: true })).toBe(true);
+    expect(canReauth({ status: 'connection_failed', has_refresh_token: false })).toBe(true);
+  });
+
+  it('returns true for needs_login', () => {
+    expect(canReauth({ status: 'needs_login', has_refresh_token: false })).toBe(true);
+  });
+
+  it('returns true for auth_required', () => {
+    expect(canReauth({ status: 'auth_required', has_refresh_token: true })).toBe(true);
+  });
+
+  it('returns true for disconnected', () => {
+    expect(canReauth({ status: 'disconnected', has_refresh_token: false })).toBe(true);
+  });
+
+  it('returns false for authenticated', () => {
+    expect(canReauth({ status: 'authenticated', has_refresh_token: true })).toBe(false);
+  });
+
+  it('returns false for refreshing', () => {
+    expect(canReauth({ status: 'refreshing', has_refresh_token: true })).toBe(false);
+  });
+
+  it('returns false when status is null', () => {
+    expect(canReauth(null)).toBe(false);
   });
 });
 

--- a/src/lib/components/detail-panel-helpers.test.ts
+++ b/src/lib/components/detail-panel-helpers.test.ts
@@ -247,8 +247,13 @@ describe('DetailPanel endpoint toggle (a11y)', () => {
 });
 
 describe('shouldShowReauthorizeButton', () => {
-  const reauthStatuses: OAuthStatusValue[] = ['disconnected', 'auth_required', 'needs_login'];
-  const nonReauthStatuses: OAuthStatusValue[] = ['authenticated', 'refreshing', 'connection_failed'];
+  const reauthStatuses: OAuthStatusValue[] = [
+    'disconnected',
+    'auth_required',
+    'needs_login',
+    'connection_failed',
+  ];
+  const nonReauthStatuses: OAuthStatusValue[] = ['authenticated', 'refreshing'];
 
   for (const s of reauthStatuses) {
     it(`returns true for oauth + "${s}"`, () => {

--- a/src/lib/components/detail-panel-helpers.ts
+++ b/src/lib/components/detail-panel-helpers.ts
@@ -6,6 +6,7 @@ const REAUTH_NEEDED_STATUSES: ReadonlyArray<OAuthStatusValue> = [
   'disconnected',
   'auth_required',
   'needs_login',
+  'connection_failed',
 ];
 
 export function shouldShowReauthorizeButton(

--- a/src/lib/oauth/actions.test.ts
+++ b/src/lib/oauth/actions.test.ts
@@ -67,9 +67,9 @@ describe('canReauthorize', () => {
     ['disconnected', true],
     ['auth_required', true],
     ['needs_login', true],
+    ['connection_failed', true],
     ['authenticated', false],
     ['refreshing', false],
-    ['connection_failed', false],
   ];
 
   for (const [status, expected] of cases) {

--- a/src/lib/oauth/actions.ts
+++ b/src/lib/oauth/actions.ts
@@ -4,6 +4,7 @@ const REAUTHORIZE_STATUSES: ReadonlyArray<OAuthStatusValue> = [
   'disconnected',
   'auth_required',
   'needs_login',
+  'connection_failed',
 ];
 
 export function canReauthorize(status: OAuthStatusValue): boolean {


### PR DESCRIPTION
## Summary

When an OAuth server is in **Connection Failed** (expired access token, refresh token present), the desktop UI previously offered no recovery action — the Refresh button only appeared for `authenticated`, and `connection_failed` was excluded from the re-authorize eligibility lists. This left a dead end.

This change surfaces two recovery actions for `connection_failed`:

- **Refresh** — shown in the Auth tab when a refresh token is present and status is `authenticated` or `connection_failed`. Reuses the existing `POST /oauth/refresh` path (the relay already accepts a manual refresh from this state).
- **Re-authenticate** — shown for `needs_login` / `auth_required` / `disconnected` / `connection_failed`, wired to the existing `reauthorize()` helper (`startOAuth` + open browser).

Adding `connection_failed` to the shared eligibility constants also enables the top-of-panel re-authorize bar for this state, consistent with the Auth tab.

## Changes

- `src/lib/components/AuthTab.svelte` — Refresh + Re-authenticate actions for `connection_failed`.
- `src/lib/components/detail-panel-helpers.ts` — add `connection_failed` to `REAUTH_NEEDED_STATUSES`.
- `src/lib/oauth/actions.ts` — add `connection_failed` to `REAUTHORIZE_STATUSES`.
- Tests updated: `AuthTab.test.ts`, `detail-panel-helpers.test.ts`, `oauth/actions.test.ts`.

Desktop-only — no relay or website changes.

## Verification

- `npm run check` — 0 errors / 0 warnings
- `npm test` — 914 passed / 35 skipped

## Notes

- `auth_required` intentionally remains re-auth-only (no silent refresh), per existing design intent.
- No disconnect/revoke button added — scope limited to refresh + re-auth.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author