### PR TITLE
fix: share busy guard across Auth tab refresh and re-auth buttons

### DIFF
--- a/src/lib/components/AuthTab.svelte
+++ b/src/lib/components/AuthTab.svelte
@@ -76,7 +76,7 @@
 
   async function handleRefresh() {
     const name = $selectedEndpoint;
-    if (!name || actionInProgress) return;
+    if (!name || actionInProgress || reauthInProgress) return;
     actionInProgress = true;
     try {
       await refreshOAuth(name);
@@ -90,7 +90,7 @@
 
   async function handleReauthorize() {
     const name = $selectedEndpoint;
-    if (!name || reauthInProgress) return;
+    if (!name || actionInProgress || reauthInProgress) return;
     reauthInProgress = true;
     try {
       await reauthorize(name, {

--- a/src/lib/components/AuthTab.svelte
+++ b/src/lib/components/AuthTab.svelte
@@ -111,6 +111,7 @@
       (['authenticated', 'connection_failed'] as OAuthStatusValue[]).includes(status.status),
   );
   let canReauth = $derived(status !== null && canReauthorize(status.status));
+  let actionBusy = $derived(actionInProgress || reauthInProgress);
 </script>
 
 <div class="h-full overflow-y-auto p-4 space-y-4">
@@ -177,14 +178,14 @@
           <button
             class="btn-sec"
             onclick={handleRefresh}
-            disabled={actionInProgress}
+            disabled={actionBusy}
           >Refresh Now</button>
         {/if}
         {#if canReauth}
           <button
             class="btn-pri"
             onclick={handleReauthorize}
-            disabled={reauthInProgress}
+            disabled={actionBusy}
             title="Open the browser to sign in again"
             aria-label="Re-authenticate"
           >Re-authenticate</button>

--- a/src/lib/components/AuthTab.test.ts
+++ b/src/lib/components/AuthTab.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 
 // Re-implement the pure logic from AuthTab.svelte so we can unit-test it.
 // These must stay in sync with the component implementation.
@@ -220,6 +220,45 @@ describe('actionBusy', () => {
 
   it('is true when both actions are in progress', () => {
     expect(actionBusy(true, true)).toBe(true);
+  });
+});
+
+// The vitest environment here is `node`, so we can't mount the component and
+// inspect a live DOM. Instead, assert against the component source so these
+// tests are meaningfully tied to the real `disabled` bindings and handler
+// guards (not just the mirrored `actionBusy` helper above). This guards the
+// regression where each button only disabled on its own in-progress flag,
+// allowing an overlapping token refresh + browser OAuth flow.
+describe('AuthTab busy-guard wiring (source contract)', () => {
+  let source = '';
+
+  beforeAll(async () => {
+    // @ts-expect-error node builtin types not installed
+    const { readFileSync } = await import('node:fs');
+    // @ts-expect-error node builtin types not installed
+    const { fileURLToPath } = await import('node:url');
+    source = readFileSync(fileURLToPath(new URL('./AuthTab.svelte', import.meta.url)), 'utf8') as string;
+  });
+
+  it('derives a shared actionBusy guard from both in-progress flags', () => {
+    expect(source).toMatch(
+      /actionBusy\s*=\s*\$derived\(\s*actionInProgress\s*\|\|\s*reauthInProgress\s*\)/,
+    );
+  });
+
+  it('binds both Refresh Now and Re-authenticate buttons to the shared guard', () => {
+    const disabledBindings = source.match(/disabled=\{actionBusy\}/g) ?? [];
+    expect(disabledBindings).toHaveLength(2);
+    // Neither button should bind disabled to a single per-flow flag anymore.
+    expect(source).not.toMatch(/disabled=\{actionInProgress\}/);
+    expect(source).not.toMatch(/disabled=\{reauthInProgress\}/);
+  });
+
+  it('early-returns from both handlers while either flow is active', () => {
+    const guards =
+      source.match(/if\s*\(!name\s*\|\|\s*actionInProgress\s*\|\|\s*reauthInProgress\)\s*return;/g) ??
+      [];
+    expect(guards).toHaveLength(2);
   });
 });
 

--- a/src/lib/components/AuthTab.test.ts
+++ b/src/lib/components/AuthTab.test.ts
@@ -61,6 +61,14 @@ function canReauth(status: MinimalOAuthStatus | null): boolean {
   );
 }
 
+// Pure mirror of the `actionBusy` derivation in AuthTab.svelte. Both the
+// "Refresh Now" and "Re-authenticate" buttons bind their `disabled` state to
+// this shared guard so neither can be triggered while either flow is running,
+// avoiding an overlapping token refresh + browser OAuth flow.
+function actionBusy(actionInProgress: boolean, reauthInProgress: boolean): boolean {
+  return actionInProgress || reauthInProgress;
+}
+
 
 describe('formatTime', () => {
   it('returns "—" for null', () => {
@@ -191,6 +199,27 @@ describe('canReauth', () => {
 
   it('returns false when status is null', () => {
     expect(canReauth(null)).toBe(false);
+  });
+});
+
+describe('actionBusy', () => {
+  it('is false when neither action is in progress', () => {
+    expect(actionBusy(false, false)).toBe(false);
+  });
+
+  // Both buttons share this guard: a refresh in progress must also disable the
+  // "Re-authenticate" button so the two flows cannot overlap.
+  it('is true when a refresh is in progress', () => {
+    expect(actionBusy(true, false)).toBe(true);
+  });
+
+  // ...and a re-authentication in progress must also disable "Refresh Now".
+  it('is true when a re-authentication is in progress', () => {
+    expect(actionBusy(false, true)).toBe(true);
+  });
+
+  it('is true when both actions are in progress', () => {
+    expect(actionBusy(true, true)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #130. When an OAuth server is in `connection_failed` with a refresh token present, both **Refresh Now** and **Re-authenticate** render in the Auth tab. Previously each button only disabled on its own in-progress flag (`actionInProgress` / `reauthInProgress`), so a user could trigger both at once — causing an overlapping token refresh + browser OAuth flow.

## Changes

- `src/lib/components/AuthTab.svelte` — introduce a shared `actionBusy = $derived(actionInProgress || reauthInProgress)` guard; both buttons now bind `disabled={actionBusy}`. The two `$state` flags remain the source of truth for each flow; only the disabled binding is shared.
- `src/lib/components/AuthTab.test.ts` — add an `actionBusy` mirror + tests verifying both buttons disable when either action is in progress.

## Verification

- `npm run check` — 0 errors / 0 warnings
- `npm test` — 918 passed / 35 skipped

Desktop-only — no relay or website changes.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author