### PR TITLE
fix(detail-panel): don't carry delete/restart confirm to another server

### DIFF
--- a/src/lib/components/DetailPanel.svelte
+++ b/src/lib/components/DetailPanel.svelte
@@ -58,6 +58,23 @@
     showReauthorize = result.showBar;
   });
 
+  // Close any open delete/restart confirm modal when the selected server
+  // changes so a confirm opened for one server can't carry over to the next.
+  // Tracked via a plain (non-reactive) variable — same prev-endpoint approach
+  // as the reauth gate above — so writing it from the effect doesn't
+  // re-trigger the effect, and we only reset when the name actually changes
+  // (opening a modal on the current server is left alone).
+  let prevConfirmEndpoint: string | null = null;
+
+  $effect(() => {
+    const name = $selectedEndpoint;
+    if (name !== prevConfirmEndpoint) {
+      prevConfirmEndpoint = name;
+      showDeleteConfirm = false;
+      showRestartConfirm = false;
+    }
+  });
+
   let tabs = $derived(
     $selectedEndpointData
       ? visibleTabs($selectedEndpointData.transport, !!$selectedEndpointData.disabled)
@@ -72,6 +89,7 @@
   });
 
   async function handleRestart() {
+    showRestartConfirm = false;
     const name = $selectedEndpoint;
     if (name) {
       try {
@@ -81,7 +99,6 @@
         toast.error(`Failed to restart "${name}"`);
       }
     }
-    showRestartConfirm = false;
   }
 
   async function handleRefresh() {
@@ -123,6 +140,7 @@
   }
 
   async function handleDelete() {
+    showDeleteConfirm = false;
     const name = $selectedEndpoint;
     if (name) {
       try {
@@ -141,7 +159,6 @@
         toast.error(`Failed to delete "${name}"`);
       }
     }
-    showDeleteConfirm = false;
   }
 
   async function handleReauthorize() {

--- a/src/lib/components/detail-panel-helpers.test.ts
+++ b/src/lib/components/detail-panel-helpers.test.ts
@@ -381,6 +381,55 @@ describe('DetailPanel re-authorize button', () => {
   });
 });
 
+// ── Confirm-modal reset on endpoint switch ──
+//
+// A delete/restart confirm opened for one server must never carry over to a
+// different server. DetailPanel guards this two ways: (1) the handlers clear
+// their confirm flag immediately on confirm — before the async mutation — and
+// (2) an effect resets both confirm flags whenever the selected endpoint name
+// changes. Verified via static source inspection (the project has no
+// component-mount test infra; test env is node, not jsdom).
+describe('DetailPanel confirm-modal reset on endpoint switch', () => {
+  const resetEffect = detailPanelSource.match(
+    /\$effect\(\(\) => \{\s*const name = \$selectedEndpoint;[\s\S]*?\}\);/,
+  );
+
+  it('resets both confirm flags in an effect keyed on selectedEndpoint change', () => {
+    expect(resetEffect, 'expected the selectedEndpoint reset effect').not.toBeNull();
+    expect(resetEffect![0]).toContain('name !== prevConfirmEndpoint');
+    expect(resetEffect![0]).toContain('prevConfirmEndpoint = name');
+    expect(resetEffect![0]).toContain('showDeleteConfirm = false');
+    expect(resetEffect![0]).toContain('showRestartConfirm = false');
+  });
+
+  it('tracks the previous endpoint in a plain (non-reactive) variable', () => {
+    expect(detailPanelSource).toMatch(/let prevConfirmEndpoint: string \| null = null;/);
+  });
+
+  it('closes the delete confirm immediately at the start of handleDelete', () => {
+    const handler = detailPanelSource.match(
+      /async function handleDelete\(\) \{[\s\S]*?\n  \}/,
+    );
+    expect(handler, 'expected handleDelete').not.toBeNull();
+    const body = handler![0];
+    // The flag clear must precede the awaited removeEndpoint call.
+    expect(body.indexOf('showDeleteConfirm = false')).toBeLessThan(
+      body.indexOf('await removeEndpoint'),
+    );
+  });
+
+  it('closes the restart confirm immediately at the start of handleRestart', () => {
+    const handler = detailPanelSource.match(
+      /async function handleRestart\(\) \{[\s\S]*?\n  \}/,
+    );
+    expect(handler, 'expected handleRestart').not.toBeNull();
+    const body = handler![0];
+    expect(body.indexOf('showRestartConfirm = false')).toBeLessThan(
+      body.indexOf('await restartEndpoint'),
+    );
+  });
+});
+
 // ── Container-stats formatters (header metrics line) ──
 
 describe('formatBytes', () => {


### PR DESCRIPTION
## Summary

Fixes a bug where deleting a server and then switching to a different server while the delete is in flight pops up the delete confirmation modal bound to the **newly-selected** server.

## Root cause

`DetailPanel.svelte` is a single reused component instance bound to the `selectedEndpointData` derived store. The confirm flags (`showDeleteConfirm`, `showRestartConfirm`) are local `$state`. `handleDelete` only set `showDeleteConfirm = false` **after** `await removeEndpoint(name)` resolved, so the modal stayed open during deletion. Switching servers in that window re-rendered the still-open `ConfirmModal` against the new server's name.

## Fix

- Clear the confirm flag at the **start** of `handleDelete` / `handleRestart` (before the await), so confirming closes the modal immediately.
- Add a `$effect` that resets `showDeleteConfirm` / `showRestartConfirm` whenever `selectedEndpoint`'s name changes, tracked via a plain `prevConfirmEndpoint` variable (mirrors the existing reauth-gate prev-endpoint pattern). Only resets on an actual change, so opening a confirm on the current server still works.

## Tests

Added source-inspection tests in `detail-panel-helpers.test.ts` covering the reset effect and the immediate-close ordering in both handlers.

## Verification

- `npm run check` — svelte-check: 0 errors, 0 warnings
- `npm test` — 975 passed, 35 skipped (1010 total)


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author