### PR TITLE
feat: show progress hint while toggling a server on/off

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@endara/desktop",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@endara/desktop",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "MIT",
       "dependencies": {
         "@humanspeak/svelte-json-view-lite": "^0.1.2",

--- a/src/lib/components/DetailPanel.svelte
+++ b/src/lib/components/DetailPanel.svelte
@@ -25,7 +25,15 @@
     formatBytes,
     formatCpuPercent,
   } from './detail-panel-helpers';
-  import { getCustomImage } from './endpoint-row-helpers';
+  import { getCustomImage, getEndpointStatusLabel } from './endpoint-row-helpers';
+  import {
+    endpointTransitions,
+    markStarting,
+    markStopping,
+    clearTransition,
+    transitionLabel,
+    shouldClearTransition,
+  } from '$lib/stores/endpointTransitions';
 
   let showRestartConfirm = $state(false);
   let showDeleteConfirm = $state(false);
@@ -64,6 +72,31 @@
       : []
   );
 
+  // Optimistic toggle hint for the currently-selected endpoint (null when no
+  // enable/disable is in flight). Drives the spinner + "Starting…/Stopping…"
+  // label on the toggle and the header secondary line.
+  let selectedPending = $derived(
+    $selectedEndpointData ? $endpointTransitions.get($selectedEndpointData.name) ?? null : null
+  );
+
+  // Reconcile pending transitions against the 2s endpoint poll: clear each one
+  // once the relay actually reports the target state (Ready/healthy for start,
+  // disabled/Stopped for stop), on any Failed/error, or after the safety
+  // timeout. Iterates the whole list so sidebar-row hints clear too, not just
+  // the selected endpoint's.
+  $effect(() => {
+    const list = $endpoints;
+    const pending = $endpointTransitions;
+    if (pending.size === 0) return;
+    const now = Date.now();
+    for (const [name, transition] of pending) {
+      const ep = list.find((e) => e.name === name);
+      if (shouldClearTransition(transition, ep, now)) {
+        clearTransition(name);
+      }
+    }
+  });
+
   $effect(() => {
     const ep = $selectedEndpointData;
     if (ep?.disabled && ($activeTab === 'tools' || $activeTab === 'logs' || $activeTab === 'profiles')) {
@@ -100,9 +133,17 @@
     const ep = $selectedEndpointData;
     if (!ep || toggling) return;
     toggling = true;
-    const action = ep.disabled ? 'enable' : 'disable';
+    const enabling = ep.disabled;
+    const action = enabling ? 'enable' : 'disable';
+    // Optimistically mark the transition BEFORE the await so the hint shows
+    // immediately on the toggle/header and sidebar row, ahead of the next poll.
+    if (enabling) {
+      markStarting(ep.name);
+    } else {
+      markStopping(ep.name);
+    }
     try {
-      if (ep.disabled) {
+      if (enabling) {
         await enableEndpoint(ep.name);
       } else {
         await disableEndpoint(ep.name);
@@ -113,10 +154,21 @@
       } catch {
         // Mutation already succeeded — silent on purpose. The 2s poll
         // loop in +page.svelte reconciles the list; surfacing a refresh
-        // error on top of the success toast below would confuse users.
+        // error on top of the toast below would confuse users.
       }
-      toast.success(`Server "${ep.name}" ${ep.disabled ? 'enabled' : 'disabled'}`);
+      // No premature "enabled" toast: the relay is still spinning the server
+      // up. The persistent "Starting…" hint communicates progress and the
+      // reconciliation effect clears it once the relay reports Ready. Disable
+      // completes quickly, so a success toast is fine there.
+      if (enabling) {
+        toast.success(`Starting "${ep.name}"…`);
+      } else {
+        toast.success(`Server "${ep.name}" disabled`);
+      }
     } catch {
+      // The mutation failed, so the server won't change state — drop the
+      // optimistic hint immediately instead of waiting for the safety timeout.
+      clearTransition(ep.name);
       toast.error(`Failed to ${action} "${ep.name}"`);
     }
     toggling = false;
@@ -178,7 +230,8 @@
           <div class="flex items-center gap-2 mt-0.5">
             <TransportBadge transport={ep.transport} />
             <IsolationBadge isolation={ep.isolation_state} />
-            <span class="text-[11px] text-(--fg3)">{ep.tool_count} tools</span>
+            <span class="text-[11px] {selectedPending ? 'text-(--accent)' : 'text-(--fg3)'}"
+              >{transitionLabel(selectedPending) ?? getEndpointStatusLabel(ep)}</span>
           </div>
           {#if getCustomImage(ep.isolation_state) || ep.container_stats}
             <div class="flex items-center gap-2 mt-0.5">
@@ -203,6 +256,14 @@
         </div>
       </div>
       <div class="flex items-center gap-1.5 flex-shrink-0">
+        {#if selectedPending}
+          <span class="flex items-center gap-1 text-[11px] text-(--accent)">
+            <svg class="w-3 h-3 animate-spin" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+              <circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="3" stroke-dasharray="28" stroke-dashoffset="8" stroke-linecap="round" />
+            </svg>
+            {transitionLabel(selectedPending)}
+          </span>
+        {/if}
         <button
           class="tgl {ep.disabled ? 'tgl-off' : ''} {toggling ? 'opacity-50' : ''}"
           onclick={handleToggle}

--- a/src/lib/components/EndpointRow.svelte
+++ b/src/lib/components/EndpointRow.svelte
@@ -6,8 +6,14 @@
   import EndpointIcon from './EndpointIcon.svelte';
   import TransportBadge from './TransportBadge.svelte';
   import { getEndpointStatusLabel } from './endpoint-row-helpers';
+  import { endpointTransitions, transitionLabel } from '$lib/stores/endpointTransitions';
 
   let { endpoint }: { endpoint: Endpoint } = $props();
+
+  // Optimistic toggle hint for this row (null when no enable/disable is in
+  // flight). Takes precedence over the normal status label/health dot so the
+  // sidebar reflects the toggle immediately, before the next poll.
+  let pending = $derived($endpointTransitions.get(endpoint.name) ?? null);
 
   // Extract error message from lifecycle if it's in Failed state
   let lifecycleError = $derived(
@@ -32,13 +38,13 @@
   class="w-full flex items-center gap-2.5 px-2.5 py-1.5 rounded-lg text-left transition-colors
     hover:bg-(--hover-bg)
     {$selectedEndpoint === endpoint.name ? 'bg-(--hover-bg)' : ''}
-    {endpoint.disabled ? 'opacity-50' : ''}"
+    {endpoint.disabled && !pending ? 'opacity-50' : ''}"
   onclick={select}
 >
   <div class="relative flex-shrink-0 text-(--fg3)" style="width: 20px; height: 20px;">
     <EndpointIcon {endpoint} size={20} />
     <span class="absolute" style="bottom: -1px; right: -1px;">
-      <HealthDot health={isFailed ? 'error' : endpoint.health} stacked={true} />
+      <HealthDot health={pending ? 'starting' : isFailed ? 'error' : endpoint.health} stacked={true} />
     </span>
   </div>
   <div class="flex-1 min-w-0">
@@ -47,7 +53,9 @@
     >{endpoint.name}</div>
     <div class="flex items-baseline gap-1.5 mt-px">
       <TransportBadge transport={endpoint.transport} />
-      {#if isFailed}
+      {#if pending}
+        <span class="text-[11px] text-(--accent)" style="font-family: var(--font-mono);">{transitionLabel(pending)}</span>
+      {:else if isFailed}
         <span
           class="text-[11px] text-(--offline) truncate max-w-[120px]"
           style="font-family: var(--font-mono);"

--- a/src/lib/stores/endpointTransitions.test.ts
+++ b/src/lib/stores/endpointTransitions.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+
+import type { Endpoint } from '$lib/types';
+import {
+  endpointTransitions,
+  markStarting,
+  markStopping,
+  clearTransition,
+  transitionLabel,
+  shouldClearTransition,
+  TRANSITION_TIMEOUT_MS,
+  type PendingTransition,
+} from './endpointTransitions';
+
+function endpoint(overrides: Partial<Endpoint> = {}): Endpoint {
+  return {
+    name: 'github',
+    transport: 'stdio',
+    health: 'unknown',
+    tool_count: 0,
+    last_activity: null,
+    disabled: false,
+    ...overrides,
+  };
+}
+
+describe('endpointTransitions store', () => {
+  beforeEach(() => {
+    endpointTransitions.set(new Map());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('markStarting / markStopping record the kind and a startedAt timestamp', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1000);
+    markStarting('github');
+    markStopping('slack');
+
+    const map = get(endpointTransitions);
+    expect(map.get('github')).toEqual({ kind: 'starting', startedAt: 1000 });
+    expect(map.get('slack')).toEqual({ kind: 'stopping', startedAt: 1000 });
+  });
+
+  it('clearTransition removes only the named transition', () => {
+    markStarting('github');
+    markStarting('slack');
+    clearTransition('github');
+
+    const map = get(endpointTransitions);
+    expect(map.has('github')).toBe(false);
+    expect(map.has('slack')).toBe(true);
+  });
+
+  it('clearTransition is a no-op (same reference) when nothing is pending', () => {
+    const before = get(endpointTransitions);
+    clearTransition('github');
+    expect(get(endpointTransitions)).toBe(before);
+  });
+
+  it('updates publish a new Map reference so subscribers re-render', () => {
+    const seen: Map<string, PendingTransition>[] = [];
+    const unsub = endpointTransitions.subscribe((m) => seen.push(m));
+    markStarting('github');
+    unsub();
+    expect(seen.length).toBe(2);
+    expect(seen[0]).not.toBe(seen[1]);
+  });
+});
+
+describe('transitionLabel', () => {
+  it('maps the kind to a human-readable hint', () => {
+    expect(transitionLabel({ kind: 'starting', startedAt: 0 })).toBe('Starting…');
+    expect(transitionLabel({ kind: 'stopping', startedAt: 0 })).toBe('Stopping…');
+  });
+
+  it('returns null when nothing is pending', () => {
+    expect(transitionLabel(null)).toBeNull();
+    expect(transitionLabel(undefined)).toBeNull();
+  });
+});
+
+describe('shouldClearTransition', () => {
+  const starting: PendingTransition = { kind: 'starting', startedAt: 1000 };
+  const stopping: PendingTransition = { kind: 'stopping', startedAt: 1000 };
+
+  it('returns false when there is no pending transition', () => {
+    expect(shouldClearTransition(null, endpoint(), 2000)).toBe(false);
+  });
+
+  it('clears once the safety timeout elapses regardless of endpoint state', () => {
+    const now = 1000 + TRANSITION_TIMEOUT_MS;
+    expect(shouldClearTransition(starting, endpoint({ health: 'starting' }), now)).toBe(true);
+    expect(shouldClearTransition(stopping, endpoint(), now)).toBe(true);
+    expect(shouldClearTransition(starting, undefined, now)).toBe(true);
+  });
+
+  it('does not clear (yet) when the endpoint has dropped from the list and timeout has not elapsed', () => {
+    expect(shouldClearTransition(starting, undefined, 1500)).toBe(false);
+  });
+
+  it('starting clears when the relay reports Ready or healthy', () => {
+    expect(
+      shouldClearTransition(starting, endpoint({ lifecycle: { state: 'Ready', server_name: 'gh' } }), 1500),
+    ).toBe(true);
+    expect(shouldClearTransition(starting, endpoint({ health: 'healthy' }), 1500)).toBe(true);
+  });
+
+  it('starting keeps waiting while still Initializing', () => {
+    expect(
+      shouldClearTransition(starting, endpoint({ lifecycle: { state: 'Initializing' }, health: 'starting' }), 1500),
+    ).toBe(false);
+  });
+
+  it('any Failed/error state clears the transition (resolves to error display)', () => {
+    expect(shouldClearTransition(starting, endpoint({ error: 'boom' }), 1500)).toBe(true);
+    expect(shouldClearTransition(starting, endpoint({ health: 'failed' }), 1500)).toBe(true);
+    expect(
+      shouldClearTransition(stopping, endpoint({ lifecycle: { state: 'Failed', error: { kind: 'x', detail: 'y' } } }), 1500),
+    ).toBe(true);
+  });
+
+  it('stopping clears once the endpoint reports disabled or Stopped', () => {
+    expect(shouldClearTransition(stopping, endpoint({ disabled: true }), 1500)).toBe(true);
+    expect(shouldClearTransition(stopping, endpoint({ lifecycle: { state: 'Stopped' } }), 1500)).toBe(true);
+  });
+
+  it('stopping keeps waiting while the endpoint still reports enabled/Ready', () => {
+    expect(
+      shouldClearTransition(stopping, endpoint({ lifecycle: { state: 'Ready', server_name: 'gh' }, health: 'healthy' }), 1500),
+    ).toBe(false);
+  });
+});

--- a/src/lib/stores/endpointTransitions.ts
+++ b/src/lib/stores/endpointTransitions.ts
@@ -1,0 +1,99 @@
+import { writable } from 'svelte/store';
+import type { Endpoint } from '$lib/types';
+
+/**
+ * Optimistic, desktop-only toggle-transition state for MCP endpoints. When a
+ * user enables/disables a server the relay takes multiple seconds to actually
+ * spin the upstream session up (process start + tool discovery), reported as
+ * `lifecycle: 'Initializing'` / `health: 'starting'`. There is no relay-side
+ * "Stopping" state, so the "Stopping…" hint is purely optimistic and clears as
+ * soon as the endpoint reports disabled/Stopped.
+ *
+ * This module is intentionally UI-free so the reconciliation logic can be unit
+ * tested without mounting Svelte components.
+ */
+export type TransitionKind = 'starting' | 'stopping';
+
+export interface PendingTransition {
+  kind: TransitionKind;
+  startedAt: number;
+}
+
+/**
+ * Safety valve: a pending transition older than this clears unconditionally so
+ * the UI can never hang in "Starting…"/"Stopping…" forever (e.g. the relay
+ * never reports Ready, or an endpoint vanishes from the list).
+ */
+export const TRANSITION_TIMEOUT_MS = 30000;
+
+/** Map of `endpointName -> PendingTransition` for all in-flight toggles. */
+export const endpointTransitions = writable<Map<string, PendingTransition>>(new Map());
+
+function setTransition(name: string, kind: TransitionKind): void {
+  endpointTransitions.update((map) => {
+    const next = new Map(map);
+    next.set(name, { kind, startedAt: Date.now() });
+    return next;
+  });
+}
+
+/** Mark an endpoint as starting (enable clicked). */
+export function markStarting(name: string): void {
+  setTransition(name, 'starting');
+}
+
+/** Mark an endpoint as stopping (disable clicked). */
+export function markStopping(name: string): void {
+  setTransition(name, 'stopping');
+}
+
+/** Clear any pending transition for an endpoint (no-op when none pending). */
+export function clearTransition(name: string): void {
+  endpointTransitions.update((map) => {
+    if (!map.has(name)) return map;
+    const next = new Map(map);
+    next.delete(name);
+    return next;
+  });
+}
+
+/** Human-readable hint for a pending transition, or null when none pending. */
+export function transitionLabel(
+  pending: PendingTransition | null | undefined,
+): 'Starting…' | 'Stopping…' | null {
+  if (!pending) return null;
+  return pending.kind === 'starting' ? 'Starting…' : 'Stopping…';
+}
+
+/**
+ * Whether a pending transition has been reconciled by the latest polled
+ * endpoint and should be cleared:
+ * - safety timeout elapsed (regardless of endpoint state);
+ * - the endpoint reports a Failed/error state (resolves to the error display);
+ * - starting + the relay reports `lifecycle: 'Ready'` (or `health: 'healthy'`);
+ * - stopping + the endpoint reports `disabled` (or `lifecycle: 'Stopped'`).
+ *
+ * `endpoint` may be undefined/null when it has dropped out of the polled list;
+ * in that case only the safety timeout applies.
+ */
+export function shouldClearTransition(
+  pending: PendingTransition | null | undefined,
+  endpoint: Endpoint | null | undefined,
+  now: number,
+): boolean {
+  if (!pending) return false;
+  if (now - pending.startedAt >= TRANSITION_TIMEOUT_MS) return true;
+  if (!endpoint) return false;
+
+  const failed =
+    !!endpoint.error ||
+    endpoint.health === 'error' ||
+    endpoint.health === 'failed' ||
+    endpoint.lifecycle?.state === 'Failed';
+  if (failed) return true;
+
+  if (pending.kind === 'starting') {
+    return endpoint.lifecycle?.state === 'Ready' || endpoint.health === 'healthy';
+  }
+  return !!endpoint.disabled || endpoint.lifecycle?.state === 'Stopped';
+}


### PR DESCRIPTION
## Summary

When a user toggles a server (MCP endpoint) on or off, the relay needs several seconds to spin the upstream process up and discover its tools. Until now the toggle flipped immediately and fired a premature "enabled" toast, so the multi-second lag looked frozen or already done.

This adds an **optimistic `Starting…/Stopping…` progress hint** that appears immediately on click and persists until the relay reports the endpoint is actually `Ready` (or `Stopped`/`Failed`).

## Changes (desktop only)

- **`src/lib/stores/endpointTransitions.ts` (new)** — UI-free transition store (`markStarting`/`markStopping`/`clearTransition`) plus pure helpers `transitionLabel` and `shouldClearTransition` (clears on Ready/healthy, disabled/Stopped, Failed/error, or a 30s safety timeout). Fully unit-tested in `endpointTransitions.test.ts`.
- **`DetailPanel.svelte`** — marks the transition *before* the await for instant feedback; keeps the existing `toggling` flag to disable the button during the API call; reworded the enable toast so it no longer claims premature completion; header secondary line now uses `transitionLabel ?? getEndpointStatusLabel` (shows `Initializing…` instead of `0 tools` during spin-up); added a reconciliation `$effect` that clears the hint when the polled endpoint reaches a terminal state.
- **`EndpointRow.svelte`** — sidebar row shows the spinning health dot + `Starting…/Stopping…` label while a transition is pending; existing behavior (Disabled, error, Initializing…, tool count) is preserved otherwise.
- **`package-lock.json`** — harmless `0.1.9`→`0.1.10` sync to match `package.json`.

No relay changes — the relay already reports the transient `Initializing`/`starting` state; this is purely a desktop UX improvement.

## Verification

Run in repo root:
- `npm run check` — 0 errors / 0 warnings
- `npm test` — 985 passed (incl. new `endpointTransitions` branch tests)
- `npm run lint` — passes (pre-existing no-op stub)

Manual: enable a stdio MCP server and confirm the hint appears immediately and resolves to a tool count when Ready; disable and confirm `Stopping…` shows briefly.

Independently reviewed and approved (all acceptance criteria met).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author