### PR TITLE
fix(overlay): drive call-card accent bar by call status

### DIFF
--- a/src/lib/overlay/OverlayCard.svelte
+++ b/src/lib/overlay/OverlayCard.svelte
@@ -59,6 +59,17 @@
   const showDuration = $derived(state !== 'inflight' && avgMs != null);
   const hasSettled = $derived(group.success > 0 || group.error > 0);
   const clickable = $derived(canFocusLog(group));
+  // Left accent bar driven by call status, not destructiveness:
+  // in-flight (blue) wins the entire time any call is in flight, else
+  // red when the group has any failed call (`group.error > 0`, even with
+  // some successes), else no bar.
+  const accentBar = $derived(
+    group.inflight > 0
+      ? 'var(--accent)'
+      : group.error > 0
+        ? 'var(--offline)'
+        : null,
+  );
   // Per-card dismiss bar visibility: rendered only after the group
   // has settled (no in-flight requests AND at least one resolved
   // request). A new started event for the same group flips
@@ -116,12 +127,13 @@
     class="tf-card tf-card-front"
     data-state={state}
     data-destructive={destructive ? 'true' : 'false'}
+    data-accent-bar={accentBar ? 'true' : 'false'}
     data-clickable={clickable ? 'true' : 'false'}
     data-stacked={stacked ? 'true' : 'false'}
     onclick={onClick}
   >
-    {#if destructive}
-      <div class="tf-accent-bar"></div>
+    {#if accentBar}
+      <div class="tf-accent-bar" style:background={accentBar}></div>
     {/if}
 
     <div class="tf-card-body">

--- a/src/lib/overlay/OverlayCard.test.ts
+++ b/src/lib/overlay/OverlayCard.test.ts
@@ -107,9 +107,27 @@ describe('OverlayCard — visual state branches', () => {
     expect(groupVisualState(group)).toBe('inflight');
   });
 
-  it('destructive variant flips border + accent bar', () => {
-    const group = g({ annotations: { destructive: true } });
-    expect(isDestructive(group)).toBe(true);
+  it('drives the accent bar by call status, not destructiveness', () => {
+    // Mirrors OverlayCard.svelte's `accentBar` derivation:
+    //   inflight > 0 ? 'var(--accent)' : error > 0 ? 'var(--offline)' : null
+    const accentBar = (group: ToolCallGroup) =>
+      group.inflight > 0
+        ? 'var(--accent)'
+        : group.error > 0
+          ? 'var(--offline)'
+          : null;
+
+    // In-flight wins (blue) the entire time any call is in flight, even
+    // when some calls already failed.
+    expect(accentBar(g({ inflight: 1, error: 1, requests: [req()] }))).toBe('var(--accent)');
+    // Settled with any failed call (even alongside successes) → red.
+    expect(accentBar(g({ success: 2, error: 1 }))).toBe('var(--offline)');
+    // All-success → no bar.
+    expect(accentBar(g({ success: 3 }))).toBeNull();
+    // Destructive no longer drives the bar; the destructive pill still does.
+    const destructiveSuccess = g({ success: 1, annotations: { destructive: true } });
+    expect(isDestructive(destructiveSuccess)).toBe(true);
+    expect(accentBar(destructiveSuccess)).toBeNull();
   });
 });
 

--- a/src/lib/overlay/overlay.css
+++ b/src/lib/overlay/overlay.css
@@ -132,9 +132,9 @@
 .tf-card-front:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .tf-card-front[data-destructive='true'] { border-color: rgba(250, 82, 82, 0.35); }
 
-.tf-accent-bar { position: absolute; left: 0; top: 0; bottom: 0; width: 3px; background: var(--offline); }
+.tf-accent-bar { position: absolute; left: 0; top: 0; bottom: 0; width: 3px; }
 .tf-card-body { padding: 12px 14px; display: flex; flex-direction: column; gap: 6px; }
-.tf-card-front[data-destructive='true'] .tf-card-body { padding-left: 16px; }
+.tf-card-front[data-accent-bar='true'] .tf-card-body { padding-left: 16px; }
 
 .tf-row-1 { display: flex; align-items: center; gap: 10px; min-width: 0; }
 .tf-icon { width: 28px; height: 28px; border-radius: 7px; background: var(--tf-icon-bg); display: flex; align-items: center; justify-content: center; color: var(--fg1); flex-shrink: 0; }


### PR DESCRIPTION
## Summary

The overlay call-card left accent bar was tied to the `destructive` annotation and hardcoded red, which visually read as a **failed call**. This change makes the accent bar a **call-status** indicator instead:

- **Blue** (`var(--accent)`) whenever the card has an in-flight call (the entire time it is in flight, including stacked groups).
- **Red** (`var(--offline)`) when the card has at least one failed call (`group.error > 0`), even if some calls also succeeded.
- **No bar** otherwise.

Destructive cards now rely solely on the red `destructive` pill. The faint destructive `border-color` rule and the `data-destructive` attribute are intentionally left untouched.

## Changes

- `OverlayCard.svelte`: accent bar driven by a `$derived` color (in-flight wins over failed), rendered via `{#if accentBar}` with an inline `style:background`; removed the `{#if destructive}` coupling; added `data-accent-bar`.
- `overlay.css`: removed the hardcoded `.tf-accent-bar` red background; re-keyed the card-body left-padding offset from `[data-destructive='true']` to `[data-accent-bar='true']`.
- `OverlayCard.test.ts`: updated the former `destructive variant flips border + accent bar` test to reflect the status-driven behavior.

## Verification

- `npm run check` → 0 errors / 0 warnings
- `npx vitest run src/lib/overlay/OverlayCard.test.ts` → 29 passed

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author