### PR TITLE
fix(theme): make native scrollbars follow dark mode

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -135,6 +135,8 @@
    ============================================================ */
 
 :root {
+  color-scheme: light;
+
   --surface:        var(--paper-0);
   --surface-alt:    var(--paper-50);
   --surface-raised: var(--paper-0);
@@ -196,6 +198,8 @@
 
 [data-theme="dark"],
 .dark {
+  color-scheme: dark;
+
   --surface:        var(--slate-100);
   --surface-alt:    var(--slate-200);
   --surface-raised: var(--slate-200);
@@ -276,6 +280,30 @@
     padding: 0;
     overflow: hidden;
     height: 100vh;
+  }
+
+  /* Theme-aware native scrollbars (main app window). The overlay window
+     hides its scrollbars separately and is intentionally not affected. */
+  ::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: var(--border);
+    border-radius: var(--radius-full);
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background: var(--border-strong);
+  }
+
+  ::-webkit-scrollbar-corner {
+    background: transparent;
   }
 }
 


### PR DESCRIPTION
## Problem

In dark mode, native scrollbars in the main app window rendered with a white track/background. The app swaps color tokens for dark mode (toggling `.dark` / `[data-theme="dark"]` on `<html>`), but `src/app.css` never declared the CSS `color-scheme` property — so the WebView painted native UI (scrollbars, form controls) using the light scheme regardless of theme.

## Fix

All changes are confined to `src/app.css`:

- Add `color-scheme: light;` to the `:root` light token block.
- Add `color-scheme: dark;` to the `[data-theme="dark"], .dark` block — this is the core fix for the white scrollbar in dark mode.
- Add theme-aware `::-webkit-scrollbar` rules in `@layer base` using existing design tokens (`--border`, `--border-strong`, `--radius-full`) so the thumb color tracks the active theme.

The overlay window deliberately hides its scrollbars; its unlayered `:global(::-webkit-scrollbar){display:none}` rule still wins over the new `@layer base` rules, so the overlay is unaffected.

## Verification

- `npm run check`: 0 errors / 0 warnings.
- Full unit suite: 978 passed (including all 33 overlay tests — overlay scrollbar suppression intact).
- Independently reviewed: only `src/app.css` changed; scrollbars render dark in dark mode (light / dark / system-following-dark) and light mode is unchanged.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author