### PR TITLE
perf(observability): keyset pagination + slim list payload

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -601,7 +601,12 @@ export interface ObservabilityCallsFilter {
   since?: number;
   until?: number;
   limit?: number;
-  offset?: number;
+  /**
+   * Opaque continuation token returned as `nextCursor` from the previous
+   * page; omit for the first page. The relay encodes `(tsStart, id)` so
+   * paging stays stable across concurrent inserts.
+   */
+  cursor?: string;
 }
 
 export async function getObservabilityCalls(

--- a/src/lib/components/Observability.svelte
+++ b/src/lib/components/Observability.svelte
@@ -15,7 +15,7 @@
   import type {
     ObservabilitySummary,
     AggregateBucketDto,
-    CallRecordDto,
+    CallSummaryDto,
     CallDetail,
   } from '$lib/types';
   import type { ToolCallEvent } from '$lib/overlay/types';
@@ -53,9 +53,11 @@
   let errorMessage = $state<string | null>(null);
   let summary = $state<ObservabilitySummary | null>(null);
   let buckets = $state<AggregateBucketDto[]>([]);
-  let calls = $state<CallRecordDto[]>([]);
-  let offset = $state(0);
-  let hasMore = $state(false);
+  let calls = $state<CallSummaryDto[]>([]);
+  // Opaque keyset cursor for the next page of `/observability/calls`, returned
+  // by the relay as `nextCursor`. `undefined` once the list is on its last
+  // page or has been reset; "Load more" is enabled iff this is non-null.
+  let nextCursor = $state<string | undefined>(undefined);
   let loadingMore = $state(false);
 
   // Filter UI state. `serverName`/`tool` empty = no constraint.
@@ -85,7 +87,7 @@
   // number. Stays null until loaded (or if the config fetch fails).
   let payloadWindowMinutes = $state<number | null>(null);
 
-  function currentFilterUi(pageOffset: number): CallsFilterUi {
+  function currentFilterUi(cursor?: string): CallsFilterUi {
     return {
       serverName,
       tool,
@@ -93,7 +95,7 @@
       windowMinutes,
       requestUid: uidFilter,
       limit: PAGE_SIZE,
-      offset: pageOffset,
+      cursor,
     };
   }
 
@@ -108,10 +110,9 @@
   }
 
   async function loadCalls() {
-    const res = await getObservabilityCalls(buildCallsFilter(currentFilterUi(0)));
+    const res = await getObservabilityCalls(buildCallsFilter(currentFilterUi()));
     calls = mergeCalls([], res.calls);
-    offset = res.calls.length;
-    hasMore = res.calls.length >= PAGE_SIZE;
+    nextCursor = res.nextCursor;
   }
 
   async function loadAll() {
@@ -127,13 +128,12 @@
   }
 
   async function loadMore() {
-    if (loadingMore || !hasMore) return;
+    if (loadingMore || !nextCursor) return;
     loadingMore = true;
     try {
-      const res = await getObservabilityCalls(buildCallsFilter(currentFilterUi(offset)));
+      const res = await getObservabilityCalls(buildCallsFilter(currentFilterUi(nextCursor)));
       calls = mergeCalls(calls, res.calls);
-      offset += res.calls.length;
-      hasMore = res.calls.length >= PAGE_SIZE;
+      nextCursor = res.nextCursor;
     } catch (err) {
       errorMessage = err instanceof Error ? err.message : String(err);
     } finally {
@@ -154,13 +154,12 @@
           bucket_seconds: 60,
           since: windowMinutes > 0 ? Date.now() - windowMinutes * 60_000 : undefined,
         }),
-        getObservabilityCalls(buildCallsFilter(currentFilterUi(0))),
+        getObservabilityCalls(buildCallsFilter(currentFilterUi())),
       ]);
       summary = aggRes.summary;
       buckets = aggRes.buckets;
       calls = mergeCalls([], callsRes.calls);
-      offset = callsRes.calls.length;
-      hasMore = callsRes.calls.length >= PAGE_SIZE;
+      nextCursor = callsRes.nextCursor;
     } catch (err) {
       errorMessage = err instanceof Error ? err.message : String(err);
     }
@@ -251,8 +250,7 @@
     // Purge succeeded: report it now, independent of the reload outcome.
     closeDetail();
     calls = [];
-    offset = 0;
-    hasMore = false;
+    nextCursor = undefined;
     showPurgeConfirm = false;
     toast.success('Tool call records purged');
     try {
@@ -289,10 +287,13 @@
             bucket_seconds: 60,
             since: windowMinutes > 0 ? Date.now() - windowMinutes * 60_000 : undefined,
           }),
-          getObservabilityCalls(buildCallsFilter(currentFilterUi(0))),
+          getObservabilityCalls(buildCallsFilter(currentFilterUi())),
         ]);
         summary = aggRes.summary;
         buckets = aggRes.buckets;
+        // Live merge: incoming first-page rows win for any UID we already
+        // have, but the cursor for "Load more" is anchored to the original
+        // first-page tail — fresh terminal events don't reset it.
         calls = mergeCalls(calls, callsRes.calls);
       } catch {
         // Transient relay hiccup — keep the current view, next event retries.
@@ -613,7 +614,7 @@
               </tbody>
             </table>
           </div>
-          {#if hasMore}
+          {#if nextCursor}
             <div class="mt-2 flex justify-center">
               <button class="btn-sec btn-sm" onclick={loadMore} disabled={loadingMore}>
                 {loadingMore ? 'Loading…' : 'Load more'}

--- a/src/lib/components/observability-helpers.test.ts
+++ b/src/lib/components/observability-helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 
-import type { CallRecordDto, AggregateBucketDto } from '$lib/types';
+import type { CallSummaryDto, AggregateBucketDto } from '$lib/types';
 import {
   buildCallsFilter,
   formatDuration,
@@ -28,32 +28,31 @@ const baseUi: CallsFilterUi = {
   windowMinutes: 0,
   requestUid: '',
   limit: 100,
-  offset: 0,
 };
 
-function call(p: Partial<CallRecordDto>): CallRecordDto {
+function call(p: Partial<CallSummaryDto>): CallSummaryDto {
   return {
     id: 1,
     requestUid: 'u1',
-    endpoint: 'e',
     serverName: 'github',
     tool: 'get_file',
     tsStart: 1000,
+    durationMs: 0,
     success: true,
-    streamed: false,
+    requestBytes: 0,
+    responseBytes: 0,
     ...p,
   };
 }
 
 describe('buildCallsFilter', () => {
-  it('omits empty server/tool and leaves success unset for "all"', () => {
-    expect(buildCallsFilter(baseUi)).toEqual({ limit: 100, offset: 0 });
+  it('omits empty server/tool and leaves success/cursor unset for "all"', () => {
+    expect(buildCallsFilter(baseUi)).toEqual({ limit: 100 });
   });
 
   it('maps trimmed server/tool and the success tri-state', () => {
     expect(buildCallsFilter({ ...baseUi, serverName: ' github ', tool: ' foo ', status: 'errors' })).toEqual({
       limit: 100,
-      offset: 0,
       server_name: 'github',
       tool: 'foo',
       success: false,
@@ -70,6 +69,11 @@ describe('buildCallsFilter', () => {
     expect(buildCallsFilter({ ...baseUi, requestUid: ' abc-123 ' }).request_uid).toBe('abc-123');
     expect(buildCallsFilter({ ...baseUi, requestUid: '   ' }).request_uid).toBeUndefined();
     expect(buildCallsFilter(baseUi).request_uid).toBeUndefined();
+  });
+
+  it('forwards an opaque cursor when present and drops it when undefined', () => {
+    expect(buildCallsFilter({ ...baseUi, cursor: 'opaque-token' }).cursor).toBe('opaque-token');
+    expect(buildCallsFilter(baseUi).cursor).toBeUndefined();
   });
 });
 

--- a/src/lib/components/observability-helpers.ts
+++ b/src/lib/components/observability-helpers.ts
@@ -1,4 +1,4 @@
-import type { CallRecordDto, AggregateBucketDto } from '$lib/types';
+import type { CallSummaryDto, AggregateBucketDto } from '$lib/types';
 import type { ToolCallEvent } from '$lib/overlay/types';
 import type { ObservabilityCallsFilter } from '$lib/api';
 
@@ -17,7 +17,12 @@ export interface CallsFilterUi {
   windowMinutes: number;
   requestUid: string;
   limit: number;
-  offset: number;
+  /**
+   * Opaque keyset continuation token returned by the previous page (or
+   * `undefined` for the first page). The relay encodes `(tsStart, id)` so
+   * paging stays stable across concurrent inserts and is O(limit) at any depth.
+   */
+  cursor?: string;
 }
 
 /**
@@ -29,7 +34,8 @@ export function buildCallsFilter(
   ui: CallsFilterUi,
   nowMs: number = Date.now(),
 ): ObservabilityCallsFilter {
-  const filter: ObservabilityCallsFilter = { limit: ui.limit, offset: ui.offset };
+  const filter: ObservabilityCallsFilter = { limit: ui.limit };
+  if (ui.cursor) filter.cursor = ui.cursor;
   const server = ui.serverName.trim();
   if (server) filter.server_name = server;
   const tool = ui.tool.trim();
@@ -75,8 +81,9 @@ export function formatBytes(n: number | undefined | null): string {
   return `${value.toFixed(1)} ${unit}`;
 }
 
-/** Status pill text + ok flag for a row. */
-export function callStatus(record: CallRecordDto): { ok: boolean; label: string } {
+/** Status pill text + ok flag for a row. Accepts both the list summary and
+ * the drill-through full record — only `success` is read. */
+export function callStatus(record: { success: boolean }): { ok: boolean; label: string } {
   if (record.success) return { ok: true, label: 'success' };
   return { ok: false, label: 'error' };
 }
@@ -181,10 +188,10 @@ export function isTerminalEvent(event: ToolCallEvent | unknown): boolean {
  * refreshes existing rows), and sort newest-first by `tsStart`.
  */
 export function mergeCalls(
-  existing: readonly CallRecordDto[],
-  incoming: readonly CallRecordDto[],
-): CallRecordDto[] {
-  const byUid = new Map<string, CallRecordDto>();
+  existing: readonly CallSummaryDto[],
+  incoming: readonly CallSummaryDto[],
+): CallSummaryDto[] {
+  const byUid = new Map<string, CallSummaryDto>();
   for (const c of existing) byUid.set(c.requestUid, c);
   for (const c of incoming) byUid.set(c.requestUid, c);
   return [...byUid.values()].sort((a, b) => b.tsStart - a.tsStart);
@@ -192,7 +199,7 @@ export function mergeCalls(
 
 /** Distinct, sorted values of one field across a call list (for filter menus). */
 export function distinctValues(
-  calls: readonly CallRecordDto[],
+  calls: readonly CallSummaryDto[],
   field: 'serverName' | 'tool',
 ): string[] {
   const set = new Set<string>();

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -182,6 +182,8 @@ export interface OAuthSetupStatusResponse {
 /**
  * A single proxied `tools/call` metadata row from `observability.db`. camelCase;
  * the relay omits `Option` fields when null, so most fields are optional.
+ * Returned by the drill-through `GET /observability/calls/{request_uid}` route
+ * — the list route returns the slim {@link CallSummaryDto} instead.
  */
 export interface CallRecordDto {
   id: number;
@@ -204,6 +206,25 @@ export interface CallRecordDto {
   requestBytes?: number;
   responseBytes?: number;
   streamed: boolean;
+}
+
+/**
+ * Slim per-row DTO for the calls list table — the only fields the list view
+ * actually renders. Drops transport/client/payload-byte detail so a 100-row
+ * page stays a few KB on the wire. The full {@link CallRecordDto} is still
+ * served by the drill-through detail route.
+ */
+export interface CallSummaryDto {
+  id: number;
+  requestUid: string;
+  serverName?: string;
+  tool: string;
+  tsStart: number;
+  durationMs: number;
+  success: boolean;
+  errorMessage?: string;
+  requestBytes: number;
+  responseBytes: number;
 }
 
 /** One aggregate time bucket (camelCase). `server` absent = all-servers bucket. */
@@ -246,11 +267,16 @@ export interface ObservabilityConfig {
   payload_buffer_budget_mb: number;
 }
 
-/** `GET /observability/calls` response wrapper. */
+/**
+ * `GET /observability/calls` response wrapper. Pagination is keyset on
+ * `(tsStart, id)` via an opaque `nextCursor` token — absent when the page is
+ * the last one. Pass the token back as the `cursor` query param to fetch the
+ * next page.
+ */
 export interface CallsResponse {
-  calls: CallRecordDto[];
+  calls: CallSummaryDto[];
   limit: number;
-  offset: number;
+  nextCursor?: string;
 }
 
 /** `GET /observability/calls/{request_uid}` response wrapper. */


### PR DESCRIPTION
## Summary
Consumes the relay's new Observability calls contract:

- **Continuation token** — the calls list now pages via the relay's opaque `nextCursor` instead of `offset`, wired through initial load, filter-change refresh, the **Load more** button, and live refresh. The dedup merge is retained as a safety net.
- **Slim list payload** — types/api updated to the slimmer calls-list DTO (only the rendered columns). The drill-through detail panel is unchanged (still full metadata + payloads).

No visible change to the Observability tab — same columns, same drill-through, same live refresh, working Load more.

## Verification
- `pnpm check` — 0 errors
- `pnpm vitest run` — 979 passed / 0 failed

Requires (pairs with) the relay PR: endara-ai/endara-relay#122.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author