### PR TITLE
feat: EMA slice 3 — org onboarding UI, resource-cred fields, expiry banner (END-19)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2024,6 +2024,15 @@ struct EndpointConfig {
     /// or — for legacy entries — in `config.toml`). The secret value itself is
     /// never returned to the UI; the field is masked write-only.
     client_secret_set: bool,
+    /// The EMA **resource** `client_id` stored per-endpoint in the DCR record
+    /// (R3); absent when unset. Not a secret, so the value is returned and the
+    /// Config tab renders it editable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    resource_client_id: Option<String>,
+    /// True iff an EMA **resource** `client_secret` is stored for this endpoint
+    /// (DCR record). The secret value itself is never returned to the UI; the
+    /// field is masked write-only.
+    resource_client_secret_set: bool,
     scopes: Option<String>,
     token_endpoint: Option<String>,
     /// Mirrors `server_type_override` from `config.toml`; absent when no
@@ -2039,6 +2048,26 @@ struct EndpointConfig {
     /// configured. The UI seeds its mount editor from this and passes the
     /// array back on update so the relay's PUT doesn't drop stored mounts.
     mounts: Option<Vec<String>>,
+    /// Mirrors the `[endpoints.auth]` sub-table for endpoints bound to an EMA
+    /// organization. Absent for ordinary endpoints — keeps their JSON shape
+    /// unchanged. The UI passes it back on update so the relay's PUT, which
+    /// rebuilds the whole endpoint config from the body, doesn't drop the
+    /// stored org binding.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    auth: Option<EndpointAuth>,
+}
+
+/// EMA org-binding block mirrored back to the UI from `[endpoints.auth]`.
+/// Mirrors the relay's `EmaAuthSummary` shape so the desktop can both display
+/// and round-trip the binding on PUT without translation.
+#[derive(Serialize)]
+struct EndpointAuth {
+    #[serde(rename = "type")]
+    auth_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    organization: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    resource: Option<String>,
 }
 
 /// Path to the DCR credentials file for an endpoint, e.g.
@@ -2047,6 +2076,49 @@ struct EndpointConfig {
 /// round-trip.
 fn dcr_file_path(name: &str) -> Result<std::path::PathBuf, String> {
     Ok(data_dir()?.join("tokens").join(format!("{name}.dcr.json")))
+}
+
+/// Credential presence read from an endpoint's `{name}.dcr.json` DCR record.
+/// Mirrors the relay's `DcrCredentials` fields the Config tab needs: whether a
+/// requesting `client_secret` is stored, the (non-secret) EMA
+/// `resource_client_id`, and whether a `resource_client_secret` is stored.
+#[derive(Default)]
+struct DcrCredentialView {
+    client_secret_set: bool,
+    resource_client_id: Option<String>,
+    resource_client_secret_set: bool,
+}
+
+/// Parse a DCR record's JSON into the credential view. A malformed record
+/// degrades gracefully to the all-absent default.
+fn parse_dcr_credential_view(json: &str) -> DcrCredentialView {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(json) else {
+        return DcrCredentialView::default();
+    };
+    let non_empty = |key: &str| {
+        value
+            .get(key)
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .filter(|s| !s.is_empty())
+    };
+    DcrCredentialView {
+        client_secret_set: non_empty("client_secret").is_some(),
+        resource_client_id: non_empty("resource_client_id"),
+        resource_client_secret_set: non_empty("resource_client_secret").is_some(),
+    }
+}
+
+/// Read and parse an endpoint's DCR record. Returns the all-absent default when
+/// no file exists or it can't be read.
+fn read_dcr_credential_view(name: &str) -> DcrCredentialView {
+    let Ok(path) = dcr_file_path(name) else {
+        return DcrCredentialView::default();
+    };
+    match std::fs::read_to_string(&path) {
+        Ok(contents) => parse_dcr_credential_view(&contents),
+        Err(_) => DcrCredentialView::default(),
+    }
 }
 
 #[tauri::command]
@@ -2109,8 +2181,13 @@ async fn get_endpoint_config(name: String) -> Result<EndpointConfig, String> {
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string())
                     .filter(|s| !s.is_empty());
-                let dcr_exists = dcr_file_path(&name).map(|p| p.exists()).unwrap_or(false);
-                let client_secret_set = dcr_exists || legacy_toml_secret.is_some();
+                // Read the DCR record's actual contents (not just existence): a
+                // resource-only EMA record (R3) has no requesting `client_secret`,
+                // so file presence alone must not imply one is stored.
+                let dcr_view = read_dcr_credential_view(&name);
+                let client_secret_set = dcr_view.client_secret_set || legacy_toml_secret.is_some();
+                let resource_client_id = dcr_view.resource_client_id;
+                let resource_client_secret_set = dcr_view.resource_client_secret_set;
                 let scopes = ep.get("scopes").and_then(|v| v.as_array()).map(|arr| {
                     arr.iter()
                         .filter_map(|v| v.as_str())
@@ -2140,6 +2217,33 @@ async fn get_endpoint_config(name: String) -> Result<EndpointConfig, String> {
                             .collect::<Vec<_>>()
                     })
                     .filter(|m| !m.is_empty());
+                // Surface the `[endpoints.auth]` sub-table for EMA-bound
+                // endpoints so the UI can both display the org and pass the
+                // block back on update (the relay's PUT rebuilds the whole
+                // endpoint config from the body — omitting `auth` would drop
+                // the binding).
+                let auth = ep.get("auth").and_then(|v| v.as_table()).map(|t| {
+                    let auth_type = t
+                        .get("type")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let organization = t
+                        .get("organization")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string())
+                        .filter(|s| !s.is_empty());
+                    let resource = t
+                        .get("resource")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string())
+                        .filter(|s| !s.is_empty());
+                    EndpointAuth {
+                        auth_type,
+                        organization,
+                        resource,
+                    }
+                });
 
                 return Ok(EndpointConfig {
                     name: name.clone(),
@@ -2154,11 +2258,14 @@ async fn get_endpoint_config(name: String) -> Result<EndpointConfig, String> {
                     oauth_server_url,
                     client_id,
                     client_secret_set,
+                    resource_client_id,
+                    resource_client_secret_set,
                     scopes,
                     token_endpoint,
                     server_type_override,
                     isolation,
                     mounts,
+                    auth,
                 });
             }
         }
@@ -2773,6 +2880,48 @@ pub fn run() {
             }
             _ => {}
         });
+}
+
+#[cfg(test)]
+mod dcr_credential_view_tests {
+    use super::*;
+
+    #[test]
+    fn parses_requesting_and_resource_creds() {
+        let json = r#"{"client_id":"req","client_secret":"sec","resource_client_id":"res","resource_client_secret":"res-sec"}"#;
+        let view = parse_dcr_credential_view(json);
+        assert!(view.client_secret_set);
+        assert_eq!(view.resource_client_id.as_deref(), Some("res"));
+        assert!(view.resource_client_secret_set);
+    }
+
+    #[test]
+    fn resource_only_record_does_not_imply_a_client_secret() {
+        // R3: a per-endpoint EMA record may carry only the resource pair with an
+        // empty requesting client_id and no requesting secret.
+        let json = r#"{"client_id":"","resource_client_id":"res"}"#;
+        let view = parse_dcr_credential_view(json);
+        assert!(!view.client_secret_set);
+        assert_eq!(view.resource_client_id.as_deref(), Some("res"));
+        assert!(!view.resource_client_secret_set);
+    }
+
+    #[test]
+    fn empty_strings_count_as_absent() {
+        let json = r#"{"client_secret":"","resource_client_id":"","resource_client_secret":""}"#;
+        let view = parse_dcr_credential_view(json);
+        assert!(!view.client_secret_set);
+        assert!(view.resource_client_id.is_none());
+        assert!(!view.resource_client_secret_set);
+    }
+
+    #[test]
+    fn malformed_json_degrades_to_default() {
+        let view = parse_dcr_credential_view("not json");
+        assert!(!view.client_secret_set);
+        assert!(view.resource_client_id.is_none());
+        assert!(!view.resource_client_secret_set);
+    }
 }
 
 #[cfg(test)]

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -544,6 +544,93 @@ describe('api', () => {
     });
   });
 
+  describe('createOrganization (client_secret)', () => {
+    it('threads client_secret through the POST body', async () => {
+      const { createOrganization } = await import('./api');
+      const mockResponse = {
+        name: 'Acme Corp',
+        provider: 'okta',
+        idp: 'https://acme.okta.com',
+        authorize_url: 'https://acme.okta.com/authorize?client_id=x',
+      };
+      vi.mocked(invoke).mockResolvedValue({ status: 201, body: JSON.stringify(mockResponse) });
+
+      const params = {
+        name: 'Acme Corp',
+        provider: 'okta',
+        slug: 'acme',
+        client_id: 'abc',
+        client_secret: 's3cret',
+      };
+      await createOrganization(params);
+      expect(invoke).toHaveBeenCalledWith(
+        'mgmt_api_request',
+        expect.objectContaining({ method: 'POST', path: '/api/organizations', body: params }),
+      );
+    });
+  });
+
+  describe('updateOrganization', () => {
+    it('PUTs to the org path, URL-encoding the name', async () => {
+      const { updateOrganization } = await import('./api');
+      const mockResponse = {
+        name: 'Acme Corp',
+        provider: 'okta',
+        idp: 'https://acme.okta.com',
+        authenticated: true,
+        client_secret_set: true,
+      };
+      mockOk(mockResponse);
+
+      const params = { client_secret: 's3cret' };
+      const res = await updateOrganization('Acme Corp', params);
+      expect(res).toEqual(mockResponse);
+      expect(invoke).toHaveBeenCalledWith(
+        'mgmt_api_request',
+        expect.objectContaining({
+          method: 'PUT',
+          path: '/api/organizations/Acme%20Corp',
+          body: params,
+        }),
+      );
+    });
+
+    it('returns the reauth response shape when the relay says identity changed', async () => {
+      const { updateOrganization, updateRequiresReauth } = await import('./api');
+      const mockResponse = {
+        name: 'Acme Renamed',
+        provider: 'okta',
+        idp: 'https://acme.okta.com',
+        authorize_url: 'https://acme.okta.com/authorize?client_id=x',
+      };
+      mockOk(mockResponse);
+
+      const res = await updateOrganization('Acme Corp', { name: 'Acme Renamed' });
+      expect(res).toEqual(mockResponse);
+      expect(updateRequiresReauth(res)).toBe(true);
+    });
+
+    it('updateRequiresReauth is false when the response carries authenticated metadata', async () => {
+      const { updateRequiresReauth } = await import('./api');
+      expect(
+        updateRequiresReauth({
+          name: 'Acme',
+          provider: 'okta',
+          idp: 'https://acme.okta.com',
+          authenticated: true,
+        }),
+      ).toBe(false);
+    });
+
+    it('throws on a relay error status', async () => {
+      const { updateOrganization } = await import('./api');
+      mockHttpError(404, JSON.stringify({ error: 'not_found' }));
+      await expect(
+        updateOrganization('Acme Corp', { client_secret: '' }),
+      ).rejects.toThrow('HTTP 404');
+    });
+  });
+
   describe('deleteOrganization', () => {
     it('DELETEs the org, encoding the name in the path', async () => {
       const { deleteOrganization } = await import('./api');

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -145,6 +145,19 @@ export interface AddEndpointParams {
    * (chmod 0600); never persisted in `config.toml`. Empty/absent = no secret.
    */
   client_secret?: string;
+  /**
+   * Optional EMA **resource** `client_id` presented at the MCP Authorization
+   * Server in Step 3 (ID-JAG redemption). Per-resource (R3), so it is persisted
+   * out-of-band via `/api/endpoints/{name}/credentials` (DCR file, chmod 0600),
+   * never in `config.toml`. Only needed for xaa.dev/Okta-style MASes.
+   */
+  resource_client_id?: string;
+  /**
+   * Optional EMA **resource** `client_secret` paired with `resource_client_id`.
+   * Write-only; persisted via `/api/endpoints/{name}/credentials` (DCR file,
+   * chmod 0600), never in `config.toml`.
+   */
+  resource_client_secret?: string;
   scopes?: string;
   token_endpoint?: string;
   /**
@@ -199,13 +212,36 @@ function mgmtError(res: ApiResponse): Error {
  */
 async function postEndpointCredentials(
   name: string,
-  fields: { client_id?: string; client_secret?: string; oauth_server_url?: string },
+  fields: {
+    client_id?: string;
+    client_secret?: string;
+    oauth_server_url?: string;
+    resource_client_id?: string;
+    resource_client_secret?: string;
+  },
 ): Promise<void> {
   const body: Record<string, string> = {};
+  // Requesting creds are write-only: only sent when non-empty (blank = keep).
   if (fields.client_id) body.client_id = fields.client_id;
   if (fields.client_secret) body.client_secret = fields.client_secret;
   if (fields.oauth_server_url) body.oauth_server_url = fields.oauth_server_url;
-  if (!body.client_id && !body.client_secret) return;
+  // EMA resource pair (R3): absent = keep, empty string = clear, value = set.
+  // Distinguish `undefined` (omit) from `''` (explicit clear) so the relay's
+  // merge can drop a stored value.
+  if (fields.resource_client_id !== undefined) body.resource_client_id = fields.resource_client_id;
+  if (fields.resource_client_secret !== undefined) {
+    body.resource_client_secret = fields.resource_client_secret;
+  }
+  // No-op when there is no credential material to set or clear. A lone
+  // `oauth_server_url` is informational and never worth a round-trip.
+  if (
+    !body.client_id &&
+    !body.client_secret &&
+    body.resource_client_id === undefined &&
+    body.resource_client_secret === undefined
+  ) {
+    return;
+  }
   const res = await mgmtRequest(
     'POST',
     `/endpoints/${encodeURIComponent(name)}/credentials`,
@@ -217,9 +253,10 @@ async function postEndpointCredentials(
 }
 
 export async function addEndpoint(params: AddEndpointParams): Promise<void> {
-  // Body excludes the write-only client_secret; credentials are persisted via
-  // the separate /credentials endpoint below (DCR file, chmod 0600).
-  const { client_secret, ...body } = params;
+  // Body excludes the write-only client_secret and the EMA resource pair;
+  // credentials are persisted via the separate /credentials endpoint below
+  // (DCR file, chmod 0600).
+  const { client_secret, resource_client_id, resource_client_secret, ...body } = params;
   const res = await mgmtRequest('POST', '/endpoints', body);
   if (res.status < 200 || res.status >= 300) {
     throw mgmtError(res);
@@ -228,6 +265,8 @@ export async function addEndpoint(params: AddEndpointParams): Promise<void> {
     client_id: params.client_id,
     client_secret,
     oauth_server_url: params.oauth_server_url,
+    resource_client_id,
+    resource_client_secret,
   });
 }
 
@@ -277,6 +316,17 @@ export interface EndpointConfig {
    * write-only field.
    */
   client_secret_set?: boolean;
+  /**
+   * The EMA **resource** `client_id` stored per-endpoint (R3); absent when
+   * unset. Not a secret, so the value is returned and rendered editable.
+   */
+  resource_client_id?: string;
+  /**
+   * `true` when an EMA **resource** `client_secret` is stored for this endpoint
+   * (DCR file). The secret value itself is never returned; the UI renders a
+   * masked, write-only field.
+   */
+  resource_client_secret_set?: boolean;
   scopes?: string;
   token_endpoint?: string;
   /**
@@ -295,6 +345,14 @@ export interface EndpointConfig {
    * `-v` `"host_path:container_path"` pairs. Absent when none are configured.
    */
   mounts?: string[];
+  /**
+   * EMA org-binding mirrored from the persisted `[endpoints.auth]` sub-table.
+   * Absent for ordinary endpoints. The UI displays the bound organization
+   * (read-only) and passes the block back on `updateEndpoint` so the relay's
+   * PUT — which rebuilds the whole endpoint config from the body — preserves
+   * the binding.
+   */
+  auth?: EmaAuthConfig;
 }
 
 export async function getEndpointConfig(name: string): Promise<EndpointConfig> {
@@ -321,6 +379,17 @@ export interface UpdateEndpointParams {
    * `config.toml`.
    */
   client_secret?: string;
+  /**
+   * EMA **resource** `client_id` (R3, MAS Step-3 credential). Absent preserves
+   * the stored value, an empty string clears it, a non-empty value sets it.
+   * Persisted via `/api/endpoints/{name}/credentials`, never in `config.toml`.
+   */
+  resource_client_id?: string;
+  /**
+   * EMA **resource** `client_secret` paired with `resource_client_id`. Same
+   * merge semantics; write-only and never returned to the UI.
+   */
+  resource_client_secret?: string;
   scopes?: string;
   token_endpoint?: string;
   /**
@@ -342,6 +411,14 @@ export interface UpdateEndpointParams {
    * array (possibly empty, to clear) for stdio endpoints.
    */
   mounts?: string[];
+  /**
+   * EMA org-binding block (`[endpoints.auth]`) round-tripped on update. The
+   * relay's PUT rebuilds the whole endpoint config from the body, so the
+   * stored binding must be sent back verbatim or it would be silently dropped.
+   * Absent for ordinary (non-EMA) endpoints — no empty `auth` key is sent in
+   * that case, keeping the PUT body byte-for-byte unchanged.
+   */
+  auth?: EmaAuthConfig;
 }
 
 export async function startOAuth(name: string): Promise<OAuthStartResult> {
@@ -396,7 +473,8 @@ export async function updateEndpoint(params: UpdateEndpointParams): Promise<void
   // Body mirrors the POST `/api/endpoints` shape: `original_name` moves to the
   // path, and `client_secret` is excluded so it is persisted out-of-band via
   // /credentials (DCR file, chmod 0600) rather than stored in `config.toml`.
-  const { original_name, client_secret, ...body } = params;
+  const { original_name, client_secret, resource_client_id, resource_client_secret, ...body } =
+    params;
   const res = await mgmtRequest(
     'PUT',
     `/endpoints/${encodeURIComponent(original_name)}`,
@@ -409,6 +487,8 @@ export async function updateEndpoint(params: UpdateEndpointParams): Promise<void
     client_id: params.client_id,
     client_secret,
     oauth_server_url: params.oauth_server_url,
+    resource_client_id,
+    resource_client_secret,
   });
 }
 
@@ -703,6 +783,13 @@ export interface CreateOrganizationParams {
   idp?: string;
   /** Pre-registered IdP client id (required for Okta/Entra; omit for CIMD/DCR). */
   client_id?: string;
+  /**
+   * Pre-registered confidential-client `client_secret`. Required for Okta/Entra
+   * apps configured as confidential clients. Persisted in the relay's secure
+   * credential store (`{org}.dcr.json`, 0600); never written to `config.toml`
+   * and never returned to the UI.
+   */
+  client_secret?: string;
 }
 
 /**
@@ -716,6 +803,78 @@ export async function createOrganization(
     method: 'POST',
     body: params,
   });
+}
+
+/**
+ * Body for `PUT /api/organizations/{org}`. All fields are optional — omitted
+ * fields preserve the current value. `client_id` and `client_secret` use an
+ * empty string (`""`) as the explicit "clear" signal so callers can
+ * distinguish "keep" (absent) from "remove" (present-and-empty).
+ */
+export interface UpdateOrganizationParams {
+  /** New display name; rename purges pooled IdP credentials. */
+  name?: string;
+  /** New provider template id (`okta`, `entra`, `google`, `ping`, `custom`). */
+  provider?: string;
+  /** New slug for templated providers. */
+  slug?: string;
+  /** New full issuer URL for `provider = "custom"`. */
+  idp?: string;
+  /** New explicit `client_id`. Empty string clears the persisted id. */
+  client_id?: string;
+  /** New confidential-client `client_secret`. Empty string deletes the stored secret. */
+  client_secret?: string;
+}
+
+/**
+ * Identity-unchanged variant of the `PUT /api/organizations/{org}` response:
+ * the org metadata was updated but credentials were preserved. Mirrors the
+ * shape of an entry in `GET /api/organizations`.
+ */
+export interface OrganizationUpdated {
+  name: string;
+  provider: string;
+  idp: string;
+  authenticated: boolean;
+  client_secret_set?: boolean;
+}
+
+/**
+ * Identity-changed variant of the `PUT /api/organizations/{org}` response:
+ * the rename/issuer/client_id change invalidated pooled credentials so the
+ * caller must re-run the IdP sign-in by opening `authorize_url`.
+ */
+export interface OrganizationReauthRequired {
+  name: string;
+  provider: string;
+  idp: string;
+  authorize_url: string;
+}
+
+/** Discriminated by the presence of `authorize_url`. */
+export type UpdateOrganizationResponse = OrganizationUpdated | OrganizationReauthRequired;
+
+/** True when the PUT response requires re-running the IdP sign-in. */
+export function updateRequiresReauth(
+  res: UpdateOrganizationResponse,
+): res is OrganizationReauthRequired {
+  return 'authorize_url' in res && typeof res.authorize_url === 'string';
+}
+
+/**
+ * PUT /api/organizations/{org} — update an existing organization's metadata
+ * and/or its persisted IdP credentials. Returns either the refreshed org
+ * metadata (credentials preserved) or a fresh SSO authorize URL (identity
+ * changed; re-authentication required).
+ */
+export async function updateOrganization(
+  name: string,
+  params: UpdateOrganizationParams,
+): Promise<UpdateOrganizationResponse> {
+  return fetchJson<UpdateOrganizationResponse>(
+    `/organizations/${encodeURIComponent(name)}`,
+    { method: 'PUT', body: params },
+  );
 }
 
 /** GET /api/organizations — configured organizations with auth status. */

--- a/src/lib/components/AddEndpointModal.svelte
+++ b/src/lib/components/AddEndpointModal.svelte
@@ -76,6 +76,12 @@
   let clientSecret = $state('');
   let scopes = $state('');
   let selectedScopes: Set<string> = $state(new Set());
+  // Optional EMA resource pairing credential (R3), settable at add-time on the
+  // org-bound custom flow. Mirrors the D2 Config-tab fields: id is editable,
+  // secret is write-only. Blank fields => no resource cred sent on create.
+  let orgBoundScopes = $state('');
+  let resourceClientId = $state('');
+  let resourceClientSecret = $state('');
   let selectedOAuthEntry: OAuthCatalogEntry | null = $state(null);
   let showingDcrFallback = $state(false);
   let dcrFallbackData: { authorization_endpoint?: string } = $state({});
@@ -153,11 +159,13 @@
   refreshOrganizations().catch(() => { /* relay unreachable — leave list empty */ });
 
   // The Organization selector only applies to the custom (non-catalog) add
-  // flow and only for the http transport — EMA endpoints are http by
-  // construction (see `buildOrgBoundEndpointParams`), so binding an org while
-  // sse/oauth is selected would silently create an http endpoint. `orgBound` is
-  // true once an org is actually chosen, switching submit to the plain EMA add
-  // path.
+  // flow and only for transports the relay accepts EMA on — currently `http`
+  // and `oauth` (see `orgBindingApplies`). EMA endpoints are built as `http`
+  // by construction (see `buildOrgBoundEndpointParams`); under an `oauth`
+  // selection that just means the org-bound add routes through the EMA `http`
+  // path and the per-server OAuth setup is dropped. `sse`/`stdio` never show
+  // the selector. `orgBound` is true once an org is actually chosen, switching
+  // submit to the plain EMA add path and bypassing `handleOAuthSubmit`.
   let orgSelectorVisible = $derived(!selectedCatalog && !selectedOAuthEntry && orgBindingApplies(transport));
   let orgBound = $derived(orgSelectorVisible && selectedOrganization.trim() !== '');
 
@@ -186,6 +194,9 @@
       clientId,
       clientSecret,
       scopes,
+      orgBoundScopes,
+      resourceClientId,
+      resourceClientSecret,
       serverTypeOverride,
       isolationEnabled,
       mounts: mountRows,
@@ -209,6 +220,9 @@
       clientId,
       clientSecret,
       scopes,
+      orgBoundScopes,
+      resourceClientId,
+      resourceClientSecret,
       serverTypeOverride,
       isolationEnabled,
       mounts: mountRows.map((m) => ({ host: m.host, container: m.container })),
@@ -285,6 +299,9 @@
     oauthServerUrl = service.oauthServerUrl || '';
     clientId = '';
     clientSecret = '';
+    orgBoundScopes = '';
+    resourceClientId = '';
+    resourceClientSecret = '';
     if (service.availableScopes && service.availableScopes.length > 0) {
       scopes = '';
       selectedScopes = new Set(service.defaultScopes);
@@ -329,6 +346,9 @@
     clientSecret = '';
     scopes = '';
     selectedScopes = new Set();
+    orgBoundScopes = '';
+    resourceClientId = '';
+    resourceClientSecret = '';
     showingDcrFallback = false;
     serverTypeOverride = server.serverTypeOverride ?? '';
     serverTypeOverrideHasDefault = Boolean(server.serverTypeOverride);
@@ -361,6 +381,9 @@
     clientSecret = '';
     scopes = '';
     selectedScopes = new Set();
+    orgBoundScopes = '';
+    resourceClientId = '';
+    resourceClientSecret = '';
     showingDcrFallback = false;
     serverTypeOverride = '';
     serverTypeOverrideHasDefault = false;
@@ -489,7 +512,14 @@
     // probe/escalation + browser-SSO path entirely — no per-server auth needed.
     const emaParams = buildOrgBoundEndpointParams(
       orgBound ? selectedOrganization : '',
-      { name, url, description },
+      {
+        name,
+        url,
+        description,
+        scopes: orgBoundScopes,
+        resourceClientId,
+        resourceClientSecret,
+      },
     );
     if (emaParams) {
       submitting = true;
@@ -1138,9 +1168,12 @@
             class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent)" />
         </div>
 
-        <!-- Organization binding (custom, http transport only). Selecting an
-             org makes the server authenticate via that org's shared EMA
-             credentials instead of its own per-server OAuth. -->
+        <!-- Organization binding (custom add only, http + oauth transports).
+             Selecting an org makes the server authenticate via that org's
+             shared EMA credentials instead of its own per-server OAuth — the
+             submit then routes through `buildOrgBoundEndpointParams` which
+             builds a plain `http` EMA endpoint, dropping the per-server OAuth
+             setup entirely. -->
         {#if orgSelectorVisible}
           <div>
             <label for="modal-ep-org" class="block text-xs font-medium mb-1 text-(--fg2)">Organization <span class="text-(--fg2)/50">(optional)</span></label>
@@ -1159,12 +1192,23 @@
               <p class="text-[11px] text-(--fg2) mt-0.5">
                 No organizations yet — use “Connect an organization” to sign in once and share its credentials across servers.
               </p>
-            {:else}
+            {:else if !orgBound}
               <p class="text-[11px] text-(--fg2) mt-0.5">
                 Bind this server to an organization to authenticate with its shared credentials instead of per-server OAuth.
               </p>
             {/if}
           </div>
+          {#if orgBound}
+            <!-- EMA outcome notice. Shown for both http and oauth selections
+                 once an org is chosen, since the submit path collapses to the
+                 same `auth.type="ema"` http endpoint and per-server OAuth is
+                 dropped. -->
+            <div class="px-3 py-2 rounded-lg border border-(--border) bg-(--surface-hover)">
+              <p class="text-[11px] text-(--fg2)">
+                This server will be added as an organization-managed (EMA) endpoint and use <strong>{selectedOrganization}</strong>'s shared credentials instead of its own OAuth.
+              </p>
+            </div>
+          {/if}
         {/if}
 
         {#if transport === 'stdio'}
@@ -1227,11 +1271,10 @@
               class="w-full text-sm px-3 py-1.5 rounded-lg border bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) {fieldErrors.url ? 'border-(--offline)' : 'border-(--border)'}" />
           </div>
 
-          {#if orgBound}
-            <p class="text-[11px] text-(--fg2)">
-              Authentication is handled by the selected organization — no per-server OAuth setup is needed.
-            </p>
-          {:else}
+          {#if !orgBound}
+          <!-- Per-server OAuth fields are dropped when an org is bound — the
+               EMA `http` endpoint reuses the org's shared credentials instead.
+               The user-facing explainer lives in the shared notice above. -->
           <!-- Curated scope checkbox list (only when the catalog entry exposes availableScopes) -->
           {#if scopeMode === 'checkbox' && selectedOAuthEntry?.availableScopes}
             <div>
@@ -1496,40 +1539,89 @@
           </div>
         {/if}
 
-        <!-- Generic Advanced section for non-OAuth transports. Auto-expanded
-             when the catalog entry ships a default `serverTypeOverride`. -->
-        {#if transport !== 'oauth'}
+        <!-- Generic Advanced section. Gated to render for non-oauth
+             transports OR any org-bound selection: org-bound OAUTH still
+             collapses to an EMA http endpoint at submit, so the EMA fields
+             (Scopes + Resource Client ID/Secret) belong here even on the
+             oauth transport. Auto-expanded when the catalog entry ships a
+             default `serverTypeOverride`. -->
+        {#if orgBound || transport !== 'oauth'}
           <details class="border border-(--border) rounded-lg" open={serverTypeOverrideHasDefault}>
             <summary class="px-3 py-2 text-xs font-medium text-(--fg2) cursor-pointer hover:bg-(--surface-hover) rounded-lg select-none">
               Advanced
             </summary>
             <div class="px-3 pb-3 space-y-3">
-              <div>
-                <label for="modal-ep-server-type-override-generic" class="block text-xs font-medium mb-1 text-(--fg2)">Server type override <span class="text-(--fg2)/50">(optional)</span></label>
-                <input
-                  id="modal-ep-server-type-override-generic"
-                  type="text"
-                  bind:value={serverTypeOverride}
-                  placeholder="e.g. my-server"
-                  maxlength={64}
-                  class="w-full text-sm px-3 py-1.5 rounded-lg border bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) {serverTypeOverrideInvalid || serverTypeOverrideTooLong ? 'border-(--offline)' : 'border-(--border)'}" />
-                <p class="text-[11px] text-(--fg2) mt-0.5">Optional. Replaces the name this server reports to MCP clients. Max 64 characters.</p>
-                {#if serverTypeOverridePreviewVisible}
-                  <p class="text-[11px] text-(--fg2) mt-0.5">Will be saved as: <code>{serverTypeOverrideSanitized}</code></p>
-                {/if}
-                {#if serverTypeOverrideInvalid}
-                  <p class="text-[11px] text-(--offline) mt-0.5">No usable characters — please include lowercase letters, digits, <code>-</code>, or <code>_</code>.</p>
-                {/if}
-                {#if serverTypeOverrideTooLong}
-                  <p class="text-[11px] text-(--offline) mt-0.5">Maximum 64 characters.</p>
-                {/if}
-              </div>
+              {#if orgBound}
+                <!-- Optional EMA scopes + resource pairing credential.
+                     `scopes` lands in the endpoint's `config.toml` (drives
+                     R2's IdP scope on first sign-in); the resource pair is
+                     stripped by `addEndpoint()` and POSTed to
+                     `/api/endpoints/{name}/credentials` (DCR file, chmod
+                     0600), never in `config.toml`. Mirrors the D2 Config-tab
+                     fields' labels and UX. -->
+                <div>
+                  <label for="modal-ep-orgbound-scopes" class="block text-xs font-medium mb-1 text-(--fg2)">Scopes <span class="text-(--fg2)/50">(optional, space-separated)</span></label>
+                  <input id="modal-ep-orgbound-scopes" type="text" bind:value={orgBoundScopes} placeholder="read write"
+                    class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent)" />
+                  <p class="text-[11px] text-(--fg2) mt-0.5">Space-separated. Leave blank for server defaults.</p>
+                </div>
+                <div>
+                  <label for="modal-ep-orgbound-resource-client-id" class="block text-xs font-medium mb-1 text-(--fg2)">
+                    Resource Client ID <span class="text-(--fg2)/50">(optional)</span>
+                  </label>
+                  <input id="modal-ep-orgbound-resource-client-id" type="text" bind:value={resourceClientId}
+                    placeholder="Resource (MAS) client ID"
+                    class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent)" />
+                  <p class="text-[11px] text-(--fg2) mt-0.5">
+                    Only for MCP servers that require a separate client at the Step-3 token exchange. Leave blank for everything else.
+                  </p>
+                </div>
+                <div>
+                  <label for="modal-ep-orgbound-resource-client-secret" class="block text-xs font-medium mb-1 text-(--fg2)">
+                    Resource Client Secret <span class="text-(--fg2)/50">(optional)</span>
+                  </label>
+                  <input id="modal-ep-orgbound-resource-client-secret" type="password" autocomplete="new-password" bind:value={resourceClientSecret}
+                    placeholder=""
+                    class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent)" />
+                  <p class="text-[11px] text-(--fg2) mt-0.5">
+                    Paired with the resource client ID. Stored in the owner-scoped credential directory, separate from <code>config.toml</code>.
+                  </p>
+                </div>
+              {/if}
+              {#if transport !== 'oauth'}
+                <div>
+                  <label for="modal-ep-server-type-override-generic" class="block text-xs font-medium mb-1 text-(--fg2)">Server type override <span class="text-(--fg2)/50">(optional)</span></label>
+                  <input
+                    id="modal-ep-server-type-override-generic"
+                    type="text"
+                    bind:value={serverTypeOverride}
+                    placeholder="e.g. my-server"
+                    maxlength={64}
+                    class="w-full text-sm px-3 py-1.5 rounded-lg border bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) {serverTypeOverrideInvalid || serverTypeOverrideTooLong ? 'border-(--offline)' : 'border-(--border)'}" />
+                  <p class="text-[11px] text-(--fg2) mt-0.5">Optional. Replaces the name this server reports to MCP clients. Max 64 characters.</p>
+                  {#if serverTypeOverridePreviewVisible}
+                    <p class="text-[11px] text-(--fg2) mt-0.5">Will be saved as: <code>{serverTypeOverrideSanitized}</code></p>
+                  {/if}
+                  {#if serverTypeOverrideInvalid}
+                    <p class="text-[11px] text-(--offline) mt-0.5">No usable characters — please include lowercase letters, digits, <code>-</code>, or <code>_</code>.</p>
+                  {/if}
+                  {#if serverTypeOverrideTooLong}
+                    <p class="text-[11px] text-(--offline) mt-0.5">Maximum 64 characters.</p>
+                  {/if}
+                </div>
+              {/if}
             </div>
           </details>
         {/if}
 
-        <!-- Test Connection (not shown for OAuth) -->
-        {#if transport !== 'oauth'}
+        <!-- Test Connection. Suppressed when:
+             - transport is `oauth` (per-server OAuth flow has its own probe), or
+             - `orgBound` is true on any transport (the org-managed EMA path
+               can't be exercised with just transport+url — the access token
+               only exists after add-time, once the org's IdP chain runs).
+             When org-bound, a short note replaces the button so the user
+             understands health is verified after adding. -->
+        {#if transport !== 'oauth' && !orgBound}
           <div class="flex items-center gap-2">
             <button
               type="button"
@@ -1562,6 +1654,10 @@
               {/if}
             {/if}
           </div>
+        {:else if orgBound}
+          <p class="text-[11px] text-(--fg2)">
+            Connection is verified via <strong>{selectedOrganization}</strong>'s shared credentials after you add the server.
+          </p>
         {/if}
 
         {#if error}

--- a/src/lib/components/AddEndpointModal.test.ts
+++ b/src/lib/components/AddEndpointModal.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import addEndpointModalSource from './AddEndpointModal.svelte?raw';
 import { sanitizeName } from '$lib/utils';
 import { CATALOG_SERVERS, type CatalogServer } from '$lib/catalog';
 import { oauthCatalog, type OAuthCatalogEntry } from '$lib/data/oauth-catalog';
@@ -733,6 +734,9 @@ describe('computeAddEndpointIsDirty', () => {
       clientId: '',
       clientSecret: '',
       scopes: '',
+      orgBoundScopes: '',
+      resourceClientId: '',
+      resourceClientSecret: '',
       serverTypeOverride: '',
       isolationEnabled: true,
       mounts: [],
@@ -767,6 +771,9 @@ describe('computeAddEndpointIsDirty', () => {
       'clientId',
       'clientSecret',
       'scopes',
+      'orgBoundScopes',
+      'resourceClientId',
+      'resourceClientSecret',
       'serverTypeOverride',
     ];
     for (const key of cases) {
@@ -1017,15 +1024,19 @@ describe('catalog containerizable flags', () => {
 });
 
 describe('orgBindingApplies', () => {
-  // EMA org-binding builds an http endpoint, so the Organization selector must
-  // be offered for http only — otherwise an sse/oauth selection would silently
-  // be converted to http by `buildOrgBoundEndpointParams`.
-  it('is true only for the http transport', () => {
+  // The relay only accepts EMA on http/oauth (watcher.rs:
+  // "EMA endpoint requires transport http or oauth"), and
+  // `buildOrgBoundEndpointParams` always emits an http EMA endpoint regardless
+  // of the chosen transport — so the Organization selector is safe to surface
+  // for both. sse carries no per-request headers (EMA can't inject Authorization)
+  // and stdio has no remote auth surface at all, so both stay excluded.
+  it('is true for the http and oauth transports', () => {
     expect(orgBindingApplies('http')).toBe(true);
+    expect(orgBindingApplies('oauth')).toBe(true);
   });
 
-  it('is false for sse, oauth, and stdio', () => {
-    for (const t of ['sse', 'oauth', 'stdio'] as const) {
+  it('is false for sse and stdio', () => {
+    for (const t of ['sse', 'stdio'] as const) {
       expect(orgBindingApplies(t)).toBe(false);
     }
   });
@@ -1085,6 +1096,183 @@ describe('buildOrgBoundEndpointParams', () => {
       description: '   ',
     });
     expect(blankDesc && 'description' in blankDesc).toBe(false);
+  });
+
+  // D3 — optional EMA scopes + resource pair (R3), settable at add-time.
+  // `scopes` stays on the POST `/endpoints` body (config.toml); the resource
+  // pair is stripped by `addEndpoint()` and POSTed to `/credentials` (DCR
+  // file). Blank/whitespace input omits each field entirely.
+  it('omits scopes / resource_client_id / resource_client_secret when no extras are supplied', () => {
+    const params = buildOrgBoundEndpointParams('Acme', {
+      name: 'My Server',
+      url: 'https://mcp.example.com/mcp',
+    });
+    expect(params && 'scopes' in params).toBe(false);
+    expect(params && 'resource_client_id' in params).toBe(false);
+    expect(params && 'resource_client_secret' in params).toBe(false);
+  });
+
+  it('includes scopes / resource_client_id / resource_client_secret when non-empty (trimmed)', () => {
+    const params = buildOrgBoundEndpointParams('Acme', {
+      name: 'My Server',
+      url: 'https://mcp.example.com/mcp',
+      scopes: '  todos.read   mcp.access  ',
+      resourceClientId: '  mas-client-abc  ',
+      resourceClientSecret: '  super-secret  ',
+    });
+    expect(params?.scopes).toBe('todos.read mcp.access');
+    expect(params?.resource_client_id).toBe('mas-client-abc');
+    expect(params?.resource_client_secret).toBe('super-secret');
+  });
+
+  it('omits each extra field independently when blank or whitespace-only', () => {
+    const params = buildOrgBoundEndpointParams('Acme', {
+      name: 'My Server',
+      url: 'https://mcp.example.com/mcp',
+      scopes: '   ',
+      resourceClientId: '',
+      resourceClientSecret: '\t\n  ',
+    });
+    expect(params && 'scopes' in params).toBe(false);
+    expect(params && 'resource_client_id' in params).toBe(false);
+    expect(params && 'resource_client_secret' in params).toBe(false);
+  });
+
+  it('still returns null when no organization is selected, even with extras supplied', () => {
+    expect(
+      buildOrgBoundEndpointParams('', {
+        name: 'My Server',
+        url: 'https://mcp.example.com/mcp',
+        scopes: 'todos.read',
+        resourceClientId: 'mas-client-abc',
+        resourceClientSecret: 'super-secret',
+      }),
+    ).toBeNull();
+  });
+
+  it('treats a partial extras set independently (scopes only, resource pair only)', () => {
+    const scopesOnly = buildOrgBoundEndpointParams('Acme', {
+      name: 'My Server',
+      url: 'https://mcp.example.com/mcp',
+      scopes: 'todos.read',
+    });
+    expect(scopesOnly?.scopes).toBe('todos.read');
+    expect(scopesOnly && 'resource_client_id' in scopesOnly).toBe(false);
+    expect(scopesOnly && 'resource_client_secret' in scopesOnly).toBe(false);
+
+    const resourceOnly = buildOrgBoundEndpointParams('Acme', {
+      name: 'My Server',
+      url: 'https://mcp.example.com/mcp',
+      resourceClientId: 'mas-client-abc',
+      resourceClientSecret: 'super-secret',
+    });
+    expect(resourceOnly && 'scopes' in resourceOnly).toBe(false);
+    expect(resourceOnly?.resource_client_id).toBe('mas-client-abc');
+    expect(resourceOnly?.resource_client_secret).toBe('super-secret');
+  });
+});
+
+// ── Test Connection suppression when org-bound ──
+//
+// When an org is selected, the EMA add-time path can't be exercised by a raw
+// transport+url probe — the access token only exists once the org's IdP chain
+// runs at add-time. Showing "Test Connection" would just return a misleading
+// 401, so it's hidden and replaced with a short post-add verification note.
+// Test environment is node (not jsdom), so the assertion is on the Svelte
+// source — mirrors the static-source style used elsewhere in this suite.
+describe('AddEndpointModal — Test Connection gating when org-bound', () => {
+  it('gates the Test Connection block on `transport !== "oauth" && !orgBound`', () => {
+    // The button only shows for non-oauth transports AND when no org is bound.
+    // The combined guard is what restores today's behavior when org is "None"
+    // (orgBound=false → the `!orgBound` branch passes → button visible).
+    expect(addEndpointModalSource).toMatch(/\{#if transport !== 'oauth' && !orgBound\}/);
+  });
+
+  it('replaces Test Connection with a post-add verification note when org-bound', () => {
+    // The `:else if orgBound` branch handles the http+orgBound case (oauth is
+    // already excluded by the outer guard) and explains the test is unavailable
+    // because verification happens via the org's shared credentials at add-time.
+    const replacementBlock = addEndpointModalSource.match(
+      /\{:else if orgBound\}[\s\S]*?Connection is verified via[\s\S]*?\{selectedOrganization\}[\s\S]*?after you add the server[\s\S]*?\{\/if\}/,
+    );
+    expect(replacementBlock, 'expected the org-bound replacement note for Test Connection').not.toBeNull();
+  });
+
+  it('renders the EMA outcome notice under an `{#if orgBound}` guard naming the selected org', () => {
+    // Shared notice rendered right after the org selector for both http and
+    // oauth selections, so the user sees the EMA endpoint outcome explicitly
+    // before submitting.
+    const noticeBlock = addEndpointModalSource.match(
+      /\{#if orgBound\}[\s\S]*?organization-managed \(EMA\) endpoint[\s\S]*?\{selectedOrganization\}[\s\S]*?shared credentials instead of its own OAuth[\s\S]*?\{\/if\}/,
+    );
+    expect(noticeBlock, 'expected the EMA outcome notice block').not.toBeNull();
+  });
+
+  // D3/D4 — The optional EMA Scopes + Resource Client ID/Secret inputs live
+  // inside the single consolidated Advanced <details>, gated on
+  // `{#if orgBound}` so they only appear once an org is actually selected.
+  // Each input is bound to its own local `$state` and threaded into
+  // `buildOrgBoundEndpointParams` on submit.
+  it('renders Scopes + Resource Client ID/Secret inputs guarded by `{#if orgBound}` inside the Advanced section', () => {
+    expect(addEndpointModalSource).toMatch(/id="modal-ep-orgbound-scopes"[\s\S]*?bind:value=\{orgBoundScopes\}/);
+    expect(addEndpointModalSource).toMatch(
+      /id="modal-ep-orgbound-resource-client-id"[\s\S]*?bind:value=\{resourceClientId\}/,
+    );
+    expect(addEndpointModalSource).toMatch(
+      /id="modal-ep-orgbound-resource-client-secret"[\s\S]*?type="password"[\s\S]*?bind:value=\{resourceClientSecret\}/,
+    );
+    // The EMA field group is nested inside the shared Advanced <details>
+    // gated on `{#if orgBound || transport !== 'oauth'}`.
+    expect(addEndpointModalSource).toMatch(
+      /\{#if orgBound \|\| transport !== 'oauth'\}[\s\S]*?<summary[^>]*>\s*Advanced\s*<\/summary>[\s\S]*?\{#if orgBound\}[\s\S]*?id="modal-ep-orgbound-scopes"/,
+    );
+  });
+
+  // D4 — After the org-bound EMA fields were folded into the pre-existing
+  // Server-type-override Advanced <details>, the http/stdio branch of the
+  // modal must have exactly ONE Advanced section, and the D3 duplicate
+  // Advanced <details> that used to live directly inside `{#if orgBound}`
+  // (sandwiching the URL/Env/Headers fields with a second Advanced summary)
+  // must no longer exist. The remaining Advanced <summary> occurrences in
+  // source are: (1) the per-server OAuth branch's Advanced (gated on
+  // `transport === 'oauth'` + `{#if !orgBound}` — never renders in the
+  // org-bound flow), and (2) the single consolidated Advanced gated on
+  // `{#if orgBound || transport !== 'oauth'}` that this task establishes.
+  it('no longer renders a duplicate Advanced <details> directly inside `{#if orgBound}` (D3 sandwich fix)', () => {
+    // The D3 layout put a full `<details>...Advanced...</details>` block
+    // directly under the `{#if orgBound}` guard, above the URL field. D4
+    // moves those fields into the consolidated Advanced further down, so
+    // no Advanced <summary> should appear between `{#if orgBound}` and the
+    // closing `{/if}` that ends the org-bound guarded block.
+    const orgBoundInnerBlock = addEndpointModalSource.match(
+      /\{#if orgBound\}\s*<!--\s*EMA outcome notice[\s\S]*?\{\/if\}/,
+    );
+    expect(orgBoundInnerBlock, 'expected the org-bound EMA notice block').not.toBeNull();
+    expect(orgBoundInnerBlock![0]).not.toMatch(/<summary[^>]*>\s*Advanced\s*<\/summary>/);
+  });
+
+  // D4 — Total Advanced <summary> occurrences in source are exactly 2:
+  // the per-server OAuth branch's Advanced (mutually exclusive with the
+  // org-bound branch via `{#if !orgBound}`) and the single consolidated
+  // Advanced. No third one may exist.
+  it('renders exactly two Advanced <summary> occurrences in source (per-server OAuth + consolidated)', () => {
+    const matches = addEndpointModalSource.match(/<summary[^>]*>\s*Advanced\s*<\/summary>/g) ?? [];
+    expect(matches.length).toBe(2);
+  });
+
+  it('keeps per-server OAuth fields under a `{#if !orgBound}` guard on the oauth transport', () => {
+    // The per-server OAuth fields (scopes, client ID/secret, etc.) are
+    // unused on the EMA path, so they're hidden when an org is bound. The
+    // outer oauth-transport branch wraps them in `{#if !orgBound}`.
+    expect(addEndpointModalSource).toMatch(/\{#if !orgBound\}[\s\S]*?Per-server OAuth fields are dropped/);
+  });
+
+  it('routes the submit button to handleSubmit (EMA path) when org-bound, bypassing handleOAuthSubmit', () => {
+    // Even on the oauth transport, an org-bound submit must go through
+    // `handleSubmit` → `buildOrgBoundEndpointParams` → plain EMA add.
+    expect(addEndpointModalSource).toMatch(
+      /onclick=\{transport === 'oauth' && !orgBound \? handleOAuthSubmit : \(\) => handleSubmit\(\)\}/,
+    );
   });
 });
 

--- a/src/lib/components/ConfigTab.svelte
+++ b/src/lib/components/ConfigTab.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getEndpointConfig, updateEndpoint, getEndpoints, getStatus, type UpdateEndpointParams } from '$lib/api';
+  import { getEndpointConfig, updateEndpoint, getEndpoints, getStatus, type UpdateEndpointParams, type EmaAuthConfig } from '$lib/api';
   import { selectedEndpoint, endpoints, selectedEndpointData } from '$lib/stores';
   import { registerDirtyChecker } from '$lib/stores/unsavedChangesGuard';
   import {
@@ -41,6 +41,14 @@
   // this state — the backend exposes only `client_secret_set: boolean`.
   let clientSecret = $state('');
   let clientSecretSet = $state(false);
+  // EMA resource (Step-3 MAS) pairing credential (R3), stored per-endpoint. The
+  // id is not a secret, so its stored value is loaded and editable; emptying it
+  // sends "" to clear. The secret is write-only — blank keeps the stored value,
+  // the "clear" toggle sends "" to drop it, and a typed value sets a new one.
+  let resourceClientId = $state('');
+  let resourceClientSecret = $state('');
+  let resourceClientSecretSet = $state(false);
+  let clearResourceSecret = $state(false);
   let scopes = $state('');
   // Optional override that replaces the upstream-reported server name in the
   // relay's connected-servers advertisement.
@@ -75,6 +83,19 @@
   // Volume mounts (stdio + container isolation only), seeded from the stored
   // `mounts` array. Mirrors the env-var editor; serialized on save.
   let mountRows: MountRow[] = $state([]);
+  // EMA org-binding mirrored from the persisted `[endpoints.auth]` sub-table.
+  // Display-only in this form (the binding is configured via Add Server), but
+  // round-tripped back on save so the relay's PUT — which rebuilds the whole
+  // endpoint config from the body — doesn't drop the binding. Null/undefined
+  // for ordinary (non-EMA) endpoints, in which case no `auth` key is sent.
+  let loadedAuth = $state<EmaAuthConfig | null>(null);
+  let emaOrganization = $derived(
+    loadedAuth?.type === 'ema' ? loadedAuth.organization ?? '' : ''
+  );
+  let emaResource = $derived(
+    loadedAuth?.type === 'ema' ? loadedAuth.resource ?? '' : ''
+  );
+  let showEmaBinding = $derived(loadedAuth?.type === 'ema');
   // The mount section only applies when the endpoint runs in a container.
   let showMounts = $derived(transport === 'stdio' && isolationEnabled);
   // Resolved user home directory, used to build a valid absolute-path mount
@@ -114,6 +135,7 @@
   let originalHeaderVars = $state('[]');
   let originalOauthServerUrl = $state('');
   let originalClientId = $state('');
+  let originalResourceClientId = $state('');
   let originalScopes = $state('');
   let originalServerTypeOverride = $state('');
   let originalIsolationEnabled = $state(false);
@@ -136,6 +158,7 @@
     originalHeaderVars = JSON.stringify(headerVars);
     originalOauthServerUrl = oauthServerUrl;
     originalClientId = clientId;
+    originalResourceClientId = resourceClientId.trim();
     originalScopes = scopes;
     originalServerTypeOverride = serverTypeOverride;
     originalIsolationEnabled = isolationEnabled;
@@ -148,6 +171,9 @@
   // The secret field is dirty only when the user has actually typed
   // something — the displayed placeholder/mask never counts as a change.
   let clientSecretDirty = $derived(clientSecret.trim().length > 0);
+  // The resource secret is dirty only when typed — the masked placeholder and
+  // the "clear" toggle are tracked separately below.
+  let resourceClientSecretDirty = $derived(resourceClientSecret.trim().length > 0);
 
   let isDirty = $derived(
     name !== originalName ||
@@ -166,7 +192,10 @@
     scopes !== originalScopes ||
     serverTypeOverride !== originalServerTypeOverride ||
     isolationEnabled !== originalIsolationEnabled ||
-    JSON.stringify(mountRows) !== originalMountRows
+    JSON.stringify(mountRows) !== originalMountRows ||
+    resourceClientId.trim() !== originalResourceClientId ||
+    resourceClientSecretDirty ||
+    clearResourceSecret
   );
 
   // Register a dirty-checker with the shared navigation guard so that any
@@ -226,10 +255,17 @@
         // the user is never able to read or accidentally re-submit it.
         clientSecret = '';
         clientSecretSet = config.client_secret_set ?? false;
+        // EMA resource creds (R3): the id is returned and editable; the secret
+        // is never returned, so we track only whether one is stored.
+        resourceClientId = config.resource_client_id ?? '';
+        resourceClientSecret = '';
+        resourceClientSecretSet = config.resource_client_secret_set ?? false;
+        clearResourceSecret = false;
         scopes = config.scopes ?? '';
         serverTypeOverride = config.server_type_override ?? '';
         isolationEnabled = isolationEnabledFromConfig(config.isolation);
         mountRows = parseMountRows(config.mounts);
+        loadedAuth = config.auth ?? null;
         snapshotOriginals();
       })
       .catch(() => {
@@ -329,6 +365,31 @@
     // typed mixed-case or whitespace.
     params.server_type_override = sanitizeName(serverTypeOverride);
 
+    // Round-trip the EMA org-binding (`[endpoints.auth]`) verbatim. The
+    // relay's PUT rebuilds the whole endpoint config from the body, so
+    // omitting `auth` would silently drop the stored binding. Non-EMA
+    // endpoints leave `loadedAuth` null and no `auth` key is sent — the PUT
+    // body stays byte-for-byte unchanged in that case.
+    if (loadedAuth) {
+      params.auth = loadedAuth;
+    }
+
+    // EMA resource (Step-3 MAS) credential (R3), persisted per-endpoint via the
+    // /credentials route. Only for EMA endpoints. `resource_client_id` is sent
+    // whenever it changed (emptied = clear, typed = set); the write-only secret
+    // is sent on an explicit clear ("") or when the user typed a new value.
+    if (showEmaBinding) {
+      const trimmedResourceClientId = resourceClientId.trim();
+      if (trimmedResourceClientId !== originalResourceClientId) {
+        params.resource_client_id = trimmedResourceClientId;
+      }
+      if (clearResourceSecret) {
+        params.resource_client_secret = '';
+      } else if (resourceClientSecretDirty) {
+        params.resource_client_secret = resourceClientSecret.trim();
+      }
+    }
+
     saving = true;
     try {
       await updateEndpoint(params);
@@ -350,6 +411,15 @@
         clientSecretSet = true;
       }
       clientSecret = '';
+      // Reflect resource-cred changes in the masked state, then reset inputs so
+      // the secret field returns to its placeholder and the clear toggle resets.
+      if (params.resource_client_secret) {
+        resourceClientSecretSet = true;
+      } else if (clearResourceSecret) {
+        resourceClientSecretSet = false;
+      }
+      resourceClientSecret = '';
+      clearResourceSecret = false;
       snapshotOriginals();
       success = 'Configuration saved';
       setTimeout(() => { success = ''; }, 3000);
@@ -432,6 +502,61 @@
           <input id="config-ep-desc" type="text" bind:value={description} placeholder="Brief description of this server"
             class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent)" />
         </div>
+
+        <!-- EMA org-binding (read-only). Shown only for endpoints whose
+             `[endpoints.auth]` block is `type = "ema"`; the binding itself is
+             configured via Add Server and is preserved on save. -->
+        {#if showEmaBinding}
+          <div>
+            <span class="block text-xs font-medium mb-1 text-(--fg2)">Organization</span>
+            <div
+              class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface)/50 text-(--fg1)"
+              data-testid="config-ep-ema-organization"
+            >
+              {emaOrganization || '(unbound)'}
+            </div>
+            {#if emaResource}
+              <p class="text-[11px] text-(--fg2) mt-0.5">Resource: <code>{emaResource}</code></p>
+            {/if}
+            <p class="text-[11px] text-(--fg2) mt-0.5">
+              This server authenticates via the organization's shared sign-in. Change the binding by removing and re-adding the server.
+            </p>
+          </div>
+
+          <!-- EMA resource (Step-3 MAS) pairing credential (R3), stored
+               per-endpoint. Only for xaa.dev/Okta-style MASes that require a
+               distinct client at the ID-JAG redemption; blank for everything
+               else. The id is editable; the secret is write-only. -->
+          <div>
+            <label for="config-ep-resource-client-id" class="block text-xs font-medium mb-1 text-(--fg2)">
+              Resource Client ID <span class="text-(--fg2)/50">(optional)</span>
+            </label>
+            <input id="config-ep-resource-client-id" type="text" bind:value={resourceClientId}
+              placeholder="Resource (MAS) client ID"
+              class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent)" />
+            <p class="text-[11px] text-(--fg2) mt-0.5">
+              Only for MCP servers that require a separate client at the Step-3 token exchange. Leave blank for everything else.
+            </p>
+          </div>
+          <div>
+            <label for="config-ep-resource-client-secret" class="block text-xs font-medium mb-1 text-(--fg2)">
+              Resource Client Secret <span class="text-(--fg2)/50">(optional)</span>
+            </label>
+            <input id="config-ep-resource-client-secret" type="password" autocomplete="new-password" bind:value={resourceClientSecret}
+              placeholder={resourceClientSecretSet ? '•••••••• (stored — type to replace)' : ''}
+              disabled={clearResourceSecret}
+              class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) disabled:opacity-50" />
+            {#if resourceClientSecretSet}
+              <label class="flex items-center gap-1.5 text-[11px] text-(--fg2) mt-1 cursor-pointer">
+                <input type="checkbox" class="accent-(--accent)" bind:checked={clearResourceSecret} />
+                Clear stored resource client secret
+              </label>
+            {/if}
+            <p class="text-[11px] text-(--fg2) mt-0.5">
+              Paired with the resource client ID. Stored in the owner-scoped credential directory, separate from <code>config.toml</code>.
+            </p>
+          </div>
+        {/if}
 
         {#if transport === 'stdio'}
           <div>

--- a/src/lib/components/ConnectOrgModal.svelte
+++ b/src/lib/components/ConnectOrgModal.svelte
@@ -20,6 +20,7 @@
     addEndpointsWithRefresh,
     startOrgConnection,
     isAlreadyInstalled,
+    pollForOrgAuth,
     type OnboardingCandidate,
   } from './onboarding-helpers';
   import { endpoints, relayPort } from '$lib/stores';
@@ -42,6 +43,8 @@
   let orgName = $state('');
   let slugOrUrl = $state('');
   let clientId = $state('');
+  // Write-only; never echoed back. Cleared on cancel/submit failure.
+  let clientSecret = $state('');
   let error = $state('');
   let submitting = $state(false);
 
@@ -120,7 +123,13 @@
       return;
     }
 
-    const params = buildCreateOrgParams(selectedProvider, name, slugOrUrl, clientId);
+    const params = buildCreateOrgParams(
+      selectedProvider,
+      name,
+      slugOrUrl,
+      clientId,
+      clientSecret,
+    );
     submitting = true;
     try {
       const res = await startOrgConnection(params, { createOrganization, openUrl });
@@ -141,35 +150,29 @@
     }
   }
 
-  // Poll the org list until the relay reports the org as authenticated (the IdP
-  // callback has landed) or the budget elapses. ~2s interval, ~120s budget.
+  // Wait for the relay to report the org as authenticated (IdP callback
+  // landed) via the shared `pollForOrgAuth` helper, then republish the org
+  // list and advance to detection. Timeout drops back to the provider step.
   async function pollForAuth(name: string) {
     pollCancelled = false;
-    const deadline = Date.now() + 120_000;
-    while (Date.now() < deadline) {
-      await new Promise((r) => setTimeout(r, 2000));
-      if (pollCancelled) return;
-      try {
-        const orgs = await listOrganizations();
-        const org = orgs.find((o) => o.name === name);
-        if (org?.authenticated) {
-          // Sign-in landed: republish so Settings flips the org to "Connected".
-          try {
-            await refreshOrganizations();
-          } catch {
-            // Non-fatal; the Settings mount poll reconciles later.
-          }
-          await runProbe(name);
-          return;
-        }
-      } catch {
-        // transient — keep polling
-      }
-    }
-    if (!pollCancelled) {
+    const outcome = await pollForOrgAuth(
+      name,
+      { listOrganizations },
+      { shouldCancel: () => pollCancelled },
+    );
+    if (outcome.status === 'cancelled') return;
+    if (outcome.status === 'timeout') {
       error = 'Sign-in timed out. Please try again.';
       step = 'provider';
+      return;
     }
+    // Sign-in landed: republish so Settings flips the org to "Connected".
+    try {
+      await refreshOrganizations();
+    } catch {
+      // Non-fatal; the Settings mount poll reconciles later.
+    }
+    await runProbe(name);
   }
 
   async function runProbe(name: string) {
@@ -320,6 +323,24 @@
             <p class="text-[11px] text-(--fg2) mt-0.5">
               Required for Okta/Entra. The IdP app must whitelist
               <code>http://127.0.0.1:{$relayPort}/oauth/callback</code>.
+            </p>
+          </div>
+
+          <div>
+            <label for="org-client-secret" class="block text-xs font-medium mb-1 text-(--fg2)">
+              Client Secret <span class="text-(--fg2)/60">(optional)</span>
+            </label>
+            <input
+              id="org-client-secret"
+              type="password"
+              autocomplete="new-password"
+              bind:value={clientSecret}
+              placeholder="Pre-registered IdP client secret"
+              class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent)"
+            />
+            <p class="text-[11px] text-(--fg2) mt-0.5">
+              Required for confidential Okta/Entra/custom IdP apps that issue a secret. Stored in
+              owner-scoped credential directory, separate from <code>config.toml</code>.
             </p>
           </div>
         </div>

--- a/src/lib/components/EditOrganizationModal.svelte
+++ b/src/lib/components/EditOrganizationModal.svelte
@@ -91,6 +91,20 @@
         return;
       }
     }
+    // Switching between two templated providers (e.g. okta → ping) needs a
+    // fresh slug — the relay stores the FULL issuer and can't reverse a slug
+    // from the previous provider's URL. Without this guard we'd send
+    // `provider` alone and the relay would rebuild an issuer using an empty
+    // slug. Mirrors the create-flow requirement in `buildCreateOrgParams`.
+    if (
+      selectedProvider &&
+      providerNeedsSlug(selectedProvider) &&
+      providerId !== org.provider &&
+      !slugOrUrl.trim()
+    ) {
+      error = 'Enter the organization slug for the new provider.';
+      return;
+    }
     submitting = true;
     try {
       const res = await updateOrganization(org.name, buildParams());

--- a/src/lib/components/EditOrganizationModal.svelte
+++ b/src/lib/components/EditOrganizationModal.svelte
@@ -1,0 +1,255 @@
+<script lang="ts">
+  import {
+    getIdpProviders,
+    updateOrganization,
+    updateRequiresReauth,
+    type UpdateOrganizationParams,
+  } from '$lib/api';
+  import type { IdpProvider, Organization } from '$lib/types';
+  import { isCustomProvider, providerNeedsSlug } from './onboarding-helpers';
+  import { focusTrap } from '$lib/actions/focusTrap';
+  import { openUrl } from '@tauri-apps/plugin-opener';
+  import { refreshOrganizations } from '$lib/stores/organizations';
+  import { toast } from 'svelte-sonner';
+
+  let { org, onclose }: { org: Organization; onclose: () => void } = $props();
+
+  let providers: IdpProvider[] = $state([]);
+  let providersError = $state('');
+  // The modal is mounted per-edit so `org` is the desired initial snapshot;
+  // we don't want to re-derive when the parent's store row updates.
+  // svelte-ignore state_referenced_locally
+  let providerId = $state(org.provider);
+  // svelte-ignore state_referenced_locally
+  let name = $state(org.name);
+  // For templated providers the relay stores the FULL issuer (we can't reverse
+  // a slug). Leave the slug field blank — submitting blank preserves the
+  // current issuer; entering a new slug rebuilds it on the relay.
+  let slugOrUrl = $state('');
+  // The relay's org listing does not expose `client_id`, so this field starts
+  // blank. Blank = preserve current; toggling `clearClientId` sends `""` so the
+  // relay drops the persisted id (next resolution falls back to CIMD/DCR).
+  let clientId = $state('');
+  let clearClientId = $state(false);
+  // Write-only. Blank = preserve current; "clearSecret" toggle = delete.
+  let clientSecret = $state('');
+  let clearSecret = $state(false);
+  let error = $state('');
+  let submitting = $state(false);
+
+  let selectedProvider = $derived(providers.find((p) => p.id === providerId) ?? null);
+  let needsField = $derived(
+    !!selectedProvider &&
+      (isCustomProvider(selectedProvider) || providerNeedsSlug(selectedProvider)),
+  );
+
+  getIdpProviders()
+    .then((p) => {
+      providers = p;
+    })
+    .catch(() => {
+      providersError = 'Failed to load providers';
+    });
+
+  function buildParams(): UpdateOrganizationParams {
+    const params: UpdateOrganizationParams = {};
+    const trimmedName = name.trim();
+    if (trimmedName && trimmedName !== org.name) params.name = trimmedName;
+    if (providerId && providerId !== org.provider) params.provider = providerId;
+    const trimmedField = slugOrUrl.trim();
+    if (trimmedField && selectedProvider) {
+      if (isCustomProvider(selectedProvider)) params.idp = trimmedField;
+      else if (providerNeedsSlug(selectedProvider)) params.slug = trimmedField;
+    }
+    // Client id: clearClientId wins ("" → drop). Otherwise blank preserves
+    // the current value; a non-empty trimmed value sets a new id.
+    if (clearClientId) params.client_id = '';
+    else {
+      const trimmedClientId = clientId.trim();
+      if (trimmedClientId) params.client_id = trimmedClientId;
+    }
+    // Client secret: clearSecret wins ("" → delete); blank preserves the
+    // current value; a non-empty trimmed value sets a new secret.
+    if (clearSecret) params.client_secret = '';
+    else {
+      const trimmedSecret = clientSecret.trim();
+      if (trimmedSecret) params.client_secret = trimmedSecret;
+    }
+    return params;
+  }
+
+  async function handleSave() {
+    error = '';
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      error = 'Enter an organization name.';
+      return;
+    }
+    if (selectedProvider && isCustomProvider(selectedProvider) && providerId !== org.provider) {
+      if (!slugOrUrl.trim()) {
+        error = 'Enter the issuer URL for the new provider.';
+        return;
+      }
+    }
+    submitting = true;
+    try {
+      const res = await updateOrganization(org.name, buildParams());
+      try {
+        await refreshOrganizations();
+      } catch {
+        // Settings mount poll reconciles later.
+      }
+      if (updateRequiresReauth(res)) {
+        await openUrl(res.authorize_url);
+        toast.success(`Browser opened to re-authenticate ${res.name}`);
+      } else {
+        toast.success(`Updated ${res.name}`);
+      }
+      onclose();
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e);
+    } finally {
+      submitting = false;
+    }
+  }
+
+  function handleCancel() {
+    onclose();
+  }
+</script>
+
+<div
+  class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+  role="presentation"
+  onclick={handleCancel}
+>
+  <div
+    class="bg-(--surface) rounded-xl shadow-xl border border-(--border) p-6 w-[34rem] max-w-[90vw] max-h-[90vh] overflow-y-auto"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Edit organization"
+    tabindex="-1"
+    use:focusTrap={{ onEscape: handleCancel }}
+    onclick={(e) => e.stopPropagation()}
+    onkeydown={(e) => e.stopPropagation()}
+  >
+    <h3 class="text-base font-semibold mb-1 text-(--fg1)">Edit organization</h3>
+    <p class="text-xs text-(--fg2) mb-4">
+      Changing the name, provider, issuer, or client ID requires re-authenticating with the IdP.
+    </p>
+
+    {#if providersError}
+      <p class="text-xs text-(--offline) mb-3">{providersError}</p>
+    {/if}
+
+    <div class="space-y-3">
+      <div>
+        <label for="edit-org-name" class="block text-xs font-medium mb-1 text-(--fg2)">
+          Organization name
+        </label>
+        <input
+          id="edit-org-name"
+          type="text"
+          bind:value={name}
+          class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent)"
+        />
+      </div>
+
+      <div>
+        <label for="edit-org-provider" class="block text-xs font-medium mb-1 text-(--fg2)">
+          Provider
+        </label>
+        <select
+          id="edit-org-provider"
+          bind:value={providerId}
+          class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface) text-(--fg1) focus:outline-none focus:border-(--accent)"
+        >
+          {#each providers as p (p.id)}
+            <option value={p.id}>{p.name}</option>
+          {/each}
+        </select>
+      </div>
+
+
+      {#if needsField && selectedProvider}
+        <div>
+          <label for="edit-org-slug" class="block text-xs font-medium mb-1 text-(--fg2)">
+            {isCustomProvider(selectedProvider) ? 'Issuer URL' : 'Organization slug'}
+            <span class="text-(--fg2)/60">(leave blank to keep current)</span>
+          </label>
+          <input
+            id="edit-org-slug"
+            type="text"
+            bind:value={slugOrUrl}
+            placeholder={isCustomProvider(selectedProvider) ? org.idp : selectedProvider.slug_hint ?? 'your-org'}
+            class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent)"
+          />
+          <p class="text-[11px] text-(--fg2) mt-0.5">
+            Current issuer: <code>{org.idp}</code>
+          </p>
+        </div>
+      {/if}
+
+      <div>
+        <label for="edit-org-client-id" class="block text-xs font-medium mb-1 text-(--fg2)">
+          Client ID <span class="text-(--fg2)/60">(leave blank to keep current)</span>
+        </label>
+        <input
+          id="edit-org-client-id"
+          type="text"
+          bind:value={clientId}
+          placeholder="Pre-registered IdP client ID"
+          disabled={clearClientId}
+          class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) disabled:opacity-50"
+        />
+        <label class="flex items-center gap-1.5 text-[11px] text-(--fg2) mt-1 cursor-pointer">
+          <input type="checkbox" class="accent-(--accent)" bind:checked={clearClientId} />
+          Clear stored client ID
+        </label>
+      </div>
+
+      <div>
+        <label for="edit-org-client-secret" class="block text-xs font-medium mb-1 text-(--fg2)">
+          Client Secret <span class="text-(--fg2)/60">(leave blank to keep current)</span>
+        </label>
+        <input
+          id="edit-org-client-secret"
+          type="password"
+          autocomplete="new-password"
+          bind:value={clientSecret}
+          placeholder={org.client_secret_set ? 'A secret is stored — type to replace' : 'Pre-registered IdP client secret'}
+          disabled={clearSecret}
+          class="w-full text-sm px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface) text-(--fg1) placeholder:text-(--fg2)/50 focus:outline-none focus:border-(--accent) disabled:opacity-50"
+        />
+        <label class="flex items-center gap-1.5 text-[11px] text-(--fg2) mt-1 cursor-pointer">
+          <input type="checkbox" class="accent-(--accent)" bind:checked={clearSecret} />
+          Clear stored client secret
+        </label>
+        <p class="text-[11px] text-(--fg2) mt-0.5">
+          Required for confidential Okta/Entra/custom IdP apps that issue a secret. Stored in
+          owner-scoped credential directory, separate from <code>config.toml</code>.
+        </p>
+      </div>
+    </div>
+
+    {#if error}
+      <p class="text-xs text-(--offline) mt-3">{error}</p>
+    {/if}
+
+    <div class="flex justify-end gap-2 pt-4">
+      <button
+        class="px-3 py-1.5 text-sm rounded-lg border border-(--border) hover:bg-(--surface-hover) transition-colors"
+        onclick={handleCancel}
+      >
+        Cancel
+      </button>
+      <button
+        class="px-3 py-1.5 text-sm rounded-lg bg-(--accent) text-white hover:opacity-90 transition-opacity disabled:opacity-60 disabled:cursor-not-allowed"
+        onclick={handleSave}
+        disabled={submitting}
+      >
+        {submitting ? 'Saving…' : 'Save'}
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/lib/components/OrgExpiryBanner.svelte
+++ b/src/lib/components/OrgExpiryBanner.svelte
@@ -80,7 +80,7 @@
 {#if message}
   <div
     role="alert"
-    class="fixed top-0 left-0 right-0 z-50 border-b border-(--degraded) bg-(--degraded)/10 text-(--fg1) px-4 py-2 flex items-center gap-3"
+    class="shrink-0 border-b border-(--degraded) bg-(--degraded)/10 text-(--fg1) px-4 py-2 flex items-center gap-3"
   >
     <span
       class="shrink-0 w-2 h-2 rounded-full bg-(--degraded)"

--- a/src/lib/components/OrgExpiryBanner.svelte
+++ b/src/lib/components/OrgExpiryBanner.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import { listOrganizations, reauthenticateOrganization } from '$lib/api';
+  import { organizations, refreshOrganizations } from '$lib/stores/organizations';
+  import { activeTopLevelTab } from '$lib/stores';
+  import {
+    orgExpiryBannerMessage,
+    pollForOrgAuth,
+    reauthenticateOrg,
+    unauthenticatedOrgs,
+  } from './onboarding-helpers';
+  import { openUrl } from '@tauri-apps/plugin-opener';
+  import { toast } from 'svelte-sonner';
+
+  // Global banner — appears at the very top of the app whenever one or more
+  // orgs report `authenticated: false` (the relay computes this from the
+  // stored ID token's expiry). Auto-dismisses once the store flips back to
+  // authenticated after a successful re-auth. The app-wide poll in
+  // `+layout.svelte` keeps the store fresh regardless of which screen is
+  // open, so users don't have to open Settings to notice an expiry.
+  const stale = $derived(unauthenticatedOrgs($organizations));
+  const message = $derived(orgExpiryBannerMessage($organizations));
+  const single = $derived(stale.length === 1 ? stale[0] : null);
+
+  let busy = $state<string | null>(null);
+
+  // Background re-auth polls keyed by org name — mirrors OrganizationsSection.
+  // A repeat click cancels the prior poll for that org, and `onDestroy`
+  // cancels all outstanding polls so no timers leak past unmount.
+  const activeReauthPolls = new Map<string, { cancelled: boolean }>();
+
+  function cancelReauthPoll(name: string) {
+    const token = activeReauthPolls.get(name);
+    if (token) {
+      token.cancelled = true;
+      activeReauthPolls.delete(name);
+    }
+  }
+
+  onDestroy(() => {
+    for (const token of activeReauthPolls.values()) token.cancelled = true;
+    activeReauthPolls.clear();
+  });
+
+  async function handleReauth(name: string) {
+    busy = name;
+    try {
+      await reauthenticateOrg(name, { reauthenticateOrganization, openUrl });
+      toast.success(`Browser opened to re-authenticate ${name}`);
+      cancelReauthPoll(name);
+      const token = { cancelled: false };
+      activeReauthPolls.set(name, token);
+      void (async () => {
+        const outcome = await pollForOrgAuth(
+          name,
+          { listOrganizations },
+          { shouldCancel: () => token.cancelled },
+        );
+        if (activeReauthPolls.get(name) === token) activeReauthPolls.delete(name);
+        if (outcome.status === 'authenticated') {
+          try {
+            await refreshOrganizations();
+          } catch {
+            // Non-fatal; the layout poll reconciles later.
+          }
+        }
+      })();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
+    } finally {
+      busy = null;
+    }
+  }
+
+  function goToSettings() {
+    activeTopLevelTab.set('settings');
+  }
+</script>
+
+{#if message}
+  <div
+    role="alert"
+    class="fixed top-0 left-0 right-0 z-50 border-b border-(--degraded) bg-(--degraded)/10 text-(--fg1) px-4 py-2 flex items-center gap-3"
+  >
+    <span
+      class="shrink-0 w-2 h-2 rounded-full bg-(--degraded)"
+      aria-hidden="true"
+    ></span>
+    <span class="text-xs font-medium truncate">{message}</span>
+    <div class="ml-auto shrink-0">
+      {#if single}
+        <button
+          class="px-2.5 py-1 text-xs rounded-lg border border-(--degraded) text-(--fg1) hover:bg-(--degraded)/20 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+          onclick={() => handleReauth(single.name)}
+          disabled={busy === single.name}
+        >
+          Re-authenticate
+        </button>
+      {:else}
+        <button
+          class="px-2.5 py-1 text-xs rounded-lg border border-(--degraded) text-(--fg1) hover:bg-(--degraded)/20 transition-colors"
+          onclick={goToSettings}
+        >
+          Open Settings
+        </button>
+      {/if}
+    </div>
+  </div>
+{/if}

--- a/src/lib/components/OrganizationsSection.svelte
+++ b/src/lib/components/OrganizationsSection.svelte
@@ -1,15 +1,18 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
   import {
     deleteOrganization,
+    listOrganizations,
     reauthenticateOrganization,
   } from '$lib/api';
   import { organizations, refreshOrganizations } from '$lib/stores/organizations';
-  import { orgStatusLabel, reauthenticateOrg } from './onboarding-helpers';
+  import { orgStatusLabel, pollForOrgAuth, reauthenticateOrg } from './onboarding-helpers';
   import { openUrl } from '@tauri-apps/plugin-opener';
   import { toast } from 'svelte-sonner';
   import ConfirmModal from './ConfirmModal.svelte';
   import ConnectOrgModal from './ConnectOrgModal.svelte';
+  import EditOrganizationModal from './EditOrganizationModal.svelte';
+  import type { Organization } from '$lib/types';
 
   let loading = $state(true);
   let error = $state('');
@@ -17,6 +20,22 @@
   let pendingRemove: string | null = $state(null);
   // Org name being re-detected (opens ConnectOrgModal in re-detect mode).
   let redetectOrg: string | null = $state(null);
+  // Org being edited (opens EditOrganizationModal). Snapshot of the row at the
+  // moment the user clicked Edit so the modal works on a stable shape.
+  let editingOrg: Organization | null = $state(null);
+
+  // Background re-auth polls keyed by org name. A repeat click cancels the
+  // prior poll for that org, and `onDestroy` cancels all outstanding polls so
+  // no timers leak past unmount.
+  const activeReauthPolls = new Map<string, { cancelled: boolean }>();
+
+  function cancelReauthPoll(name: string) {
+    const token = activeReauthPolls.get(name);
+    if (token) {
+      token.cancelled = true;
+      activeReauthPolls.delete(name);
+    }
+  }
 
   async function loadOrgs() {
     loading = true;
@@ -32,12 +51,38 @@
 
   onMount(loadOrgs);
 
+  onDestroy(() => {
+    for (const token of activeReauthPolls.values()) token.cancelled = true;
+    activeReauthPolls.clear();
+  });
+
   async function handleReauth(name: string) {
     busy = name;
     try {
       await reauthenticateOrg(name, { reauthenticateOrganization, openUrl });
-      await refreshOrganizations();
       toast.success(`Browser opened to re-authenticate ${name}`);
+      // Restart any prior poll for this org so a second click doesn't leave
+      // the previous timer running.
+      cancelReauthPoll(name);
+      const token = { cancelled: false };
+      activeReauthPolls.set(name, token);
+      // Poll runs in the background so the per-row `busy` indicator clears
+      // as soon as the browser opens (matching the initial-connect UX).
+      void (async () => {
+        const outcome = await pollForOrgAuth(
+          name,
+          { listOrganizations },
+          { shouldCancel: () => token.cancelled },
+        );
+        if (activeReauthPolls.get(name) === token) activeReauthPolls.delete(name);
+        if (outcome.status === 'authenticated') {
+          try {
+            await refreshOrganizations();
+          } catch {
+            // Non-fatal; the mount reload reconciles later.
+          }
+        }
+      })();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : String(e));
     } finally {
@@ -102,6 +147,14 @@
             </button>
             <button
               class="px-2.5 py-1 text-xs rounded-lg border border-(--border) hover:bg-(--surface-hover) transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+              onclick={() => (editingOrg = org)}
+              disabled={busy === org.name}
+              title="Edit organization name, provider, or credentials"
+            >
+              Edit
+            </button>
+            <button
+              class="px-2.5 py-1 text-xs rounded-lg border border-(--border) hover:bg-(--surface-hover) transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
               onclick={() => handleReauth(org.name)}
               disabled={busy === org.name}
             >
@@ -123,6 +176,10 @@
 
 {#if redetectOrg}
   <ConnectOrgModal redetectOrg={redetectOrg} onclose={() => { redetectOrg = null; }} />
+{/if}
+
+{#if editingOrg}
+  <EditOrganizationModal org={editingOrg} onclose={() => { editingOrg = null; }} />
 {/if}
 
 {#if pendingRemove}

--- a/src/lib/components/add-endpoint-helpers.ts
+++ b/src/lib/components/add-endpoint-helpers.ts
@@ -108,14 +108,19 @@ export function resolveIsolation(
 
 /**
  * Whether the EMA Organization selector applies to the custom add flow for a
- * given transport. Only the plain `http` transport qualifies: EMA endpoints are
- * http by construction (`buildOrgBoundEndpointParams` builds an `http` endpoint
- * whose EMA `resource` is the server URL), so offering org-binding for
- * `sse`/`oauth`/`stdio` would let a non-http selection silently create an http
- * endpoint. The caller still applies the catalog/OAuth-entry guards.
+ * given transport. The relay only accepts EMA on `http` or `oauth` transports
+ * (`watcher.rs`: "EMA endpoint requires transport http or oauth"), and EMA
+ * endpoints are built as `http` by construction
+ * (`buildOrgBoundEndpointParams` builds an `http` endpoint whose EMA `resource`
+ * is the server URL) — so offering the selector under `oauth` is safe (it just
+ * routes the org-bound add through the same EMA `http` path, dropping the
+ * per-server OAuth setup). `sse` and `stdio` stay excluded: SSE carries no
+ * per-request headers so EMA can't inject the Authorization header, and stdio
+ * has no remote auth surface at all. The caller still applies the catalog /
+ * OAuth-entry guards.
  */
 export function orgBindingApplies(transport: AddEndpointTransport): boolean {
-  return transport === 'http';
+  return transport === 'http' || transport === 'oauth';
 }
 
 /**
@@ -283,10 +288,26 @@ export function validateAddEndpointForm(input: AddEndpointFormInput): AddEndpoin
  * `auth.type="ema"` block whose `resource` is the server URL the minted access
  * token is scoped to. The URL is required (it becomes the `resource`); the name
  * is still required by the caller's own form validation.
+ *
+ * Optional `scopes` / `resourceClientId` / `resourceClientSecret` mirror the
+ * D2 Config-tab fields and are included on the returned params **only when
+ * non-empty after trim**. `scopes` stays on the POST `/endpoints` body (lands
+ * in the endpoint's `config.toml` and drives R2's IdP scope on first sign-in);
+ * the resource pair is stripped by `addEndpoint()` and POSTed to
+ * `/api/endpoints/{name}/credentials` (DCR file, chmod 0600), never in
+ * `config.toml`. Blank/whitespace input for any of the three behaves exactly
+ * as the no-extras path (field omitted entirely).
  */
 export function buildOrgBoundEndpointParams(
   organization: string,
-  fields: { name: string; url: string; description?: string },
+  fields: {
+    name: string;
+    url: string;
+    description?: string;
+    scopes?: string;
+    resourceClientId?: string;
+    resourceClientSecret?: string;
+  },
 ): AddEndpointParams | null {
   const org = organization.trim();
   if (!org) return null;
@@ -305,6 +326,18 @@ export function buildOrgBoundEndpointParams(
   const description = fields.description?.trim();
   if (description) {
     params.description = description;
+  }
+  const scopes = fields.scopes?.trim();
+  if (scopes) {
+    params.scopes = scopes.split(/\s+/).join(' ');
+  }
+  const resourceClientId = fields.resourceClientId?.trim();
+  if (resourceClientId) {
+    params.resource_client_id = resourceClientId;
+  }
+  const resourceClientSecret = fields.resourceClientSecret?.trim();
+  if (resourceClientSecret) {
+    params.resource_client_secret = resourceClientSecret;
   }
   return params;
 }
@@ -340,6 +373,12 @@ export interface AddEndpointFormSnapshot {
   clientId: string;
   clientSecret: string;
   scopes: string;
+  /** Org-bound (EMA) endpoint scopes — separate from the OAuth `scopes` field
+   *  above since the org-bound advanced block is mutually exclusive with the
+   *  per-server OAuth advanced block (`{#if !orgBound}`). */
+  orgBoundScopes: string;
+  resourceClientId: string;
+  resourceClientSecret: string;
   serverTypeOverride: string;
   isolationEnabled: boolean;
   mounts: MountRow[];
@@ -396,6 +435,9 @@ export function computeAddEndpointIsDirty(
   if (snapshot.clientId !== current.clientId) return true;
   if (snapshot.clientSecret !== current.clientSecret) return true;
   if (snapshot.scopes !== current.scopes) return true;
+  if (snapshot.orgBoundScopes !== current.orgBoundScopes) return true;
+  if (snapshot.resourceClientId !== current.resourceClientId) return true;
+  if (snapshot.resourceClientSecret !== current.resourceClientSecret) return true;
   if (snapshot.serverTypeOverride !== current.serverTypeOverride) return true;
   if (snapshot.isolationEnabled !== current.isolationEnabled) return true;
   if (!sameMountList(snapshot.mounts, current.mounts)) return true;

--- a/src/lib/components/onboarding-helpers.test.ts
+++ b/src/lib/components/onboarding-helpers.test.ts
@@ -17,6 +17,9 @@ import {
   orgStatusLabel,
   startOrgConnection,
   reauthenticateOrg,
+  pollForOrgAuth,
+  unauthenticatedOrgs,
+  orgExpiryBannerMessage,
 } from './onboarding-helpers';
 import type { AddEndpointParams } from '$lib/api';
 
@@ -141,6 +144,53 @@ describe('buildCreateOrgParams', () => {
       provider: 'custom',
       idp: 'https://id.example.com',
       client_id: 'abc123',
+    });
+  });
+
+  it('includes a trimmed client_secret when provided', () => {
+    expect(buildCreateOrgParams(okta, 'Acme', 'acme', 'abc123', '  s3cret  ')).toEqual({
+      name: 'Acme',
+      provider: 'okta',
+      slug: 'acme',
+      client_id: 'abc123',
+      client_secret: 's3cret',
+    });
+  });
+
+  it('omits client_secret when blank or whitespace-only', () => {
+    expect(buildCreateOrgParams(okta, 'Acme', 'acme', 'abc123', '   ')).toEqual({
+      name: 'Acme',
+      provider: 'okta',
+      slug: 'acme',
+      client_id: 'abc123',
+    });
+    expect(buildCreateOrgParams(okta, 'Acme', 'acme', 'abc123')).toEqual({
+      name: 'Acme',
+      provider: 'okta',
+      slug: 'acme',
+      client_id: 'abc123',
+    });
+  });
+
+  it('allows a client_secret without a client_id (confidential public-client edge case)', () => {
+    expect(buildCreateOrgParams(custom, 'Acme', 'https://id.example.com', '', 's3cret')).toEqual({
+      name: 'Acme',
+      provider: 'custom',
+      idp: 'https://id.example.com',
+      client_secret: 's3cret',
+    });
+  });
+
+  it('omits client creds when blank or whitespace-only', () => {
+    expect(buildCreateOrgParams(okta, 'Acme', 'acme', '   ', '   ')).toEqual({
+      name: 'Acme',
+      provider: 'okta',
+      slug: 'acme',
+    });
+    expect(buildCreateOrgParams(okta, 'Acme', 'acme')).toEqual({
+      name: 'Acme',
+      provider: 'okta',
+      slug: 'acme',
     });
   });
 });
@@ -400,6 +450,116 @@ describe('reauthenticateOrg', () => {
 });
 
 // ---------------------------------------------------------------------------
+// pollForOrgAuth — shared by ConnectOrgModal and OrganizationsSection so both
+// initial-connect and Settings re-authenticate flip the row from "Sign-in
+// required" to "Connected" on the same cadence.
+// ---------------------------------------------------------------------------
+
+const orgRow = (name: string, authenticated: boolean): Organization => ({
+  name,
+  provider: 'okta',
+  idp: 'okta',
+  authenticated,
+});
+
+describe('pollForOrgAuth', () => {
+  it('resolves once the org flips to authenticated', async () => {
+    const listOrganizations = vi
+      .fn()
+      .mockResolvedValueOnce([orgRow('Acme', false)])
+      .mockResolvedValueOnce([orgRow('Acme', false)])
+      .mockResolvedValueOnce([orgRow('Acme', true)]);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const outcome = await pollForOrgAuth(
+      'Acme',
+      { listOrganizations },
+      { intervalMs: 10, timeoutMs: 1000, sleep },
+    );
+
+    expect(outcome).toEqual({ status: 'authenticated' });
+    expect(listOrganizations).toHaveBeenCalledTimes(3);
+    // Sleep runs once per poll iteration before the list call.
+    expect(sleep).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledWith(10);
+  });
+
+  it('keeps polling through transient list failures', async () => {
+    const listOrganizations = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('relay hiccup'))
+      .mockResolvedValueOnce([orgRow('Acme', true)]);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const outcome = await pollForOrgAuth(
+      'Acme',
+      { listOrganizations },
+      { intervalMs: 1, timeoutMs: 100, sleep },
+    );
+
+    expect(outcome).toEqual({ status: 'authenticated' });
+    expect(listOrganizations).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns cancelled without touching the relay when aborted before the first list call', async () => {
+    const listOrganizations = vi.fn();
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const outcome = await pollForOrgAuth(
+      'Acme',
+      { listOrganizations },
+      { intervalMs: 1, timeoutMs: 100, sleep, shouldCancel: () => true },
+    );
+
+    expect(outcome).toEqual({ status: 'cancelled' });
+    expect(listOrganizations).not.toHaveBeenCalled();
+  });
+
+  it('returns cancelled mid-poll and stops issuing list calls', async () => {
+    let cancelled = false;
+    const listOrganizations = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        cancelled = true;
+        return [orgRow('Acme', false)];
+      })
+      .mockImplementation(async () => [orgRow('Acme', false)]);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const outcome = await pollForOrgAuth(
+      'Acme',
+      { listOrganizations },
+      { intervalMs: 1, timeoutMs: 1000, sleep, shouldCancel: () => cancelled },
+    );
+
+    expect(outcome).toEqual({ status: 'cancelled' });
+    // First iteration issued the list call that flipped the cancel flag;
+    // the second iteration bails at the pre-list cancel check.
+    expect(listOrganizations).toHaveBeenCalledTimes(1);
+  });
+
+  it('times out when the org never reports authenticated', async () => {
+    const listOrganizations = vi.fn().mockResolvedValue([orgRow('Acme', false)]);
+    let now = 0;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now);
+    const sleep = vi.fn().mockImplementation(async (ms: number) => {
+      now += ms;
+    });
+
+    const outcome = await pollForOrgAuth(
+      'Acme',
+      { listOrganizations },
+      { intervalMs: 50, timeoutMs: 100, sleep },
+    );
+
+    expect(outcome).toEqual({ status: 'timeout' });
+    // Loop budget covers two iterations (50 + 50 = 100), then deadline fails.
+    expect(listOrganizations).toHaveBeenCalledTimes(2);
+    nowSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Wiring (source-level, mirroring the `?raw` convention in Settings.test.ts)
 // ---------------------------------------------------------------------------
 
@@ -432,6 +592,36 @@ describe('OrganizationsSection wires list / re-auth / remove', () => {
   });
 });
 
+describe('OrganizationsSection polls for auth after re-authenticate', () => {
+  it('kicks off pollForOrgAuth and cancels stale polls on unmount / repeat click', async () => {
+    const source = (await import('./OrganizationsSection.svelte?raw')).default;
+    // Uses the shared helper (not a copy-pasted loop) so the initial-connect
+    // and Settings re-auth flows stay in lockstep.
+    expect(source).toMatch(/pollForOrgAuth\(/);
+    expect(source).toMatch(/listOrganizations/);
+    // Per-row `busy` clears once the browser opens; poll continues in the
+    // background inside a `void (async () => ...)` block.
+    expect(source).toMatch(/void\s*\(async\s*\(\)\s*=>/);
+    // Cancellation plumbing: repeat click cancels the prior poll, and
+    // `onDestroy` cancels every outstanding poll so no timers leak.
+    expect(source).toMatch(/onDestroy/);
+    expect(source).toMatch(/activeReauthPolls/);
+    expect(source).toMatch(/cancelReauthPoll/);
+    expect(source).toMatch(/shouldCancel:/);
+  });
+});
+
+describe('ConnectOrgModal reuses the shared poll-for-auth helper', () => {
+  it('delegates pollForAuth to pollForOrgAuth so both flows share cadence + cancel', async () => {
+    const source = (await import('./ConnectOrgModal.svelte?raw')).default;
+    expect(source).toMatch(/pollForOrgAuth\(/);
+    // Cancellation is threaded via `shouldCancel` — the raw setTimeout loop
+    // that used to live here is gone.
+    expect(source).toMatch(/shouldCancel:\s*\(\)\s*=>\s*pollCancelled/);
+    expect(source).not.toMatch(/setTimeout\(r,\s*2000\)/);
+  });
+});
+
 describe('OrganizationsSection offers per-org re-detect', () => {
   it('renders ConnectOrgModal in re-detect mode, gated on sign-in', async () => {
     const source = (await import('./OrganizationsSection.svelte?raw')).default;
@@ -452,6 +642,72 @@ describe('ConnectOrgModal supports re-detect + already-installed greying', () =>
     expect(source).toContain('runProbe(redetectOrg)');
     expect(source).toContain('isAlreadyInstalled');
     expect(source).toContain('Already added');
+  });
+});
+
+describe('ConnectOrgModal exposes a Client Secret field', () => {
+  it('binds a clientSecret state to a password input and threads it through buildCreateOrgParams', async () => {
+    const source = (await import('./ConnectOrgModal.svelte?raw')).default;
+    expect(source).toMatch(/let\s+clientSecret\s*=\s*\$state\(/);
+    expect(source).toContain('id="org-client-secret"');
+    expect(source).toMatch(/type="password"/);
+    expect(source).toMatch(
+      /buildCreateOrgParams\(\s*selectedProvider\s*,\s*name\s*,\s*slugOrUrl\s*,\s*clientId\s*,\s*clientSecret\s*,?\s*\)/,
+    );
+  });
+});
+
+describe('ConnectOrgModal no longer exposes resource credential fields', () => {
+  it('moved the resource (Step-3 MAS) credential to the per-endpoint Config tab (R3)', async () => {
+    const source = (await import('./ConnectOrgModal.svelte?raw')).default;
+    expect(source).not.toContain('id="org-resource-client-id"');
+    expect(source).not.toContain('id="org-resource-client-secret"');
+  });
+});
+
+describe('ConfigTab exposes per-endpoint EMA resource credential fields', () => {
+  it('binds resource client id/secret for EMA endpoints and persists via updateEndpoint', async () => {
+    const source = (await import('./ConfigTab.svelte?raw')).default;
+    // Fields live under the EMA-binding section, gated on showEmaBinding.
+    expect(source).toContain('id="config-ep-resource-client-id"');
+    expect(source).toContain('id="config-ep-resource-client-secret"');
+    expect(source).toMatch(/let\s+resourceClientId\s*=\s*\$state\(/);
+    expect(source).toMatch(/let\s+resourceClientSecret\s*=\s*\$state\(/);
+    // Write-only secret with an explicit clear toggle (absent-vs-empty merge).
+    expect(source).toContain('clearResourceSecret');
+    expect(source).toMatch(/params\.resource_client_secret\s*=\s*''/);
+    expect(source).toMatch(/params\.resource_client_id\s*=/);
+  });
+});
+
+describe('OrganizationsSection offers per-org Edit', () => {
+  it('renders an Edit button that opens EditOrganizationModal', async () => {
+    const source = (await import('./OrganizationsSection.svelte?raw')).default;
+    expect(source).toMatch(
+      /import\s+EditOrganizationModal\s+from\s+['"]\.\/EditOrganizationModal\.svelte['"]/,
+    );
+    expect(source).toContain('editingOrg');
+    expect(source).toMatch(/>\s*Edit\s*<\/button>/);
+    expect(source).toMatch(/<EditOrganizationModal[\s\S]*org=\{editingOrg\}/);
+  });
+});
+
+describe('EditOrganizationModal uses the update API + reauth fork', () => {
+  it('calls updateOrganization and opens authorize_url when identity changed', async () => {
+    const source = (await import('./EditOrganizationModal.svelte?raw')).default;
+    expect(source).toMatch(/updateOrganization\(/);
+    expect(source).toMatch(/updateRequiresReauth\(/);
+    // Client secret field never shows the stored secret back to the user.
+    expect(source).toContain('id="edit-org-client-secret"');
+    expect(source).toMatch(/type="password"/);
+    // The "clear" toggles send an explicit empty string (per relay contract).
+    expect(source).toContain('clearSecret');
+    expect(source).toContain('clearClientId');
+    expect(source).toMatch(/refreshOrganizations\(/);
+    // R3 moved the resource (Step-3 MAS) credential fields off the org modal to
+    // the per-endpoint Config tab — they must no longer appear here.
+    expect(source).not.toContain('id="edit-org-resource-client-id"');
+    expect(source).not.toContain('id="edit-org-resource-client-secret"');
   });
 });
 
@@ -511,5 +767,47 @@ describe('addEndpointsWithRefresh', () => {
 
     expect(getEndpoints).toHaveBeenCalledTimes(1);
     expect(setEndpoints).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wave 20 — Org-expiry banner derive logic
+// ---------------------------------------------------------------------------
+
+describe('unauthenticatedOrgs / orgExpiryBannerMessage (banner derive)', () => {
+  const mk = (name: string, authenticated: boolean): Organization => ({
+    name,
+    provider: 'okta',
+    idp: 'okta',
+    authenticated,
+  });
+
+  it('filters to only orgs with authenticated === false', () => {
+    const list = [mk('acme', true), mk('beta-co', false), mk('gamma', true), mk('delta', false)];
+    expect(unauthenticatedOrgs(list).map((o) => o.name)).toEqual(['beta-co', 'delta']);
+  });
+
+  it('returns null when there are zero orgs (banner hidden)', () => {
+    expect(orgExpiryBannerMessage([])).toBeNull();
+  });
+
+  it('returns null when every org is authenticated (banner hidden)', () => {
+    expect(orgExpiryBannerMessage([mk('acme', true), mk('gamma', true)])).toBeNull();
+  });
+
+  it('names the org for a single unauthenticated org', () => {
+    expect(orgExpiryBannerMessage([mk('acme', true), mk('beta-co', false)])).toBe(
+      'Sign-in required for beta-co',
+    );
+  });
+
+  it('counts unauthenticated orgs when more than one need re-auth', () => {
+    const msg = orgExpiryBannerMessage([
+      mk('acme', true),
+      mk('beta-co', false),
+      mk('delta', false),
+      mk('eps', false),
+    ]);
+    expect(msg).toBe('3 organizations need re-authentication');
   });
 });

--- a/src/lib/components/onboarding-helpers.test.ts
+++ b/src/lib/components/onboarding-helpers.test.ts
@@ -709,6 +709,21 @@ describe('EditOrganizationModal uses the update API + reauth fork', () => {
     expect(source).not.toContain('id="edit-org-resource-client-id"');
     expect(source).not.toContain('id="edit-org-resource-client-secret"');
   });
+
+  it('requires a slug when switching to a different templated provider', async () => {
+    const source = (await import('./EditOrganizationModal.svelte?raw')).default;
+    // Custom-provider switch still requires an issuer URL.
+    expect(source).toMatch(
+      /isCustomProvider\(selectedProvider\)[\s\S]*?providerId\s*!==\s*org\.provider[\s\S]*?slugOrUrl\.trim\(\)[\s\S]*?Enter the issuer URL/,
+    );
+    // Templated-to-templated switch (okta → ping) requires a fresh slug —
+    // the previous guard only fired for custom providers, so a blank slug
+    // silently sent `provider` without `slug` and the relay rebuilt the
+    // issuer with an empty slug.
+    expect(source).toMatch(
+      /providerNeedsSlug\(selectedProvider\)[\s\S]*?providerId\s*!==\s*org\.provider[\s\S]*?slugOrUrl\.trim\(\)[\s\S]*?Enter the organization slug/,
+    );
+  });
 });
 
 describe('addEndpointsWithRefresh', () => {

--- a/src/lib/components/onboarding-helpers.ts
+++ b/src/lib/components/onboarding-helpers.ts
@@ -9,6 +9,62 @@ import type {
 } from '$lib/types';
 
 // ---------------------------------------------------------------------------
+// Poll-for-auth (shared by initial-connect flow and Settings re-authenticate)
+// ---------------------------------------------------------------------------
+
+export interface PollForOrgAuthDeps {
+  listOrganizations: () => Promise<Organization[]>;
+}
+
+export interface PollForOrgAuthOptions {
+  /** Poll cadence in ms. Default 2000. */
+  intervalMs?: number;
+  /** Overall budget in ms. Default 120_000. */
+  timeoutMs?: number;
+  /** Callback checked before each list call — return true to abort. */
+  shouldCancel?: () => boolean;
+  /** Sleep primitive; overridable for tests. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export type PollForOrgAuthResult =
+  | { status: 'authenticated' }
+  | { status: 'cancelled' }
+  | { status: 'timeout' };
+
+/**
+ * Poll the org list until the relay reports the named org as authenticated
+ * (its IdP callback landed) or the budget elapses. Used by both the Connect-
+ * org flow and Settings → re-authenticate so the two share a single cadence
+ * and cancellation contract. Transient list failures are swallowed so a brief
+ * relay hiccup does not abort the wait.
+ */
+export async function pollForOrgAuth(
+  name: string,
+  deps: PollForOrgAuthDeps,
+  opts: PollForOrgAuthOptions = {},
+): Promise<PollForOrgAuthResult> {
+  const intervalMs = opts.intervalMs ?? 2000;
+  const timeoutMs = opts.timeoutMs ?? 120_000;
+  const shouldCancel = opts.shouldCancel ?? (() => false);
+  const sleep = opts.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    await sleep(intervalMs);
+    if (shouldCancel()) return { status: 'cancelled' };
+    try {
+      const orgs = await deps.listOrganizations();
+      const org = orgs.find((o) => o.name === name);
+      if (org?.authenticated) return { status: 'authenticated' };
+    } catch {
+      // transient — keep polling
+    }
+  }
+  return { status: 'timeout' };
+}
+
+// ---------------------------------------------------------------------------
 // Provider picker — issuer build (M6/M8)
 // ---------------------------------------------------------------------------
 
@@ -49,17 +105,23 @@ export function buildIssuerPreview(provider: IdpProvider, slug: string): string 
  * raw issuer as `idp`; templated providers send `slug` (omitted when the
  * provider needs none, e.g. Google). An optional pre-registered `client_id`
  * (required for Okta/Entra) is trimmed and only included when non-empty;
- * leaving it blank takes the CIMD/DCR path.
+ * leaving it blank takes the CIMD/DCR path. An optional confidential-client
+ * `client_secret` is trimmed and only included when non-empty; the relay
+ * persists it in the secure credential store, never `config.toml`. The EMA
+ * **resource** pairing credential is per-resource (R3) and is configured on the
+ * endpoint's Config tab, not here.
  */
 export function buildCreateOrgParams(
   provider: IdpProvider,
   name: string,
   slugOrUrl: string,
   clientId = '',
+  clientSecret = '',
 ): CreateOrganizationParams {
   const trimmedName = name.trim();
   const trimmedValue = slugOrUrl.trim();
   const trimmedClientId = clientId.trim();
+  const trimmedClientSecret = clientSecret.trim();
   let params: CreateOrganizationParams;
   if (isCustomProvider(provider)) {
     params = { name: trimmedName, provider: provider.id, idp: trimmedValue };
@@ -71,6 +133,9 @@ export function buildCreateOrgParams(
   }
   if (trimmedClientId) {
     params.client_id = trimmedClientId;
+  }
+  if (trimmedClientSecret) {
+    params.client_secret = trimmedClientSecret;
   }
   return params;
 }
@@ -248,6 +313,32 @@ export async function addEndpointsWithRefresh(
 /** Human-readable auth-status label for an org row in the management list. */
 export function orgStatusLabel(org: Organization): string {
   return org.authenticated ? 'Connected' : 'Sign-in required';
+}
+
+// ---------------------------------------------------------------------------
+// Org-expiry banner — derive logic (Wave 20)
+// ---------------------------------------------------------------------------
+
+/**
+ * The list of orgs whose IdP auth is expired/unauthenticated. `authenticated`
+ * is already computed by the relay from the stored ID token's expiry, so this
+ * is a plain filter — no client-side clock math.
+ */
+export function unauthenticatedOrgs(orgs: Organization[]): Organization[] {
+  return orgs.filter((o) => o.authenticated === false);
+}
+
+/**
+ * Banner headline for the global org-expiry banner. Returns `null` when no
+ * orgs need re-auth (the banner then renders nothing). Single-org copy names
+ * the org so the user knows exactly which sign-in lapsed; multi-org copy
+ * counts them so the banner stays short.
+ */
+export function orgExpiryBannerMessage(orgs: Organization[]): string | null {
+  const stale = unauthenticatedOrgs(orgs);
+  if (stale.length === 0) return null;
+  if (stale.length === 1) return `Sign-in required for ${stale[0].name}`;
+  return `${stale.length} organizations need re-authentication`;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -319,12 +319,17 @@ export interface IdpProvider {
  * One organization from `GET /api/organizations`. `authenticated` reflects
  * whether the relay's credential pool holds usable IdP credentials for the org
  * (a non-expired ID token or a refresh token to silently re-mint one).
+ *
+ * `client_secret_set` is optional — older relays omit it. When present and
+ * `true` the org has a confidential-client secret persisted in the secure
+ * credential store; the secret value itself is never returned to the UI.
  */
 export interface Organization {
   name: string;
   provider: string;
   idp: string;
   authenticated: boolean;
+  client_secret_set?: boolean;
 }
 
 /**

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,9 +4,15 @@
   import { listen } from '@tauri-apps/api/event';
   import { checkAndAutoDownload, listenForUpdateChecks } from '$lib/updater';
   import { activeTopLevelTab } from '$lib/stores';
+  import { refreshOrganizations } from '$lib/stores/organizations';
   import { Toaster } from 'svelte-sonner';
+  import OrgExpiryBanner from '$lib/components/OrgExpiryBanner.svelte';
 
   let { children } = $props();
+
+  // App-wide org auth-status poll cadence (ms). ~30s keeps the banner
+  // reactive to expiries without spamming the relay.
+  const ORG_POLL_INTERVAL_MS = 30_000;
 
   // The overlay window (`/overlay/` route) has a narrowly-scoped Tauri
   // capability that intentionally omits the `notification:*` and
@@ -38,9 +44,19 @@
     // channel the updater actually used on every check.
     const unlistenChecked = listenForUpdateChecks();
 
+    // App-wide org poll — keeps `organizations.authenticated` fresh so the
+    // global expiry banner reacts even when Settings isn't open. Failures
+    // are swallowed (relay unreachable → leave the store as-is), matching
+    // the existing background-poll patterns.
+    void refreshOrganizations().catch(() => {});
+    const orgPollInterval = setInterval(() => {
+      void refreshOrganizations().catch(() => {});
+    }, ORG_POLL_INTERVAL_MS);
+
     return () => {
       clearTimeout(initialTimeout);
       clearInterval(interval);
+      clearInterval(orgPollInterval);
       unlisten.then((fn) => fn());
       unlistenChecked.then((fn) => fn());
     };
@@ -48,5 +64,8 @@
 </script>
 
 <Toaster position="bottom-right" duration={5000} richColors closeButton />
+{#if !isOverlayWindow}
+  <OrgExpiryBanner />
+{/if}
 {@render children()}
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -64,8 +64,23 @@
 </script>
 
 <Toaster position="bottom-right" duration={5000} richColors closeButton />
-{#if !isOverlayWindow}
-  <OrgExpiryBanner />
+{#if isOverlayWindow}
+  {@render children()}
+{:else}
+  <!--
+    Wrap the app in a viewport-sized flex column so the org-expiry banner
+    renders IN-FLOW as the first child and pushes the page content down.
+    This keeps the top tab bar (and its `data-tauri-drag-region`) visible
+    and clickable when an org is expired — the previous `position: fixed`
+    banner overlapped the tab nav and the macOS traffic-light strip.
+    When the banner has no message it renders nothing, leaving the
+    `flex-1` child at full viewport height — pixel-identical to before.
+  -->
+  <div class="flex flex-col h-screen w-screen overflow-hidden">
+    <OrgExpiryBanner />
+    <div class="flex-1 min-h-0">
+      {@render children()}
+    </div>
+  </div>
 {/if}
-{@render children()}
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -209,7 +209,7 @@
 <svelte:window onkeydown={handleGlobalKeydown} />
 
 {#if showRelayStartupFailure}
-  <div class="flex h-screen w-screen items-center justify-center bg-(--surface-alt) p-6">
+  <div class="flex h-full w-full items-center justify-center bg-(--surface-alt) p-6">
     <div class="w-full max-w-2xl rounded-2xl border border-red-500/20 bg-(--surface) p-8 shadow-sm">
       <div class="mb-6 inline-flex items-center rounded-full bg-red-500/10 px-3 py-1 text-xs font-medium text-red-600 dark:text-red-400">
         Relay startup failed
@@ -253,7 +253,7 @@
 {:else if $miniPlayerMode}
   <MiniPlayer />
 {:else}
-  <div class="flex flex-col h-screen w-screen overflow-hidden">
+  <div class="flex flex-col h-full w-full overflow-hidden">
     <!-- Top-level tab bar -->
     <div class="flex items-center border-b border-(--border) bg-(--chrome-bg) px-2 pt-1 shrink-0 relative" data-tauri-drag-region>
       <div class="flex">


### PR DESCRIPTION
## EMA slice 3 — org onboarding UI, resource-cred fields, expiry banner (END-19)

Desktop-side slice-3 refinements for the Enterprise-Managed Authentication (EMA) chain landed in the END-19 base PRs (relay#121 / desktop#140). Pairs with [`endara-ai/endara-relay#127`](https://github.com/endara-ai/endara-relay/pull/127).

### Highlights

- **Org onboarding UI** — `ConnectOrgModal` and `OrganizationsSection` pick up the org lifecycle updates from relay (confidential-client secret, resource-scope defaults) and expose a full org edit path via the new `EditOrganizationModal`.
- **Add Server — resource-credential fields** — `AddEndpointModal` gains per-endpoint `resource_client_id`, `resource_client_secret`, and `resource_scope` inputs in a consolidated **Advanced** section. Values flow through `add-endpoint-helpers.ts` and the Tauri command surface into the endpoint's own `{name}.dcr.json` store server-side, so credentials never leak onto the IdP-facing legs.
- **Consolidated Advanced section** — the previously scattered advanced fields collapse into a single expandable section in the Add Server modal, keeping the default flow simple.
- **Re-auth polling** — `onboarding-helpers.ts` drives a poll that flips the Settings row to **Connected** once the resource legs succeed, so the user does not need to reload after finishing SSO.
- **Full-width org-expiry banner** — new `OrgExpiryBanner` component wired into `+layout.svelte` renders app-wide above the main content whenever an org's tokens are near expiry, with a 30-second poll that refreshes org state so the banner appears/disappears without user interaction (and so the Settings pane's per-org rows stay in sync).

### Commits

- `feat: EMA slice 3 — org onboarding UI, per-endpoint resource-cred fields, re-auth polling (END-19)`
- `feat: full-width org-expiry banner + app-wide org poll`

### Verification

- `pnpm check` — 0 errors / 0 warnings
- `pnpm test` — 1081 passed / 39 skipped / 0 failed
- `pnpm build` — clean

Refs END-19.
