### PR TITLE
chore: address deferred Copilot review nits from #142

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -127,6 +127,20 @@ export interface EmaAuthConfig {
   resource: string;
 }
 
+/**
+ * Read/round-trip shape of the persisted `[endpoints.auth]` sub-table, as
+ * surfaced by `getEndpointConfig` and echoed back on `updateEndpoint`. Unlike
+ * the strict add-time `EmaAuthConfig`, `organization`/`resource` are optional
+ * here because the Tauri backend serializes them from an `Option`-typed
+ * `EndpointAuth`, so a stored binding may round-trip without every field
+ * present. `type` stays the `'ema'` discriminant the UI keys off.
+ */
+export interface EmaAuthSummary {
+  type: 'ema';
+  organization?: string;
+  resource?: string;
+}
+
 export interface AddEndpointParams {
   name: string;
   transport: 'stdio' | 'sse' | 'http' | 'oauth';
@@ -352,7 +366,7 @@ export interface EndpointConfig {
    * PUT — which rebuilds the whole endpoint config from the body — preserves
    * the binding.
    */
-  auth?: EmaAuthConfig;
+  auth?: EmaAuthSummary;
 }
 
 export async function getEndpointConfig(name: string): Promise<EndpointConfig> {
@@ -418,7 +432,7 @@ export interface UpdateEndpointParams {
    * Absent for ordinary (non-EMA) endpoints — no empty `auth` key is sent in
    * that case, keeping the PUT body byte-for-byte unchanged.
    */
-  auth?: EmaAuthConfig;
+  auth?: EmaAuthSummary;
 }
 
 export async function startOAuth(name: string): Promise<OAuthStartResult> {

--- a/src/lib/components/ConfigTab.svelte
+++ b/src/lib/components/ConfigTab.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getEndpointConfig, updateEndpoint, getEndpoints, getStatus, type UpdateEndpointParams, type EmaAuthConfig } from '$lib/api';
+  import { getEndpointConfig, updateEndpoint, getEndpoints, getStatus, type UpdateEndpointParams, type EmaAuthSummary } from '$lib/api';
   import { selectedEndpoint, endpoints, selectedEndpointData } from '$lib/stores';
   import { registerDirtyChecker } from '$lib/stores/unsavedChangesGuard';
   import {
@@ -88,7 +88,7 @@
   // round-tripped back on save so the relay's PUT — which rebuilds the whole
   // endpoint config from the body — doesn't drop the binding. Null/undefined
   // for ordinary (non-EMA) endpoints, in which case no `auth` key is sent.
-  let loadedAuth = $state<EmaAuthConfig | null>(null);
+  let loadedAuth = $state<EmaAuthSummary | null>(null);
   let emaOrganization = $derived(
     loadedAuth?.type === 'ema' ? loadedAuth.organization ?? '' : ''
   );

--- a/src/lib/components/ConnectOrgModal.svelte
+++ b/src/lib/components/ConnectOrgModal.svelte
@@ -43,7 +43,7 @@
   let orgName = $state('');
   let slugOrUrl = $state('');
   let clientId = $state('');
-  // Write-only; never echoed back. Cleared on cancel/submit failure.
+  // Write-only; never echoed back. Retained in memory while the modal is open.
   let clientSecret = $state('');
   let error = $state('');
   let submitting = $state(false);


### PR DESCRIPTION
Small follow-up addressing the three advisory Copilot review nits that were acknowledged as deferred (non-blocking) when #142 merged. Type-only + comment-only changes; no runtime behavior change.

### Nits from #142

1. **`src/lib/api.ts` — `EndpointConfig.auth` type precision** ✅ Done
   - Copilot: read-side `auth` reused the strict add-time `EmaAuthConfig` (`organization`/`resource` required), overstating guarantees vs. the Tauri backend's `Option`-typed `EndpointAuth` serialization.
   - Fix: added a dedicated read/round-trip `EmaAuthSummary` type (`{ type: 'ema'; organization?: string; resource?: string }`) and pointed `EndpointConfig.auth` at it. `EmaAuthConfig` stays strict for add-time creation.

2. **`src/lib/api.ts` — `UpdateEndpointParams.auth` type precision** ✅ Done
   - Same narrowing: `UpdateEndpointParams.auth` now uses `EmaAuthSummary` to match the round-tripped shape from `getEndpointConfig`.

3. **`src/lib/components/ConnectOrgModal.svelte` — `clientSecret` doc-comment** ✅ Done
   - Copilot: the comment claimed the value is "Cleared on cancel/submit failure", but no code clears it in those paths.
   - Fix (comment-only): reworded to "Write-only; never echoed back. Retained in memory while the modal is open." to match actual behavior.

### Notes / what was kept minimal

- **`type` kept as the `'ema'` discriminant** (not widened to `string`). The relay always emits `type = "ema"` for EMA bindings and the UI keys off it (`loadedAuth?.type === 'ema'` in `ConfigTab.svelte`, `ep.auth?.type === 'ema'` in `onboarding-helpers.ts`). Widening it would reduce a useful discriminant with no real safety gain; the substantive concern in both nits was the optional `organization`/`resource` fields, which is what was narrowed.
- Only consumer needing a type touch-up was `ConfigTab.svelte` (`loadedAuth` state + import), since it assigns `config.auth` in and `params.auth` back out. Its derived accessors already used `?? ''`, so optional fields were already anticipated. No other consumers or call sites required changes.
- Write side (`AddEndpointParams.auth`) intentionally left as strict `EmaAuthConfig` — Copilot only flagged the read/round-trip surfaces.

### Gates (from `packages/desktop`)

- `pnpm check` → 0 errors, 0 warnings
- `pnpm test` → 1083 passed, 39 skipped
- `pnpm build` → success

Refs #142. Do not merge without review.
