### PR TITLE
chore: bump version to 0.1.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endara/desktop",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "description": "Endara Desktop — Tauri + Svelte tray app for relay management",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "endara-desktop"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "arc-swap",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endara-desktop"
-version = "0.1.10"
+version = "0.1.11"
 description = "Endara Desktop — relay management tray app"
 authors = ["Endara"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Endara Desktop",
   "mainBinaryName": "Endara Desktop",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "identifier": "ai.endara.desktop",
   "build": {
     "beforeDevCommand": "ENDARA_DEV_PORT=9500 bash scripts/kill-relay.sh; npm run dev",


### PR DESCRIPTION
Post-stable-v0.1.10 base version bump (Scenario 3).

Bumps the committed base version from `0.1.10` to `0.1.11` in lockstep:

- `package.json` — `"version"`
- `src-tauri/Cargo.toml` — package `version` field
- `src-tauri/tauri.conf.json` — `"version"`
- `src-tauri/Cargo.lock` — own-package version line (via `cargo update --workspace`)

`pnpm-lock.yaml` is untouched (no diff — pnpm does not pin the package's own version).

Gates: `pnpm check` and `pnpm build` pass. No functional changes.
