### PR TITLE
fix(oauth): present connection_failed as connectivity issue and surface discovery_unreachable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: sudo apt-get update
       - name: Install system dependencies
         if: runner.os == 'Linux'
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
           version: 1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
         with:
           workspaces: './src-tauri -> target'
           save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Refresh apt package index
+        if: runner.os == 'Linux'
+        run: sudo apt-get update
       - name: Install system dependencies
         if: runner.os == 'Linux'
         uses: awalsh128/cache-apt-pkgs-action@latest

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -432,6 +432,30 @@ describe('api', () => {
     });
   });
 
+  describe('startOAuth', () => {
+    // Regression coverage: the relay returns HTTP 502 with
+    // `{"error":"discovery_unreachable","detail":...}` when RFC 8414 discovery
+    // times out. It must pass through as a typed result (like dcr_unsupported /
+    // discovery_failed) so reauthorize() can show the connectivity toast — not
+    // fall into the generic non-2xx branch and throw.
+    it('returns discovery_unreachable as a typed result instead of throwing on 502', async () => {
+      const { startOAuth } = await import('./api');
+      mockHttpError(
+        502,
+        JSON.stringify({
+          error: 'discovery_unreachable',
+          detail: 'Could not reach the OAuth server to discover its endpoints.',
+        }),
+      );
+
+      const result = await startOAuth('sunsama');
+      expect(result).toEqual({
+        error: 'discovery_unreachable',
+        detail: 'Could not reach the OAuth server to discover its endpoints.',
+      });
+    });
+  });
+
   describe('oauthProbe', () => {
     // The add-server flow relies on this probe being non-blocking: any
     // failure/timeout/non-2xx must resolve to `{ oauth_supported: false }`

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -454,6 +454,50 @@ describe('api', () => {
         detail: 'Could not reach the OAuth server to discover its endpoints.',
       });
     });
+
+    it('returns dcr_unsupported as a typed result instead of throwing on 4xx', async () => {
+      const { startOAuth } = await import('./api');
+      mockHttpError(
+        400,
+        JSON.stringify({
+          error: 'dcr_unsupported',
+          detail: 'The OAuth server does not support Dynamic Client Registration.',
+        }),
+      );
+
+      const result = await startOAuth('sunsama');
+      expect(result).toEqual({
+        error: 'dcr_unsupported',
+        detail: 'The OAuth server does not support Dynamic Client Registration.',
+      });
+    });
+
+    it('returns discovery_failed as a typed result instead of throwing on 400', async () => {
+      const { startOAuth } = await import('./api');
+      mockHttpError(
+        400,
+        JSON.stringify({
+          error: 'discovery_failed',
+          detail: 'OAuth discovery returned an invalid metadata document.',
+        }),
+      );
+
+      const result = await startOAuth('sunsama');
+      expect(result).toEqual({
+        error: 'discovery_failed',
+        detail: 'OAuth discovery returned an invalid metadata document.',
+      });
+    });
+
+    it('throws on a 500 with an unrelated error body (generic non-2xx branch)', async () => {
+      const { startOAuth } = await import('./api');
+      mockHttpError(
+        500,
+        JSON.stringify({ error: 'internal_error', detail: 'unexpected relay failure' }),
+      );
+
+      await expect(startOAuth('sunsama')).rejects.toThrow('unexpected relay failure');
+    });
   });
 
   describe('oauthProbe', () => {

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -457,18 +457,23 @@ describe('api', () => {
 
     it('returns dcr_unsupported as a typed result instead of throwing on 4xx', async () => {
       const { startOAuth } = await import('./api');
+      // The relay's dcr_unsupported envelope uses `message` (plus endpoint
+      // metadata), not the `{ error, detail }` ErrorResponse shape used by the
+      // discovery_* errors — see OAuthDcrUnsupportedResponse in the relay.
       mockHttpError(
-        400,
+        422,
         JSON.stringify({
           error: 'dcr_unsupported',
-          detail: 'The OAuth server does not support Dynamic Client Registration.',
+          message: 'The OAuth server does not support Dynamic Client Registration.',
+          authorization_endpoint: 'https://auth.example.com/authorize',
         }),
       );
 
       const result = await startOAuth('sunsama');
       expect(result).toEqual({
         error: 'dcr_unsupported',
-        detail: 'The OAuth server does not support Dynamic Client Registration.',
+        message: 'The OAuth server does not support Dynamic Client Registration.',
+        authorization_endpoint: 'https://auth.example.com/authorize',
       });
     });
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -438,11 +438,14 @@ export interface UpdateEndpointParams {
 export async function startOAuth(name: string): Promise<OAuthStartResult> {
   const res = await mgmtRequest('POST', `/endpoints/${encodeURIComponent(name)}/oauth/start`);
   const data = res.body ? JSON.parse(res.body) : {};
-  // dcr_unsupported / discovery_failed are returned as typed responses, not thrown
+  // dcr_unsupported / discovery_failed / discovery_unreachable are returned as typed responses, not thrown
   if ((res.status < 200 || res.status >= 300) && data?.error === 'dcr_unsupported') {
     return data as OAuthStartResult;
   }
   if ((res.status < 200 || res.status >= 300) && data?.error === 'discovery_failed') {
+    return data as OAuthStartResult;
+  }
+  if ((res.status < 200 || res.status >= 300) && data?.error === 'discovery_unreachable') {
     return data as OAuthStartResult;
   }
   if (res.status < 200 || res.status >= 300) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -438,17 +438,11 @@ export interface UpdateEndpointParams {
 export async function startOAuth(name: string): Promise<OAuthStartResult> {
   const res = await mgmtRequest('POST', `/endpoints/${encodeURIComponent(name)}/oauth/start`);
   const data = res.body ? JSON.parse(res.body) : {};
-  // dcr_unsupported / discovery_failed / discovery_unreachable are returned as typed responses, not thrown
-  if ((res.status < 200 || res.status >= 300) && data?.error === 'dcr_unsupported') {
-    return data as OAuthStartResult;
-  }
-  if ((res.status < 200 || res.status >= 300) && data?.error === 'discovery_failed') {
-    return data as OAuthStartResult;
-  }
-  if ((res.status < 200 || res.status >= 300) && data?.error === 'discovery_unreachable') {
-    return data as OAuthStartResult;
-  }
   if (res.status < 200 || res.status >= 300) {
+    // dcr_unsupported / discovery_failed / discovery_unreachable are returned as typed responses, not thrown
+    if (['dcr_unsupported', 'discovery_failed', 'discovery_unreachable'].includes(data?.error)) {
+      return data as OAuthStartResult;
+    }
     throw new Error(data?.detail || data?.error || `HTTP ${res.status}`);
   }
   return data as OAuthStartResult;

--- a/src/lib/components/AuthTab.svelte
+++ b/src/lib/components/AuthTab.svelte
@@ -134,7 +134,10 @@
       </div>
       {#if connectivityFailure}
         <p class="mt-2 text-xs text-(--fg2)">
-          Server unreachable — your authorization is likely still valid. Retry once your connection is back.
+          Server unreachable — your authorization is likely still valid.
+          {canRefresh
+            ? 'Retry once your connection is back.'
+            : 'Re-authenticate once your connection is back.'}
         </p>
       {/if}
     </div>

--- a/src/lib/components/AuthTab.svelte
+++ b/src/lib/components/AuthTab.svelte
@@ -3,7 +3,7 @@
   import { selectedEndpoint, oauthStatuses } from '$lib/stores';
   import { getOAuthStatus, refreshOAuth, startOAuth } from '$lib/api';
   import { openUrl } from '@tauri-apps/plugin-opener';
-  import { canReauthorize, reauthorize } from '$lib/oauth/actions';
+  import { canReauthorize, isConnectivityFailure, reauthorize } from '$lib/oauth/actions';
   import { toast } from 'svelte-sonner';
 
   let status = $state<OAuthStatus | null>(null);
@@ -111,6 +111,7 @@
       (['authenticated', 'connection_failed'] as OAuthStatusValue[]).includes(status.status),
   );
   let canReauth = $derived(status !== null && canReauthorize(status.status));
+  let connectivityFailure = $derived(status !== null && isConnectivityFailure(status.status));
   let actionBusy = $derived(actionInProgress || reauthInProgress);
 </script>
 
@@ -131,6 +132,11 @@
         <span class="inline-block w-2.5 h-2.5 rounded-full {statusColors[status.status]}"></span>
         <span class="t-body font-medium text-(--fg1)">{statusLabels[status.status]}</span>
       </div>
+      {#if connectivityFailure}
+        <p class="mt-2 text-xs text-(--fg2)">
+          Server unreachable — your authorization is likely still valid. Retry once your connection is back.
+        </p>
+      {/if}
     </div>
 
     <!-- Token Details -->
@@ -176,14 +182,14 @@
       <div class="flex gap-2">
         {#if canRefresh}
           <button
-            class="btn-sec"
+            class={connectivityFailure ? 'btn-pri' : 'btn-sec'}
             onclick={handleRefresh}
             disabled={actionBusy}
           >Refresh Now</button>
         {/if}
         {#if canReauth}
           <button
-            class="btn-pri"
+            class={connectivityFailure && canRefresh ? 'btn-sec' : 'btn-pri'}
             onclick={handleReauthorize}
             disabled={actionBusy}
             title="Open the browser to sign in again"

--- a/src/lib/components/AuthTab.test.ts
+++ b/src/lib/components/AuthTab.test.ts
@@ -61,6 +61,14 @@ function canReauth(status: MinimalOAuthStatus | null): boolean {
   );
 }
 
+// Pure mirror of the `connectivityFailure` derivation in AuthTab.svelte, which
+// delegates to `isConnectivityFailure()` from $lib/oauth/actions. Kept in sync
+// so we can unit-test which statuses trigger the connectivity presentation
+// (explanatory copy + Refresh Now promoted to primary).
+function connectivityFailure(status: MinimalOAuthStatus | null): boolean {
+  return status !== null && status.status === 'connection_failed';
+}
+
 // Pure mirror of the `actionBusy` derivation in AuthTab.svelte. Both the
 // "Refresh Now" and "Re-authenticate" buttons bind their `disabled` state to
 // this shared guard so neither can be triggered while either flow is running,
@@ -202,6 +210,29 @@ describe('canReauth', () => {
   });
 });
 
+describe('connectivityFailure', () => {
+  it('returns true only for connection_failed', () => {
+    expect(connectivityFailure({ status: 'connection_failed', has_refresh_token: true })).toBe(true);
+    expect(connectivityFailure({ status: 'connection_failed', has_refresh_token: false })).toBe(true);
+  });
+
+  it('returns false for auth-expiry and other statuses', () => {
+    for (const status of [
+      'authenticated',
+      'needs_login',
+      'refreshing',
+      'auth_required',
+      'disconnected',
+    ] as OAuthStatusValue[]) {
+      expect(connectivityFailure({ status, has_refresh_token: true })).toBe(false);
+    }
+  });
+
+  it('returns false when status is null', () => {
+    expect(connectivityFailure(null)).toBe(false);
+  });
+});
+
 describe('actionBusy', () => {
   it('is false when neither action is in progress', () => {
     expect(actionBusy(false, false)).toBe(false);
@@ -259,6 +290,51 @@ describe('AuthTab busy-guard wiring (source contract)', () => {
       source.match(/if\s*\(!name\s*\|\|\s*actionInProgress\s*\|\|\s*reauthInProgress\)\s*return;/g) ??
       [];
     expect(guards).toHaveLength(2);
+  });
+});
+
+// Source contract for the connection_failed presentation: when the server is
+// unreachable the stored tokens are likely still valid, so Refresh Now becomes
+// the primary action, Re-authenticate is demoted to secondary (only when a
+// refresh is actually possible), and explanatory copy replaces the implied
+// "auth expired" framing.
+describe('AuthTab connectivity-failure wiring (source contract)', () => {
+  let source = '';
+
+  beforeAll(async () => {
+    // @ts-expect-error node builtin types not installed
+    const { readFileSync } = await import('node:fs');
+    // @ts-expect-error node builtin types not installed
+    const { fileURLToPath } = await import('node:url');
+    source = readFileSync(fileURLToPath(new URL('./AuthTab.svelte', import.meta.url)), 'utf8') as string;
+  });
+
+  it('derives connectivityFailure from isConnectivityFailure(status.status)', () => {
+    expect(source).toMatch(
+      /connectivityFailure\s*=\s*\$derived\(\s*status\s*!==\s*null\s*&&\s*isConnectivityFailure\(status\.status\)\s*\)/,
+    );
+  });
+
+  it('promotes Refresh Now to primary on connectivity failure', () => {
+    expect(source).toMatch(/class=\{connectivityFailure\s*\?\s*'btn-pri'\s*:\s*'btn-sec'\}/);
+  });
+
+  it('demotes Re-authenticate to secondary only when a refresh is possible', () => {
+    expect(source).toMatch(
+      /class=\{connectivityFailure\s*&&\s*canRefresh\s*\?\s*'btn-sec'\s*:\s*'btn-pri'\}/,
+    );
+  });
+
+  it('gates the connectivity copy block on connectivityFailure', () => {
+    expect(source).toMatch(
+      /\{#if connectivityFailure\}[\s\S]*?Server unreachable — your authorization is likely still valid\.[\s\S]*?\{\/if\}/,
+    );
+  });
+
+  it('points the copy at Re-authenticate when no refresh token is available', () => {
+    expect(source).toMatch(
+      /\{canRefresh\s*\?\s*'Retry once your connection is back\.'\s*:\s*'Re-authenticate once your connection is back\.'\}/,
+    );
   });
 });
 

--- a/src/lib/components/AuthTab.test.ts
+++ b/src/lib/components/AuthTab.test.ts
@@ -61,8 +61,9 @@ function canReauth(status: MinimalOAuthStatus | null): boolean {
   );
 }
 
-// Pure mirror of the `connectivityFailure` derivation in AuthTab.svelte, which
-// delegates to `isConnectivityFailure()` from $lib/oauth/actions. Kept in sync
+// Pure mirror of the `connectivityFailure` derivation in AuthTab.svelte. This
+// is a direct string comparison that must be kept in sync with
+// `isConnectivityFailure()` from $lib/oauth/actions (and AuthTab's derivation)
 // so we can unit-test which statuses trigger the connectivity presentation
 // (explanatory copy + Refresh Now promoted to primary).
 function connectivityFailure(status: MinimalOAuthStatus | null): boolean {

--- a/src/lib/oauth/actions.test.ts
+++ b/src/lib/oauth/actions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { canReauthorize, reauthorize, type ReauthorizeDeps } from './actions';
+import { canReauthorize, isConnectivityFailure, reauthorize, type ReauthorizeDeps } from './actions';
 import type { OAuthStartResult, OAuthStatusValue } from '$lib/types';
 
 function makeDeps(overrides: Partial<ReauthorizeDeps> = {}): ReauthorizeDeps {
@@ -49,6 +49,18 @@ describe('reauthorize', () => {
     );
   });
 
+  it('reports a connectivity error when startOAuth returns discovery_unreachable', async () => {
+    const deps = makeDeps({
+      startOAuth: vi.fn().mockResolvedValue({ error: 'discovery_unreachable' } as OAuthStartResult),
+    });
+    await reauthorize('srv', deps);
+    expect(deps.openUrl).not.toHaveBeenCalled();
+    expect(deps.onSuccess).not.toHaveBeenCalled();
+    expect(deps.onError).toHaveBeenCalledWith(
+      "Couldn't reach the server to start authorization. Check your connection and try again.",
+    );
+  });
+
   it('reports a dcr_unsupported error when startOAuth returns that error', async () => {
     const deps = makeDeps({
       startOAuth: vi.fn().mockResolvedValue({ error: 'dcr_unsupported' } as OAuthStartResult),
@@ -75,6 +87,23 @@ describe('canReauthorize', () => {
   for (const [status, expected] of cases) {
     it(`returns ${expected} for status "${status}"`, () => {
       expect(canReauthorize(status)).toBe(expected);
+    });
+  }
+});
+
+describe('isConnectivityFailure', () => {
+  const cases: Array<[OAuthStatusValue, boolean]> = [
+    ['connection_failed', true],
+    ['disconnected', false],
+    ['auth_required', false],
+    ['needs_login', false],
+    ['authenticated', false],
+    ['refreshing', false],
+  ];
+
+  for (const [status, expected] of cases) {
+    it(`returns ${expected} for status "${status}"`, () => {
+      expect(isConnectivityFailure(status)).toBe(expected);
     });
   }
 });

--- a/src/lib/oauth/actions.ts
+++ b/src/lib/oauth/actions.ts
@@ -11,6 +11,15 @@ export function canReauthorize(status: OAuthStatusValue): boolean {
   return REAUTHORIZE_STATUSES.includes(status);
 }
 
+/**
+ * `connection_failed` means the server is unreachable — the stored tokens are
+ * likely still valid, so retry/refresh (not re-authentication) should be the
+ * suggested first step in the UI.
+ */
+export function isConnectivityFailure(status: OAuthStatusValue): boolean {
+  return status === 'connection_failed';
+}
+
 export interface ReauthorizeDeps {
   startOAuth: (name: string) => Promise<OAuthStartResult>;
   openUrl: (url: string) => Promise<void>;
@@ -23,6 +32,8 @@ export async function reauthorize(name: string, deps: ReauthorizeDeps): Promise<
   if ('authorize_url' in result) {
     await deps.openUrl(result.authorize_url);
     deps.onSuccess('Browser opened for authorization');
+  } else if ('error' in result && result.error === 'discovery_unreachable') {
+    deps.onError("Couldn't reach the server to start authorization. Check your connection and try again.");
   } else if ('error' in result && result.error === 'discovery_failed') {
     deps.onError('OAuth discovery failed. Go to Settings to configure OAuth server URL manually.');
   } else if ('error' in result && result.error === 'dcr_unsupported') {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -167,7 +167,16 @@ export interface OAuthStartDiscoveryFailed {
   detail?: string;
 }
 
-export type OAuthStartResult = OAuthStartSuccess | OAuthStartDcrUnsupported | OAuthStartDiscoveryFailed;
+export interface OAuthStartDiscoveryUnreachable {
+  error: 'discovery_unreachable';
+  detail?: string;
+}
+
+export type OAuthStartResult =
+  | OAuthStartSuccess
+  | OAuthStartDcrUnsupported
+  | OAuthStartDiscoveryFailed
+  | OAuthStartDiscoveryUnreachable;
 
 export type OAuthSetupStatus = 'awaiting_credentials' | 'awaiting_auth' | 'authorized';
 


### PR DESCRIPTION
## Problem

During a transient network outage to an OAuth MCP server (observed 2026-07-27 with `api.sunsama.com` on 0.1.11-rc.3), the endpoint's `connection_failed` state read as "authorization expired" in the UI, steering the user into an unnecessary re-authentication — which then failed further down the stack (see companion relay PR).

## Fix

- **AuthTab.svelte**: `connection_failed` now shows connectivity-focused copy ("server unreachable — your authorization is likely still valid") and makes **Refresh Now** the primary action, with Re-authenticate secondary (Re-authenticate stays primary when there is no refresh token to retry with).
- **oauth/actions.ts**: new `isConnectivityFailure()` helper; `reauthorize()` maps the relay's new `discovery_unreachable` error to a connectivity toast: "Couldn't reach the server to start authorization. Check your connection and try again."
- **api.ts**: `startOAuth()` passes the relay's `502 {"error":"discovery_unreachable","detail":...}` response through as a typed result instead of throwing (same pattern as `dcr_unsupported` / `discovery_failed`), so the `reauthorize()` branch is reachable end-to-end.
- **types.ts**: adds `OAuthStartDiscoveryUnreachable` to `OAuthStartResult`.

## Tests

- Api-layer regression test for the 502 `discovery_unreachable` pass-through (confirmed failing before the `api.ts` change), plus coverage of the other typed pass-throughs and the generic non-2xx throw.
- `reauthorize()` `discovery_unreachable` branch and `isConnectivityFailure()` table tests; AuthTab display expectations updated.
- `pnpm test`: 1091 passed | 39 skipped; `pnpm check`: 0 errors.

Companion relay PR that introduces the `discovery_unreachable` error: endara-ai/endara-relay#133

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author