### PR TITLE
chore: bump version to 0.1.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endara/desktop",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "description": "Endara Desktop — Tauri + Svelte tray app for relay management",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "endara-desktop"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "arc-swap",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endara-desktop"
-version = "0.1.11"
+version = "0.1.12"
 description = "Endara Desktop — relay management tray app"
 authors = ["Endara"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Endara Desktop",
   "mainBinaryName": "Endara Desktop",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "identifier": "ai.endara.desktop",
   "build": {
     "beforeDevCommand": "ENDARA_DEV_PORT=9500 bash scripts/kill-relay.sh; npm run dev",


### PR DESCRIPTION
Scenario 3 base-version bump after the stable v0.1.11 release.

- `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json` → `0.1.12` in lockstep
- `src-tauri/Cargo.lock` refreshed via `cargo update --workspace`
- `pnpm-lock.yaml` untouched (does not pin the package's own version)

Verified with `pnpm run check` (0 errors).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author