### PR TITLE
fix: recover Profiles tab from transient load failure

### DIFF
--- a/src/lib/components/Profiles.svelte
+++ b/src/lib/components/Profiles.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { listProfiles, type ProfileSummary } from '$lib/api';
+  import { activeTopLevelTab, relaySidecarStatus, type RelaySidecarStatusType } from '$lib/stores';
+  import type { TopLevelTabId } from '$lib/relaySidecarUi';
   import { requestNavigation } from '$lib/stores/unsavedChangesGuard';
+  import {
+    shouldAutoReloadOnRelayRecovery,
+    shouldAutoReloadOnTabActivation,
+  } from './profiles-retry-helpers';
   import ProfileSidebar from './ProfileSidebar.svelte';
   import ProfileDetail from './ProfileDetail.svelte';
   import CreateProfileModal from './CreateProfileModal.svelte';
@@ -10,6 +16,7 @@
   let selectedPath: string | null = $state(null);
   let loading = $state(true);
   let loadError = $state('');
+  let retrying = $state(false);
   let showCreateModal = $state(false);
 
   async function load() {
@@ -25,8 +32,44 @@
     }
   }
 
+  async function retry() {
+    if (retrying) return;
+    retrying = true;
+    try {
+      await load();
+    } finally {
+      retrying = false;
+    }
+  }
+
   onMount(() => {
     load();
+
+    // Auto-recover from a transient load failure: re-run load() when the
+    // Profiles tab becomes active again, or when the relay sidecar comes
+    // back to `running` (the tab stays mounted via display:none keep-alive,
+    // so a relay restart otherwise strands it on the error state). Both
+    // only fire while `loadError` is set — successful loads never refetch.
+    let prevTab: TopLevelTabId | undefined;
+    const unsubTab = activeTopLevelTab.subscribe((tab) => {
+      if (shouldAutoReloadOnTabActivation(tab, prevTab, Boolean(loadError))) {
+        void retry();
+      }
+      prevTab = tab;
+    });
+
+    let prevRelayStatus: RelaySidecarStatusType | undefined;
+    const unsubRelay = relaySidecarStatus.subscribe((status) => {
+      if (shouldAutoReloadOnRelayRecovery(status, prevRelayStatus, Boolean(loadError))) {
+        void retry();
+      }
+      prevRelayStatus = status;
+    });
+
+    return () => {
+      unsubTab();
+      unsubRelay();
+    };
   });
 
   function handleSelect(path: string | null) {
@@ -57,8 +100,11 @@
 
 <div class="h-full flex flex-col">
   {#if loadError && profiles.length === 0}
-    <div class="flex-1 flex items-center justify-center text-(--offline) text-sm">
-      {loadError}
+    <div class="flex-1 flex flex-col items-center justify-center gap-3">
+      <div class="text-(--offline) text-sm">{loadError}</div>
+      <button class="btn-sec btn-sm" onclick={retry} disabled={retrying}>
+        {retrying ? 'Retrying…' : 'Retry'}
+      </button>
     </div>
   {:else if !loading && profiles.length === 0}
     <div

--- a/src/lib/components/ProfilesTab.svelte
+++ b/src/lib/components/ProfilesTab.svelte
@@ -77,7 +77,7 @@
       <button
         class="btn-sec btn-sm"
         onclick={() => {
-          if ($selectedEndpoint) load($selectedEndpoint);
+          if ($selectedEndpoint) void load($selectedEndpoint);
         }}
       >
         Retry

--- a/src/lib/components/ProfilesTab.svelte
+++ b/src/lib/components/ProfilesTab.svelte
@@ -72,7 +72,17 @@
       {/each}
     </div>
   {:else if error}
-    <div class="text-sm text-(--offline)">{error}</div>
+    <div class="flex flex-col items-start gap-2">
+      <div class="text-sm text-(--offline)">{error}</div>
+      <button
+        class="btn-sec btn-sm"
+        onclick={() => {
+          if ($selectedEndpoint) load($selectedEndpoint);
+        }}
+      >
+        Retry
+      </button>
+    </div>
   {:else if rows.length === 0}
     <div class="text-sm text-(--fg3) text-center py-6">
       No profiles yet — create one in the Profiles tab to namespace your servers.

--- a/src/lib/components/profiles-retry-helpers.ts
+++ b/src/lib/components/profiles-retry-helpers.ts
@@ -1,0 +1,31 @@
+import type { RelaySidecarStatusType } from '$lib/stores';
+import type { TopLevelTabId } from '$lib/relaySidecarUi';
+
+/**
+ * True when the Profiles top-level tab just became active while the last
+ * profiles load failed. `prevTab === undefined` means this is the initial
+ * subscription callback (onMount already loads), so it never triggers.
+ * Staying on the profiles tab (prevTab === 'profiles') doesn't re-trigger —
+ * only an actual activation transition does.
+ */
+export function shouldAutoReloadOnTabActivation(
+  tab: TopLevelTabId,
+  prevTab: TopLevelTabId | undefined,
+  hasLoadError: boolean,
+): boolean {
+  return tab === 'profiles' && prevTab !== undefined && prevTab !== 'profiles' && hasLoadError;
+}
+
+/**
+ * True when the relay sidecar just transitioned to `running` while the last
+ * profiles load failed — covers the user sitting on the Profiles tab through
+ * a relay restart. `prevStatus === undefined` (initial subscription callback)
+ * never triggers.
+ */
+export function shouldAutoReloadOnRelayRecovery(
+  status: RelaySidecarStatusType,
+  prevStatus: RelaySidecarStatusType | undefined,
+  hasLoadError: boolean,
+): boolean {
+  return status === 'running' && prevStatus !== undefined && prevStatus !== 'running' && hasLoadError;
+}

--- a/src/lib/components/profiles-retry.test.ts
+++ b/src/lib/components/profiles-retry.test.ts
@@ -111,7 +111,7 @@ describe('shouldAutoReloadOnRelayRecovery', () => {
 describe('ProfilesTab error-state Retry button (source wiring)', () => {
   it('renders a Retry button in the error branch that re-runs load($selectedEndpoint)', () => {
     expect(profilesTabSource).toMatch(
-      /\{:else if error\}[\s\S]*?\{error\}[\s\S]*?<button[\s\S]*?if \(\$selectedEndpoint\) load\(\$selectedEndpoint\);[\s\S]*?Retry[\s\S]*?\{:else if rows\.length === 0\}/,
+      /\{:else if error\}[\s\S]*?\{error\}[\s\S]*?<button[\s\S]*?if \(\$selectedEndpoint\) void load\(\$selectedEndpoint\);[\s\S]*?Retry[\s\S]*?\{:else if rows\.length === 0\}/,
     );
   });
 });

--- a/src/lib/components/profiles-retry.test.ts
+++ b/src/lib/components/profiles-retry.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+
+import profilesSource from './Profiles.svelte?raw';
+import profilesTabSource from './ProfilesTab.svelte?raw';
+import {
+  shouldAutoReloadOnRelayRecovery,
+  shouldAutoReloadOnTabActivation,
+} from './profiles-retry-helpers';
+
+// Coverage for "recover Profiles tab from transient load failure".
+//
+// The Svelte components can't be mounted in the node test environment
+// (matching the convention documented in Profiles.unsaved.test.ts), so the
+// component wiring is asserted at the source level and the reload-decision
+// logic is exercised behaviourally through the extracted helpers.
+
+describe('Profiles error-state Retry button (source wiring)', () => {
+  it('renders a Retry button in the load-error branch that calls retry()', () => {
+    // Error branch shows the message plus a Retry button wired to retry().
+    expect(profilesSource).toMatch(
+      /\{#if loadError && profiles\.length === 0\}[\s\S]*?\{loadError\}[\s\S]*?<button[\s\S]*?onclick=\{retry\}[\s\S]*?Retry[\s\S]*?\{:else if/,
+    );
+  });
+
+  it('retry() re-runs load() and exposes a retrying state for the button', () => {
+    expect(profilesSource).toMatch(
+      /async function retry\(\)\s*\{[\s\S]*?retrying = true;[\s\S]*?await load\(\);[\s\S]*?retrying = false;[\s\S]*?\}/,
+    );
+    expect(profilesSource).toMatch(/disabled=\{retrying\}/);
+    expect(profilesSource).toMatch(/retrying \? 'Retrying…' : 'Retry'/);
+  });
+
+  it('load() success populates profiles and clears loadError (Retry renders data)', () => {
+    // Clicking Retry runs load(); on success it stores the fetched profiles
+    // and clears the error, which switches the template off the error branch.
+    expect(profilesSource).toMatch(
+      /const data = await listProfiles\(\);\s*profiles = data;\s*loadError = '';/,
+    );
+  });
+});
+
+describe('Profiles auto-reload subscriptions (source wiring)', () => {
+  it('subscribes to activeTopLevelTab and retries via shouldAutoReloadOnTabActivation', () => {
+    expect(profilesSource).toMatch(
+      /activeTopLevelTab\.subscribe\(\(tab\) => \{[\s\S]*?shouldAutoReloadOnTabActivation\(tab, prevTab, Boolean\(loadError\)\)[\s\S]*?void retry\(\);[\s\S]*?prevTab = tab;/,
+    );
+  });
+
+  it('subscribes to relaySidecarStatus and retries via shouldAutoReloadOnRelayRecovery', () => {
+    expect(profilesSource).toMatch(
+      /relaySidecarStatus\.subscribe\(\(status\) => \{[\s\S]*?shouldAutoReloadOnRelayRecovery\(status, prevRelayStatus, Boolean\(loadError\)\)[\s\S]*?void retry\(\);[\s\S]*?prevRelayStatus = status;/,
+    );
+  });
+
+  it('cleans up both subscriptions on unmount', () => {
+    expect(profilesSource).toMatch(
+      /return \(\) => \{\s*unsubTab\(\);\s*unsubRelay\(\);\s*\};/,
+    );
+  });
+});
+
+describe('shouldAutoReloadOnTabActivation', () => {
+  it('triggers when the profiles tab becomes active after a failed load', () => {
+    expect(shouldAutoReloadOnTabActivation('profiles', 'servers', true)).toBe(true);
+    expect(shouldAutoReloadOnTabActivation('profiles', 'settings', true)).toBe(true);
+  });
+
+  it('does not trigger when the last load succeeded', () => {
+    expect(shouldAutoReloadOnTabActivation('profiles', 'servers', false)).toBe(false);
+  });
+
+  it('does not trigger on the initial subscription callback (onMount already loads)', () => {
+    expect(shouldAutoReloadOnTabActivation('profiles', undefined, true)).toBe(false);
+  });
+
+  it('does not re-trigger while staying on the profiles tab', () => {
+    expect(shouldAutoReloadOnTabActivation('profiles', 'profiles', true)).toBe(false);
+  });
+
+  it('does not trigger when a different tab becomes active', () => {
+    expect(shouldAutoReloadOnTabActivation('servers', 'profiles', true)).toBe(false);
+    expect(shouldAutoReloadOnTabActivation('settings', 'servers', true)).toBe(false);
+  });
+});
+
+describe('shouldAutoReloadOnRelayRecovery', () => {
+  it('triggers when the relay transitions to running while loadError is set', () => {
+    expect(shouldAutoReloadOnRelayRecovery('running', 'restarting', true)).toBe(true);
+    expect(shouldAutoReloadOnRelayRecovery('running', 'starting', true)).toBe(true);
+    expect(shouldAutoReloadOnRelayRecovery('running', 'failed', true)).toBe(true);
+  });
+
+  it('does not trigger when the last load succeeded', () => {
+    expect(shouldAutoReloadOnRelayRecovery('running', 'restarting', false)).toBe(false);
+  });
+
+  it('does not trigger on the initial subscription callback', () => {
+    expect(shouldAutoReloadOnRelayRecovery('running', undefined, true)).toBe(false);
+  });
+
+  it('does not re-trigger while the relay stays running', () => {
+    expect(shouldAutoReloadOnRelayRecovery('running', 'running', true)).toBe(false);
+  });
+
+  it('does not trigger on transitions to non-running states', () => {
+    expect(shouldAutoReloadOnRelayRecovery('failed', 'running', true)).toBe(false);
+    expect(shouldAutoReloadOnRelayRecovery('restarting', 'running', true)).toBe(false);
+  });
+});
+
+describe('ProfilesTab error-state Retry button (source wiring)', () => {
+  it('renders a Retry button in the error branch that re-runs load($selectedEndpoint)', () => {
+    expect(profilesTabSource).toMatch(
+      /\{:else if error\}[\s\S]*?\{error\}[\s\S]*?<button[\s\S]*?if \(\$selectedEndpoint\) load\(\$selectedEndpoint\);[\s\S]*?Retry[\s\S]*?\{:else if rows\.length === 0\}/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

The top-level Profiles tab was a dead end after a failed initial load (e.g. the relay sidecar wasn't up yet, or restarted): the error message rendered with no way to recover short of restarting the app, because the tab stays mounted via the `display:none` keep-alive and `load()` only ran in `onMount`.

This PR makes the tab recoverable:

- **Retry button** in `Profiles.svelte`'s load-error state, with a `Retrying…` disabled state while the reload is in flight (matches the Settings relay Retry pattern).
- **Auto-reload on tab activation**: subscribes to `activeTopLevelTab`; when it transitions to `profiles` while `loadError` is set, `load()` re-runs automatically. Successful loads never refetch on activation.
- **Auto-reload on relay recovery**: subscribes to `relaySidecarStatus`; when it transitions to `running` while `loadError` is set, `load()` re-runs — covers the user sitting on the Profiles tab through a relay restart.
- **`ProfilesTab.svelte`** (server-detail inner tab) gets the same minimal Retry affordance on its error state, re-running `load($selectedEndpoint)`.

The reload-decision predicates are extracted into `profiles-retry-helpers.ts` following the existing `*-helpers.ts` convention.

## Tests

`profiles-retry.test.ts` follows the `Profiles.unsaved.test.ts` convention (source-level wiring assertions + behavioral helper tests, since components can't be mounted in the node test environment):

- Error state renders a Retry button wired to `retry()`; `retry()` re-runs `load()` and success populates profiles / clears the error.
- Tab re-activation after a failed load triggers reload (and not on initial subscription, not when staying on the tab, not after a successful load).
- Relay `running` transition triggers reload (and not while staying running, not on non-running transitions, not after a successful load).
- `ProfilesTab.svelte` error state renders Retry wired to `load($selectedEndpoint)`.

## Verification

- `npm run check` — 0 errors, 0 warnings
- `npm run lint` — no linter configured
- `npm test` — 1150 passed | 39 skipped

Scope: no changes to `UnifiedCatalog.svelte`, routing, or relay lifecycle code.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author