### PR TITLE
feat: add write-directories settings with native picker

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@humanspeak/svelte-json-view-lite':
         specifier: ^0.1.2
         version: 0.1.2(svelte@5.55.9)
+      '@tanstack/svelte-virtual':
+        specifier: ^3.13.35
+        version: 3.13.35(svelte@5.55.9)
       '@tauri-apps/api':
         specifier: ^2.11.0
         version: 2.11.0
@@ -536,6 +539,14 @@ packages:
     resolution: {integrity: sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tanstack/svelte-virtual@3.13.35':
+    resolution: {integrity: sha512-4ur3bPzSXnZZtQWwns/ziCR9pJ/4x/AlBIeDZu96MKrRMbZBL1TQkGiO+ZaX5zCgdpXUZwJnehKzBp32KOumCQ==}
+    peerDependencies:
+      svelte: ^3.48.0 || ^4.0.0 || ^5.0.0
+
+  '@tanstack/virtual-core@3.17.7':
+    resolution: {integrity: sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==}
 
   '@tauri-apps/api@2.11.0':
     resolution: {integrity: sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==}
@@ -1425,6 +1436,13 @@ snapshots:
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
       vite: 6.4.2(jiti@2.7.0)(lightningcss@1.32.0)
+
+  '@tanstack/svelte-virtual@3.13.35(svelte@5.55.9)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.7
+      svelte: 5.55.9
+
+  '@tanstack/virtual-core@3.17.7': {}
 
   '@tauri-apps/api@2.11.0': {}
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -466,6 +466,10 @@ fn read_write_dirs() -> Vec<String> {
     let Ok(parsed) = read_config() else {
         return Vec::new();
     };
+    // De-duplicate while preserving first-seen order: a hand-edited config
+    // with duplicate entries would otherwise produce duplicate keys in the
+    // UI's keyed `{#each}` list.
+    let mut seen = std::collections::HashSet::new();
     parsed
         .get("relay")
         .and_then(|v| v.as_table())
@@ -474,6 +478,7 @@ fn read_write_dirs() -> Vec<String> {
         .map(|arr| {
             arr.iter()
                 .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .filter(|s| seen.insert(s.clone()))
                 .collect()
         })
         .unwrap_or_default()
@@ -1829,6 +1834,18 @@ async fn get_write_dirs() -> Result<Vec<String>, String> {
 
 #[tauri::command]
 async fn set_write_dirs(dirs: Vec<String>) -> Result<(), String> {
+    // Fail fast at the Tauri boundary: the native picker only produces
+    // absolute paths, and the relay rejects relative entries on reload —
+    // but never persist an entry the relay would later flag.
+    if let Some(bad) = dirs
+        .iter()
+        .find(|d| d.is_empty() || !std::path::Path::new(d).is_absolute())
+    {
+        return Err(format!(
+            "write_dirs entries must be absolute paths, got: {bad:?}"
+        ));
+    }
+
     let mut table = read_config().unwrap_or_else(|_| toml::Table::new());
 
     // Ensure [relay] section exists. The relay's `RelayConfig` requires
@@ -3988,6 +4005,33 @@ mod write_dirs_tests {
 
         rt.block_on(set_write_dirs(vec![]))
             .expect("clear write_dirs");
+        assert!(read_write_dirs().is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn get_write_dirs_deduplicates_preserving_order() {
+        let _home = HomeGuard::new();
+        write_config_str(
+            "[relay]\nmachine_name = \"x\"\nwrite_dirs = [\"/tmp/a\", \"/tmp/b\", \"/tmp/a\"]\n",
+        );
+        assert_eq!(read_write_dirs(), vec!["/tmp/a", "/tmp/b"]);
+    }
+
+    #[test]
+    #[serial]
+    fn set_write_dirs_rejects_relative_and_empty_paths() {
+        let _home = HomeGuard::new();
+        let rt = rt();
+        write_config_str("[relay]\nmachine_name = \"x\"\n");
+
+        for bad in ["relative/path", "", "./dot"] {
+            let err = rt
+                .block_on(set_write_dirs(vec!["/tmp/a".to_string(), bad.to_string()]))
+                .expect_err("non-absolute entry should be rejected");
+            assert!(err.contains("absolute"), "unexpected error: {err}");
+        }
+        // Nothing was persisted by the rejected calls.
         assert!(read_write_dirs().is_empty());
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -459,6 +459,26 @@ fn read_toon_output() -> bool {
         .unwrap_or(true)
 }
 
+/// Read `relay.write_dirs` from `~/.endara/config.toml`.
+/// Returns an empty list on any error, missing section, or missing key —
+/// matches the relay's own default (no writable directories).
+fn read_write_dirs() -> Vec<String> {
+    let Ok(parsed) = read_config() else {
+        return Vec::new();
+    };
+    parsed
+        .get("relay")
+        .and_then(|v| v.as_table())
+        .and_then(|t| t.get("write_dirs"))
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 /// Holds the relay sidecar child process handle.
 pub struct RelayState {
     child: Arc<Mutex<Option<tauri_plugin_shell::process::CommandChild>>>,
@@ -1799,6 +1819,53 @@ async fn set_toon_output(enabled: bool) -> Result<(), String> {
     write_config(&table)
 }
 
+/// Get the list of directories sandbox scripts may write into.
+/// Returns an empty list (the relay's own default) if the config is missing,
+/// malformed, has no `[relay]` section, or has no `write_dirs` field.
+#[tauri::command]
+async fn get_write_dirs() -> Result<Vec<String>, String> {
+    Ok(read_write_dirs())
+}
+
+#[tauri::command]
+async fn set_write_dirs(dirs: Vec<String>) -> Result<(), String> {
+    let mut table = read_config().unwrap_or_else(|_| toml::Table::new());
+
+    // Ensure [relay] section exists. The relay's `RelayConfig` requires
+    // `machine_name`, so populate it from the system hostname when creating
+    // the section from scratch — otherwise the relay's next config reload
+    // would fail to deserialize.
+    let relay = table
+        .entry("relay")
+        .or_insert_with(|| {
+            let mut t = toml::Table::new();
+            let machine_name = hostname::get()
+                .ok()
+                .and_then(|h| h.into_string().ok())
+                .unwrap_or_else(|| "unknown".to_string());
+            t.insert(
+                "machine_name".to_string(),
+                toml::Value::String(machine_name),
+            );
+            toml::Value::Table(t)
+        })
+        .as_table_mut()
+        .ok_or("Invalid [relay] section in config")?;
+
+    // De-duplicate while preserving first-seen order so repeated picker
+    // selections never produce duplicate entries on disk.
+    let mut seen = std::collections::HashSet::new();
+    let deduped: Vec<toml::Value> = dirs
+        .into_iter()
+        .filter(|d| seen.insert(d.clone()))
+        .map(toml::Value::String)
+        .collect();
+
+    relay.insert("write_dirs".to_string(), toml::Value::Array(deduped));
+
+    write_config(&table)
+}
+
 /// Get the current update channel ("stable" or "beta").
 #[tauri::command]
 async fn get_update_channel() -> Result<String, String> {
@@ -2515,6 +2582,8 @@ pub fn run() {
             set_js_execution_mode,
             get_toon_output,
             set_toon_output,
+            get_write_dirs,
+            set_write_dirs,
             get_config_path_display,
             get_buffered_relay_logs,
             get_update_channel,
@@ -3787,6 +3856,262 @@ mod toon_output_tests {
             Some(false),
             "toon_output should be set to false"
         );
+
+        let endpoints = parsed
+            .get("endpoints")
+            .and_then(|v| v.as_array())
+            .expect("[[endpoints]] preserved");
+        assert_eq!(endpoints.len(), 1, "endpoint count should be unchanged");
+        let ep = endpoints[0].as_table().expect("endpoint is a table");
+        assert_eq!(ep.get("name").and_then(|v| v.as_str()), Some("gmail-acct"));
+        assert_eq!(ep.get("transport").and_then(|v| v.as_str()), Some("stdio"));
+        assert_eq!(
+            ep.get("tool_prefix").and_then(|v| v.as_str()),
+            Some("gmail")
+        );
+        assert_eq!(ep.get("command").and_then(|v| v.as_str()), Some("echo"));
+        let args = ep
+            .get("args")
+            .and_then(|v| v.as_array())
+            .expect("args preserved");
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0].as_str(), Some("hi"));
+    }
+}
+
+#[cfg(test)]
+mod write_dirs_tests {
+    //! Round-trip coverage for `read_write_dirs` and `set_write_dirs`.
+    //! Mirrors `toon_output_tests` but pins the default to an empty list —
+    //! a missing field, missing section, missing file, or malformed file all
+    //! resolve to no writable directories.
+    use super::*;
+    use serial_test::serial;
+    use tempfile::TempDir;
+
+    struct HomeGuard {
+        prior: Option<String>,
+        _tmp: TempDir,
+    }
+
+    impl HomeGuard {
+        fn new() -> Self {
+            let prior = std::env::var("HOME").ok();
+            let tmp = tempfile::tempdir().expect("create tempdir");
+            std::env::set_var("HOME", tmp.path());
+            Self { prior, _tmp: tmp }
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            match &self.prior {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+    }
+
+    fn rt() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build tokio runtime")
+    }
+
+    fn write_config_str(contents: &str) {
+        let path = config_path().expect("config_path");
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent dir");
+        }
+        std::fs::write(&path, contents).expect("write config.toml");
+    }
+
+    fn read_config_str() -> String {
+        let path = config_path().expect("config_path");
+        std::fs::read_to_string(&path).expect("read config.toml")
+    }
+
+    #[test]
+    #[serial]
+    fn get_write_dirs_returns_entries_when_set() {
+        let _home = HomeGuard::new();
+        write_config_str("[relay]\nmachine_name = \"x\"\nwrite_dirs = [\"/tmp/a\", \"/tmp/b\"]\n");
+        assert_eq!(read_write_dirs(), vec!["/tmp/a", "/tmp/b"]);
+    }
+
+    #[test]
+    #[serial]
+    fn get_write_dirs_returns_empty_when_field_missing() {
+        let _home = HomeGuard::new();
+        write_config_str("[relay]\nmachine_name = \"x\"\n");
+        assert!(read_write_dirs().is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn get_write_dirs_returns_empty_when_no_relay_section() {
+        let _home = HomeGuard::new();
+        write_config_str("[desktop]\nupdate_channel = \"stable\"\n");
+        assert!(read_write_dirs().is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn get_write_dirs_returns_empty_when_file_missing() {
+        let _home = HomeGuard::new();
+        // No config.toml written.
+        assert!(read_write_dirs().is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn get_write_dirs_returns_empty_when_file_malformed() {
+        let _home = HomeGuard::new();
+        write_config_str("not valid toml ====\n");
+        assert!(read_write_dirs().is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn set_write_dirs_roundtrips() {
+        let _home = HomeGuard::new();
+        let rt = rt();
+        write_config_str("[relay]\nmachine_name = \"x\"\n");
+
+        rt.block_on(set_write_dirs(vec![
+            "/tmp/a".to_string(),
+            "/tmp/b".to_string(),
+        ]))
+        .expect("set write_dirs");
+        assert_eq!(read_write_dirs(), vec!["/tmp/a", "/tmp/b"]);
+
+        rt.block_on(set_write_dirs(vec![]))
+            .expect("clear write_dirs");
+        assert!(read_write_dirs().is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn set_write_dirs_deduplicates_preserving_order() {
+        let _home = HomeGuard::new();
+        let rt = rt();
+        write_config_str("[relay]\nmachine_name = \"x\"\n");
+
+        rt.block_on(set_write_dirs(vec![
+            "/tmp/a".to_string(),
+            "/tmp/b".to_string(),
+            "/tmp/a".to_string(),
+        ]))
+        .expect("set write_dirs");
+
+        assert_eq!(read_write_dirs(), vec!["/tmp/a", "/tmp/b"]);
+    }
+
+    #[test]
+    #[serial]
+    fn set_write_dirs_creates_missing_relay_section() {
+        let _home = HomeGuard::new();
+        let rt = rt();
+        write_config_str("[desktop]\nupdate_channel = \"stable\"\n");
+
+        rt.block_on(set_write_dirs(vec!["/tmp/a".to_string()]))
+            .expect("set_write_dirs should succeed");
+
+        let toml_str = read_config_str();
+        let parsed: toml::Table =
+            toml::from_str(&toml_str).expect("re-parse config.toml as toml::Table");
+
+        let relay = parsed
+            .get("relay")
+            .and_then(|v| v.as_table())
+            .expect("[relay] section should exist");
+        let dirs = relay
+            .get("write_dirs")
+            .and_then(|v| v.as_array())
+            .expect("write_dirs should be set");
+        assert_eq!(dirs.len(), 1);
+        assert_eq!(dirs[0].as_str(), Some("/tmp/a"));
+        let machine_name = relay
+            .get("machine_name")
+            .and_then(|v| v.as_str())
+            .expect("machine_name should be set");
+        assert!(
+            !machine_name.is_empty(),
+            "machine_name should be non-empty, got {machine_name:?}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn set_write_dirs_preserves_other_fields() {
+        let _home = HomeGuard::new();
+        let rt = rt();
+        write_config_str(
+            "[desktop]\n\
+             update_channel = \"beta\"\n\
+             \n\
+             [relay]\n\
+             machine_name = \"host\"\n\
+             token_dir = \"/tmp/x\"\n\
+             local_js_execution = true\n\
+             toon_output = false\n\
+             \n\
+             [[endpoints]]\n\
+             name = \"gmail-acct\"\n\
+             transport = \"stdio\"\n\
+             tool_prefix = \"gmail\"\n\
+             command = \"echo\"\n\
+             args = [\"hi\"]\n",
+        );
+
+        rt.block_on(set_write_dirs(vec!["/tmp/allowed".to_string()]))
+            .expect("set_write_dirs should succeed");
+
+        let toml_str = read_config_str();
+        let parsed: toml::Table =
+            toml::from_str(&toml_str).expect("re-parse config.toml as toml::Table");
+
+        let desktop = parsed
+            .get("desktop")
+            .and_then(|v| v.as_table())
+            .expect("[desktop] preserved");
+        assert_eq!(
+            desktop.get("update_channel").and_then(|v| v.as_str()),
+            Some("beta"),
+            "update_channel should be preserved"
+        );
+
+        let relay = parsed
+            .get("relay")
+            .and_then(|v| v.as_table())
+            .expect("[relay] preserved");
+        assert_eq!(
+            relay.get("machine_name").and_then(|v| v.as_str()),
+            Some("host"),
+            "machine_name should be preserved"
+        );
+        assert_eq!(
+            relay.get("token_dir").and_then(|v| v.as_str()),
+            Some("/tmp/x"),
+            "token_dir should be preserved"
+        );
+        assert_eq!(
+            relay.get("local_js_execution").and_then(|v| v.as_bool()),
+            Some(true),
+            "local_js_execution should be preserved"
+        );
+        assert_eq!(
+            relay.get("toon_output").and_then(|v| v.as_bool()),
+            Some(false),
+            "toon_output should be preserved"
+        );
+        let dirs = relay
+            .get("write_dirs")
+            .and_then(|v| v.as_array())
+            .expect("write_dirs should be set");
+        assert_eq!(dirs.len(), 1);
+        assert_eq!(dirs[0].as_str(), Some("/tmp/allowed"));
 
         let endpoints = parsed
             .get("endpoints")

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { theme, jsExecutionMode, toonOutput, relayPort, relayConnected, relaySidecarStatus, relaySidecarError, updateStatus, updateVersion, updateError, updateChannel, lastCheckedChannel } from '$lib/stores';
+  import { theme, jsExecutionMode, toonOutput, writeDirs, relayPort, relayConnected, relaySidecarStatus, relaySidecarError, updateStatus, updateVersion, updateError, updateChannel, lastCheckedChannel } from '$lib/stores';
   import { autoStartEnabled, fetchAutoStart, toggleAutoStart } from '$lib/stores/autostart';
   import {
     AUTO_DISMISS_MS_MAX,
@@ -27,6 +27,8 @@
   import { canRetryRelay, getSettingsStatusLabel, restartRelay } from '$lib/relaySidecarUi';
   import { fetchJsExecutionMode, toggleJsExecutionMode } from '$lib/jsExecutionModeUi';
   import { fetchToonOutput, toggleToonOutput } from '$lib/toonOutputUi';
+  import { fetchWriteDirs, addWriteDir, removeWriteDir } from '$lib/writeDirsUi';
+  import { open as dialogOpen } from '@tauri-apps/plugin-dialog';
   import { checkAndAutoDownload, restartApp, getUpdateChannel, setUpdateChannel } from '$lib/updater';
   import { onMount, onDestroy } from 'svelte';
   import { toast } from 'svelte-sonner';
@@ -160,6 +162,7 @@
     fetchRelayStatus();
     fetchJsExecutionMode();
     fetchToonOutput();
+    fetchWriteDirs();
     fetchAutoStart();
     fetchOverlaySettings();
     subscribeOverlaySettingsChanges()
@@ -247,6 +250,27 @@
       console.error('Failed to load observability config:', e);
     } finally {
       obsLoading = false;
+    }
+  }
+
+  let addingWriteDir = $state(false);
+
+  async function handleAddWriteDir() {
+    if (addingWriteDir) return;
+    addingWriteDir = true;
+    try {
+      const selected = await dialogOpen({
+        directory: true,
+        multiple: false,
+        title: 'Add write directory',
+      });
+      if (selected && typeof selected === 'string') {
+        await addWriteDir(selected);
+      }
+    } catch (e) {
+      console.error('Failed to pick write directory:', e);
+    } finally {
+      addingWriteDir = false;
     }
   }
 
@@ -391,6 +415,40 @@
       >
         <span class="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform {$toonOutput ? 'translate-x-5' : ''}"></span>
       </button>
+    </div>
+
+    <div>
+      <div class="flex items-start justify-between gap-4">
+        <div>
+          <div class="text-sm font-medium">Write directories</div>
+          <div class="text-xs text-(--fg2) mt-0.5">Directories that sandbox scripts may write into. Scripts cannot write anywhere else on disk.</div>
+        </div>
+        <button
+          class="shrink-0 px-3 py-1.5 text-xs rounded-lg border border-(--border) hover:bg-(--surface-hover) text-(--fg2) transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+          onclick={handleAddWriteDir}
+          disabled={addingWriteDir}
+        >
+          Add directory…
+        </button>
+      </div>
+      {#if $writeDirs.length > 0}
+        <ul class="mt-2 space-y-1">
+          {#each $writeDirs as dir (dir)}
+            <li class="flex items-center justify-between gap-2 px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface)">
+              <span class="text-xs font-mono break-all">{dir}</span>
+              <button
+                class="shrink-0 text-xs text-(--fg2) hover:text-red-500 transition-colors"
+                onclick={() => removeWriteDir(dir)}
+                aria-label="Remove write directory {dir}"
+              >
+                Remove
+              </button>
+            </li>
+          {/each}
+        </ul>
+      {:else}
+        <p class="mt-2 text-xs text-(--fg2)/70">No write directories configured.</p>
+      {/if}
     </div>
 
     <div class="flex items-start justify-between gap-4">

--- a/src/lib/components/Settings.test.ts
+++ b/src/lib/components/Settings.test.ts
@@ -281,6 +281,131 @@ describe('Settings TOON output helpers', () => {
   });
 });
 
+describe('Settings write directories helpers', () => {
+  const invokeMock = invoke as unknown as ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    invokeMock.mockReset();
+    getConfigMock.mockReset();
+    reloadConfigMock.mockReset();
+    // Reset the shared store to its default (empty) before each test so
+    // order doesn't matter.
+    const { writeDirs } = await import('$lib/stores');
+    writeDirs.set([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetchWriteDirs updates the store from the Tauri command', async () => {
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'get_write_dirs') return Promise.resolve(['/tmp/a', '/tmp/b']);
+      return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
+    });
+    const { fetchWriteDirs } = await import('$lib/writeDirsUi');
+    const { writeDirs } = await import('$lib/stores');
+
+    await fetchWriteDirs();
+
+    expect(invokeMock).toHaveBeenCalledWith('get_write_dirs');
+    expect(get(writeDirs)).toEqual(['/tmp/a', '/tmp/b']);
+  });
+
+  it('fetchWriteDirs is resilient to a failing Tauri command', async () => {
+    invokeMock.mockImplementation((cmd: string) => {
+      return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
+    });
+    const { fetchWriteDirs } = await import('$lib/writeDirsUi');
+    const { writeDirs } = await import('$lib/stores');
+    writeDirs.set(['/tmp/kept']);
+
+    await expect(fetchWriteDirs()).resolves.toBeUndefined();
+    expect(get(writeDirs)).toEqual(['/tmp/kept']);
+  });
+
+  it('addWriteDir calls set_write_dirs then reloadConfig, in order', async () => {
+    const callOrder: string[] = [];
+    invokeMock.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
+      if (cmd === 'set_write_dirs') {
+        callOrder.push(`set:${JSON.stringify(args?.dirs)}`);
+        return Promise.resolve(undefined);
+      }
+      return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
+    });
+    reloadConfigMock.mockImplementation(() => {
+      callOrder.push('reload');
+      return Promise.resolve();
+    });
+    const { addWriteDir } = await import('$lib/writeDirsUi');
+    const { writeDirs } = await import('$lib/stores');
+    writeDirs.set(['/tmp/a']);
+
+    await addWriteDir('/tmp/b');
+
+    expect(invokeMock).toHaveBeenCalledWith('set_write_dirs', { dirs: ['/tmp/a', '/tmp/b'] });
+    expect(reloadConfigMock).toHaveBeenCalledTimes(1);
+    expect(callOrder).toEqual(['set:["/tmp/a","/tmp/b"]', 'reload']);
+    expect(get(writeDirs)).toEqual(['/tmp/a', '/tmp/b']);
+  });
+
+  it('addWriteDir is a no-op for a duplicate directory', async () => {
+    const { addWriteDir } = await import('$lib/writeDirsUi');
+    const { writeDirs } = await import('$lib/stores');
+    writeDirs.set(['/tmp/a']);
+
+    await addWriteDir('/tmp/a');
+
+    expect(invokeMock).not.toHaveBeenCalled();
+    expect(reloadConfigMock).not.toHaveBeenCalled();
+    expect(get(writeDirs)).toEqual(['/tmp/a']);
+  });
+
+  it('removeWriteDir calls set_write_dirs then reloadConfig with the entry removed', async () => {
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'set_write_dirs') return Promise.resolve(undefined);
+      return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
+    });
+    reloadConfigMock.mockResolvedValue(undefined);
+    const { removeWriteDir } = await import('$lib/writeDirsUi');
+    const { writeDirs } = await import('$lib/stores');
+    writeDirs.set(['/tmp/a', '/tmp/b']);
+
+    await removeWriteDir('/tmp/a');
+
+    expect(invokeMock).toHaveBeenCalledWith('set_write_dirs', { dirs: ['/tmp/b'] });
+    expect(reloadConfigMock).toHaveBeenCalledTimes(1);
+    expect(get(writeDirs)).toEqual(['/tmp/b']);
+  });
+
+  it('removeWriteDir is a no-op for an unknown directory', async () => {
+    const { removeWriteDir } = await import('$lib/writeDirsUi');
+    const { writeDirs } = await import('$lib/stores');
+    writeDirs.set(['/tmp/a']);
+
+    await removeWriteDir('/tmp/zzz');
+
+    expect(invokeMock).not.toHaveBeenCalled();
+    expect(reloadConfigMock).not.toHaveBeenCalled();
+    expect(get(writeDirs)).toEqual(['/tmp/a']);
+  });
+
+  it('addWriteDir reverts the store when set_write_dirs rejects', async () => {
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'set_write_dirs') return Promise.reject(new Error('write failed'));
+      return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
+    });
+    const { addWriteDir } = await import('$lib/writeDirsUi');
+    const { writeDirs } = await import('$lib/stores');
+    writeDirs.set(['/tmp/a']);
+
+    await addWriteDir('/tmp/b');
+
+    expect(get(writeDirs)).toEqual(['/tmp/a']);
+    expect(reloadConfigMock).not.toHaveBeenCalled();
+  });
+});
+
 
 // Phase 5 — "Activity overlay" section in Settings.svelte. The handlers are
 // inline arrow functions, so following the codebase convention used in

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -6,6 +6,7 @@ export const endpoints = writable<Endpoint[]>([]);
 export const selectedEndpoint = writable<string | null>(null);
 export const jsExecutionMode = writable<boolean>(false);
 export const toonOutput = writable<boolean>(true);
+export const writeDirs = writable<string[]>([]);
 
 function createThemeStore() {
   const stored = typeof window !== 'undefined' ? localStorage.getItem('endara-theme') as Theme | null : null;

--- a/src/lib/writeDirsUi.ts
+++ b/src/lib/writeDirsUi.ts
@@ -1,0 +1,51 @@
+import { invoke } from '@tauri-apps/api/core';
+import { get } from 'svelte/store';
+import { writeDirs } from './stores';
+import { reloadConfig } from './api';
+
+// Read the sandbox write-directory list from the Tauri backend, which reads
+// `~/.endara/config.toml` directly. Mirrors `fetchToonOutput`: the relay is
+// intentionally NOT in the read path so a cold-started UI never races the
+// relay socket coming up.
+export async function fetchWriteDirs(): Promise<void> {
+  try {
+    const dirs = await invoke<string[]>('get_write_dirs');
+    writeDirs.set(dirs);
+  } catch (e) {
+    // Swallow and leave the store at its current value so a transient
+    // failure never throws during Settings mount.
+    console.error('Failed to get write directories:', e);
+  }
+}
+
+// Persist a new directory list: write through Tauri (which updates
+// `~/.endara/config.toml`), then ask the running relay to re-read its config
+// so the live sidecar picks up the list without a restart. Optimistically
+// updates the store first and reverts on failure — same shape as
+// `toggleToonOutput`.
+async function persistWriteDirs(next: string[]): Promise<void> {
+  const prior = get(writeDirs);
+  writeDirs.set(next);
+  try {
+    await invoke('set_write_dirs', { dirs: next });
+    await reloadConfig();
+  } catch (e) {
+    writeDirs.set(prior);
+    console.error('Failed to set write directories:', e);
+  }
+}
+
+// Add a directory to the list. Duplicate selections are a no-op so repeated
+// picker choices never produce duplicate entries.
+export async function addWriteDir(dir: string): Promise<void> {
+  const current = get(writeDirs);
+  if (current.includes(dir)) return;
+  await persistWriteDirs([...current, dir]);
+}
+
+// Remove a directory from the list.
+export async function removeWriteDir(dir: string): Promise<void> {
+  const current = get(writeDirs);
+  if (!current.includes(dir)) return;
+  await persistWriteDirs(current.filter((d) => d !== dir));
+}


### PR DESCRIPTION
## Summary

Adds a "Write directories" setting to the desktop app so users can manage the relay sandbox's `write_dirs` allowlist from the UI, with a native folder picker.

User-visible behavior:

- New settings section listing the directories that sandbox `writeFile` calls are allowed to write into.
- "Add directory" opens the native OS folder picker (Tauri dialog); the chosen directory is added as an absolute path. Entries can be removed individually.
- The list is persisted to the relay config's `write_dirs` array, so the relay picks it up as its write allowlist. An empty list means sandbox writes stay disabled (opt-in only).

## Safety / UI behavior

- Directories are always absolute paths chosen via the native picker — no free-text path entry, reducing typo/traversal risk.
- The desktop UI only edits the allowlist; enforcement (canonical-prefix checks, per-run limits) lives in the relay.

## Linear

END-21 — add writeFile so tool media can reach the filesystem.

## Commits

- feat: add write directories setting with native folder picker
- chore: sync pnpm-lock.yaml with declared @tanstack/svelte-virtual dependency
