### PR TITLE
feat: declare NSLocalNetworkUsageDescription for macOS Local Network permission

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Endara connects to MCP servers on your local network, such as home automation hubs.</string>
+</dict>
+</plist>

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>Endara connects to MCP servers on your local network, such as home automation hubs.</string>
+	<string>This app connects to devices and services on your local network that you configure, such as home automation hubs.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

The macOS bundle did not declare NSLocalNetworkUsageDescription, leaving the Local Network permission prompt behavior to chance. Real support case: connecting to a Home Assistant MCP server on the LAN failed with an opaque error because the permission was granted while the relay sidecar was already running.

## Changes

- Adds src-tauri/Info.plist with NSLocalNetworkUsageDescription (Tauri v2 auto-merges this file into the bundled Info.plist).

## Testing

- Plist XML validated. The bundle merge should be confirmed by a macOS build (this branch was authored in a Linux environment); please verify the built app's Info.plist contains the key.

Companion PR: endara-ai/endara-relay surfaces the full error cause chain and a macOS Local Network hint on LAN connect failures.