### PR TITLE
feat: Reset authorization button on the Auth tab

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -448,6 +448,24 @@ export async function startOAuth(name: string): Promise<OAuthStartResult> {
   return data as OAuthStartResult;
 }
 
+/**
+ * "Reset authorization": the relay revokes the old grant (upstream +
+ * local) and starts a fresh flow with forced consent. Response shape is
+ * identical to `startOAuth`.
+ */
+export async function resetOAuth(name: string): Promise<OAuthStartResult> {
+  const res = await mgmtRequest('POST', `/endpoints/${encodeURIComponent(name)}/oauth/reset`);
+  const data = res.body ? JSON.parse(res.body) : {};
+  if (res.status < 200 || res.status >= 300) {
+    // dcr_unsupported / discovery_failed / discovery_unreachable are returned as typed responses, not thrown
+    if (['dcr_unsupported', 'discovery_failed', 'discovery_unreachable'].includes(data?.error)) {
+      return data as OAuthStartResult;
+    }
+    throw new Error(data?.detail || data?.error || `HTTP ${res.status}`);
+  }
+  return data as OAuthStartResult;
+}
+
 export async function setOAuthCredentials(
   name: string,
   clientId: string,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -435,8 +435,12 @@ export interface UpdateEndpointParams {
   auth?: EmaAuthSummary;
 }
 
-export async function startOAuth(name: string): Promise<OAuthStartResult> {
-  const res = await mgmtRequest('POST', `/endpoints/${encodeURIComponent(name)}/oauth/start`);
+/**
+ * Shared POST for the OAuth flow-starting endpoints (`start` and `reset`),
+ * which return the identical `OAuthStartResult` shape.
+ */
+async function oauthFlowRequest(name: string, action: 'start' | 'reset'): Promise<OAuthStartResult> {
+  const res = await mgmtRequest('POST', `/endpoints/${encodeURIComponent(name)}/oauth/${action}`);
   const data = res.body ? JSON.parse(res.body) : {};
   if (res.status < 200 || res.status >= 300) {
     // dcr_unsupported / discovery_failed / discovery_unreachable are returned as typed responses, not thrown
@@ -448,22 +452,17 @@ export async function startOAuth(name: string): Promise<OAuthStartResult> {
   return data as OAuthStartResult;
 }
 
+export async function startOAuth(name: string): Promise<OAuthStartResult> {
+  return oauthFlowRequest(name, 'start');
+}
+
 /**
  * "Reset authorization": the relay revokes the old grant (upstream +
  * local) and starts a fresh flow with forced consent. Response shape is
  * identical to `startOAuth`.
  */
 export async function resetOAuth(name: string): Promise<OAuthStartResult> {
-  const res = await mgmtRequest('POST', `/endpoints/${encodeURIComponent(name)}/oauth/reset`);
-  const data = res.body ? JSON.parse(res.body) : {};
-  if (res.status < 200 || res.status >= 300) {
-    // dcr_unsupported / discovery_failed / discovery_unreachable are returned as typed responses, not thrown
-    if (['dcr_unsupported', 'discovery_failed', 'discovery_unreachable'].includes(data?.error)) {
-      return data as OAuthStartResult;
-    }
-    throw new Error(data?.detail || data?.error || `HTTP ${res.status}`);
-  }
-  return data as OAuthStartResult;
+  return oauthFlowRequest(name, 'reset');
 }
 
 export async function setOAuthCredentials(

--- a/src/lib/components/AuthTab.svelte
+++ b/src/lib/components/AuthTab.svelte
@@ -3,7 +3,7 @@
   import { selectedEndpoint, oauthStatuses } from '$lib/stores';
   import { getOAuthStatus, refreshOAuth, startOAuth, resetOAuth } from '$lib/api';
   import { openUrl } from '@tauri-apps/plugin-opener';
-  import { canReauthorize, isConnectivityFailure, reauthorize, resetAuthorization } from '$lib/oauth/actions';
+  import { canReauthorize, canResetAuthorization, isConnectivityFailure, reauthorize, resetAuthorization } from '$lib/oauth/actions';
   import { toast } from 'svelte-sonner';
 
   let status = $state<OAuthStatus | null>(null);
@@ -130,6 +130,7 @@
       (['authenticated', 'connection_failed'] as OAuthStatusValue[]).includes(status.status),
   );
   let canReauth = $derived(status !== null && canReauthorize(status.status));
+  let canReset = $derived(status !== null && canResetAuthorization(status.status));
   let connectivityFailure = $derived(status !== null && isConnectivityFailure(status.status));
   let actionBusy = $derived(actionInProgress || reauthInProgress || resetInProgress);
 </script>
@@ -200,7 +201,7 @@
     </div>
 
     <!-- Actions -->
-    {#if canRefresh || canReauth}
+    {#if canRefresh || canReauth || canReset}
       <div class="flex gap-2">
         {#if canRefresh}
           <button
@@ -218,7 +219,7 @@
             aria-label="Re-authenticate"
           >Re-authenticate</button>
         {/if}
-        {#if canReauth}
+        {#if canReset}
           <button
             class="btn-sec"
             onclick={handleReset}

--- a/src/lib/components/AuthTab.svelte
+++ b/src/lib/components/AuthTab.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import type { OAuthStatus, OAuthStatusValue } from '$lib/types';
   import { selectedEndpoint, oauthStatuses } from '$lib/stores';
-  import { getOAuthStatus, refreshOAuth, startOAuth } from '$lib/api';
+  import { getOAuthStatus, refreshOAuth, startOAuth, resetOAuth } from '$lib/api';
   import { openUrl } from '@tauri-apps/plugin-opener';
-  import { canReauthorize, isConnectivityFailure, reauthorize } from '$lib/oauth/actions';
+  import { canReauthorize, isConnectivityFailure, reauthorize, resetAuthorization } from '$lib/oauth/actions';
   import { toast } from 'svelte-sonner';
 
   let status = $state<OAuthStatus | null>(null);
@@ -11,6 +11,7 @@
   let error = $state('');
   let actionInProgress = $state(false);
   let reauthInProgress = $state(false);
+  let resetInProgress = $state(false);
 
   const statusColors: Record<OAuthStatusValue, string> = {
     authenticated: 'bg-(--healthy)',
@@ -76,7 +77,7 @@
 
   async function handleRefresh() {
     const name = $selectedEndpoint;
-    if (!name || actionInProgress || reauthInProgress) return;
+    if (!name || actionInProgress || reauthInProgress || resetInProgress) return;
     actionInProgress = true;
     try {
       await refreshOAuth(name);
@@ -90,7 +91,7 @@
 
   async function handleReauthorize() {
     const name = $selectedEndpoint;
-    if (!name || actionInProgress || reauthInProgress) return;
+    if (!name || actionInProgress || reauthInProgress || resetInProgress) return;
     reauthInProgress = true;
     try {
       await reauthorize(name, {
@@ -105,6 +106,24 @@
     reauthInProgress = false;
   }
 
+  async function handleReset() {
+    const name = $selectedEndpoint;
+    if (!name || actionInProgress || reauthInProgress || resetInProgress) return;
+    resetInProgress = true;
+    try {
+      await resetAuthorization(name, {
+        resetOAuth,
+        openUrl,
+        onSuccess: toast.success,
+        onError: toast.error,
+      });
+      await fetchStatus(name);
+    } catch {
+      toast.error('Failed to reset authorization');
+    }
+    resetInProgress = false;
+  }
+
   let canRefresh = $derived(
     status !== null &&
       status.has_refresh_token &&
@@ -112,7 +131,7 @@
   );
   let canReauth = $derived(status !== null && canReauthorize(status.status));
   let connectivityFailure = $derived(status !== null && isConnectivityFailure(status.status));
-  let actionBusy = $derived(actionInProgress || reauthInProgress);
+  let actionBusy = $derived(actionInProgress || reauthInProgress || resetInProgress);
 </script>
 
 <div class="h-full overflow-y-auto p-4 space-y-4">
@@ -198,6 +217,15 @@
             title="Open the browser to sign in again"
             aria-label="Re-authenticate"
           >Re-authenticate</button>
+        {/if}
+        {#if canReauth}
+          <button
+            class="btn-sec"
+            onclick={handleReset}
+            disabled={actionBusy}
+            title="Discard the old grant and re-approve access — the provider will show its consent screen again"
+            aria-label="Reset authorization"
+          >Reset authorization</button>
         {/if}
       </div>
     {/if}

--- a/src/lib/components/AuthTab.test.ts
+++ b/src/lib/components/AuthTab.test.ts
@@ -330,9 +330,20 @@ describe('AuthTab reset-authorization wiring (source contract)', () => {
     expect(source).toMatch(/await resetAuthorization\(name,\s*\{\s*resetOAuth,/);
   });
 
-  it('gates the button on the same canReauth derivation as Re-authenticate', () => {
-    const gates = source.match(/\{#if canReauth\}/g) ?? [];
-    expect(gates).toHaveLength(2);
+  // The reset button must be reachable while AUTHENTICATED (the primary use
+  // case is resetting a live grant), so it gates on canReset — derived from
+  // canResetAuthorization() — not on canReauth, which excludes that state.
+  it('gates the button on canReset derived from canResetAuthorization', () => {
+    expect(source).toMatch(
+      /canReset\s*=\s*\$derived\(\s*status\s*!==\s*null\s*&&\s*canResetAuthorization\(status\.status\)\s*\)/,
+    );
+    expect(source).toMatch(
+      /\{#if canReset\}[\s\S]*?aria-label="Reset authorization"[\s\S]*?\{\/if\}/,
+    );
+  });
+
+  it('includes canReset in the actions-row visibility gate', () => {
+    expect(source).toMatch(/\{#if canRefresh \|\| canReauth \|\| canReset\}/);
   });
 });
 

--- a/src/lib/components/AuthTab.test.ts
+++ b/src/lib/components/AuthTab.test.ts
@@ -70,12 +70,17 @@ function connectivityFailure(status: MinimalOAuthStatus | null): boolean {
   return status !== null && status.status === 'connection_failed';
 }
 
-// Pure mirror of the `actionBusy` derivation in AuthTab.svelte. Both the
-// "Refresh Now" and "Re-authenticate" buttons bind their `disabled` state to
-// this shared guard so neither can be triggered while either flow is running,
-// avoiding an overlapping token refresh + browser OAuth flow.
-function actionBusy(actionInProgress: boolean, reauthInProgress: boolean): boolean {
-  return actionInProgress || reauthInProgress;
+// Pure mirror of the `actionBusy` derivation in AuthTab.svelte. The
+// "Refresh Now", "Re-authenticate" and "Reset authorization" buttons all bind
+// their `disabled` state to this shared guard so none can be triggered while
+// any flow is running, avoiding overlapping token refresh + browser OAuth
+// flows.
+function actionBusy(
+  actionInProgress: boolean,
+  reauthInProgress: boolean,
+  resetInProgress = false,
+): boolean {
+  return actionInProgress || reauthInProgress || resetInProgress;
 }
 
 
@@ -253,6 +258,11 @@ describe('actionBusy', () => {
   it('is true when both actions are in progress', () => {
     expect(actionBusy(true, true)).toBe(true);
   });
+
+  // ...and a reset in progress must disable the other two buttons as well.
+  it('is true when a reset is in progress', () => {
+    expect(actionBusy(false, false, true)).toBe(true);
+  });
 });
 
 // The vitest environment here is `node`, so we can't mount the component and
@@ -272,25 +282,57 @@ describe('AuthTab busy-guard wiring (source contract)', () => {
     source = readFileSync(fileURLToPath(new URL('./AuthTab.svelte', import.meta.url)), 'utf8') as string;
   });
 
-  it('derives a shared actionBusy guard from both in-progress flags', () => {
+  it('derives a shared actionBusy guard from all three in-progress flags', () => {
     expect(source).toMatch(
-      /actionBusy\s*=\s*\$derived\(\s*actionInProgress\s*\|\|\s*reauthInProgress\s*\)/,
+      /actionBusy\s*=\s*\$derived\(\s*actionInProgress\s*\|\|\s*reauthInProgress\s*\|\|\s*resetInProgress\s*\)/,
     );
   });
 
-  it('binds both Refresh Now and Re-authenticate buttons to the shared guard', () => {
+  it('binds Refresh Now, Re-authenticate and Reset authorization buttons to the shared guard', () => {
     const disabledBindings = source.match(/disabled=\{actionBusy\}/g) ?? [];
-    expect(disabledBindings).toHaveLength(2);
-    // Neither button should bind disabled to a single per-flow flag anymore.
+    expect(disabledBindings).toHaveLength(3);
+    // No button should bind disabled to a single per-flow flag anymore.
     expect(source).not.toMatch(/disabled=\{actionInProgress\}/);
     expect(source).not.toMatch(/disabled=\{reauthInProgress\}/);
+    expect(source).not.toMatch(/disabled=\{resetInProgress\}/);
   });
 
-  it('early-returns from both handlers while either flow is active', () => {
+  it('early-returns from all three handlers while any flow is active', () => {
     const guards =
-      source.match(/if\s*\(!name\s*\|\|\s*actionInProgress\s*\|\|\s*reauthInProgress\)\s*return;/g) ??
-      [];
-    expect(guards).toHaveLength(2);
+      source.match(
+        /if\s*\(!name\s*\|\|\s*actionInProgress\s*\|\|\s*reauthInProgress\s*\|\|\s*resetInProgress\)\s*return;/g,
+      ) ?? [];
+    expect(guards).toHaveLength(3);
+  });
+});
+
+// Source contract for the "Reset authorization" action: a secondary button
+// next to Re-authenticate that calls the reset flow (upstream revoke + forced
+// consent) via resetAuthorization() with the resetOAuth API dependency.
+describe('AuthTab reset-authorization wiring (source contract)', () => {
+  let source = '';
+
+  beforeAll(async () => {
+    // @ts-expect-error node builtin types not installed
+    const { readFileSync } = await import('node:fs');
+    // @ts-expect-error node builtin types not installed
+    const { fileURLToPath } = await import('node:url');
+    source = readFileSync(fileURLToPath(new URL('./AuthTab.svelte', import.meta.url)), 'utf8') as string;
+  });
+
+  it('renders a secondary Reset authorization button', () => {
+    expect(source).toMatch(
+      /class="btn-sec"[\s\S]*?onclick=\{handleReset\}[\s\S]*?aria-label="Reset authorization"/,
+    );
+  });
+
+  it('wires handleReset to resetAuthorization with the resetOAuth dependency', () => {
+    expect(source).toMatch(/await resetAuthorization\(name,\s*\{\s*resetOAuth,/);
+  });
+
+  it('gates the button on the same canReauth derivation as Re-authenticate', () => {
+    const gates = source.match(/\{#if canReauth\}/g) ?? [];
+    expect(gates).toHaveLength(2);
   });
 });
 

--- a/src/lib/oauth/actions.test.ts
+++ b/src/lib/oauth/actions.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
-import { canReauthorize, isConnectivityFailure, reauthorize, type ReauthorizeDeps } from './actions';
+import {
+  canReauthorize,
+  isConnectivityFailure,
+  reauthorize,
+  resetAuthorization,
+  type ReauthorizeDeps,
+  type ResetAuthorizationDeps,
+} from './actions';
 import type { OAuthStartResult, OAuthStatusValue } from '$lib/types';
 
 function makeDeps(overrides: Partial<ReauthorizeDeps> = {}): ReauthorizeDeps {
@@ -71,6 +78,78 @@ describe('reauthorize', () => {
     expect(deps.onError).toHaveBeenCalledWith(
       'This server requires manual OAuth app registration. Go to Settings to enter your Client ID.',
     );
+  });
+});
+
+function makeResetDeps(overrides: Partial<ResetAuthorizationDeps> = {}): ResetAuthorizationDeps {
+  return {
+    resetOAuth: vi.fn().mockResolvedValue({ authorize_url: 'https://example.com/authorize?prompt=consent' } as OAuthStartResult),
+    openUrl: vi.fn().mockResolvedValue(undefined),
+    onSuccess: vi.fn(),
+    onError: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('resetAuthorization', () => {
+  it('calls resetOAuth with the endpoint name', async () => {
+    const deps = makeResetDeps();
+    await resetAuthorization('my-server', deps);
+    expect(deps.resetOAuth).toHaveBeenCalledTimes(1);
+    expect(deps.resetOAuth).toHaveBeenCalledWith('my-server');
+  });
+
+  it('opens the authorize URL and explains the consent screen on success', async () => {
+    const deps = makeResetDeps();
+    await resetAuthorization('srv', deps);
+    expect(deps.openUrl).toHaveBeenCalledWith('https://example.com/authorize?prompt=consent');
+    expect(deps.onSuccess).toHaveBeenCalledWith(
+      'Authorization reset — approve access on the consent screen to finish',
+    );
+    expect(deps.onError).not.toHaveBeenCalled();
+  });
+
+  it('reports a connectivity error when resetOAuth returns discovery_unreachable', async () => {
+    const deps = makeResetDeps({
+      resetOAuth: vi.fn().mockResolvedValue({ error: 'discovery_unreachable' } as OAuthStartResult),
+    });
+    await resetAuthorization('srv', deps);
+    expect(deps.openUrl).not.toHaveBeenCalled();
+    expect(deps.onSuccess).not.toHaveBeenCalled();
+    expect(deps.onError).toHaveBeenCalledWith(
+      "Couldn't reach the server to start authorization. Check your connection and try again.",
+    );
+  });
+
+  it('reports a discovery_failed error when resetOAuth returns that error', async () => {
+    const deps = makeResetDeps({
+      resetOAuth: vi.fn().mockResolvedValue({ error: 'discovery_failed' } as OAuthStartResult),
+    });
+    await resetAuthorization('srv', deps);
+    expect(deps.openUrl).not.toHaveBeenCalled();
+    expect(deps.onError).toHaveBeenCalledWith(
+      'OAuth discovery failed. Go to Settings to configure OAuth server URL manually.',
+    );
+  });
+
+  it('reports a dcr_unsupported error when resetOAuth returns that error', async () => {
+    const deps = makeResetDeps({
+      resetOAuth: vi.fn().mockResolvedValue({ error: 'dcr_unsupported' } as OAuthStartResult),
+    });
+    await resetAuthorization('srv', deps);
+    expect(deps.openUrl).not.toHaveBeenCalled();
+    expect(deps.onError).toHaveBeenCalledWith(
+      'This server requires manual OAuth app registration. Go to Settings to enter your Client ID.',
+    );
+  });
+
+  it('reports a generic error for an unrecognized result', async () => {
+    const deps = makeResetDeps({
+      resetOAuth: vi.fn().mockResolvedValue({ error: 'something_else' } as unknown as OAuthStartResult),
+    });
+    await resetAuthorization('srv', deps);
+    expect(deps.openUrl).not.toHaveBeenCalled();
+    expect(deps.onError).toHaveBeenCalledWith('Failed to reset authorization');
   });
 });
 

--- a/src/lib/oauth/actions.test.ts
+++ b/src/lib/oauth/actions.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
   canReauthorize,
+  canResetAuthorization,
   isConnectivityFailure,
   reauthorize,
   resetAuthorization,
@@ -116,8 +117,10 @@ describe('resetAuthorization', () => {
     await resetAuthorization('srv', deps);
     expect(deps.openUrl).not.toHaveBeenCalled();
     expect(deps.onSuccess).not.toHaveBeenCalled();
+    // The relay has already discarded the old grant by the time the start
+    // half fails, so the copy must say the reset happened.
     expect(deps.onError).toHaveBeenCalledWith(
-      "Couldn't reach the server to start authorization. Check your connection and try again.",
+      "Authorization was reset, but the new sign-in couldn't start: the server is unreachable. Re-authenticate when the connection is back.",
     );
   });
 
@@ -128,7 +131,7 @@ describe('resetAuthorization', () => {
     await resetAuthorization('srv', deps);
     expect(deps.openUrl).not.toHaveBeenCalled();
     expect(deps.onError).toHaveBeenCalledWith(
-      'OAuth discovery failed. Go to Settings to configure OAuth server URL manually.',
+      'Authorization was reset, but OAuth discovery failed. Go to Settings to configure the OAuth server URL, then re-authenticate.',
     );
   });
 
@@ -139,7 +142,7 @@ describe('resetAuthorization', () => {
     await resetAuthorization('srv', deps);
     expect(deps.openUrl).not.toHaveBeenCalled();
     expect(deps.onError).toHaveBeenCalledWith(
-      'This server requires manual OAuth app registration. Go to Settings to enter your Client ID.',
+      'Authorization was reset, but this server requires manual OAuth app registration. Go to Settings to enter your Client ID, then re-authenticate.',
     );
   });
 
@@ -166,6 +169,25 @@ describe('canReauthorize', () => {
   for (const [status, expected] of cases) {
     it(`returns ${expected} for status "${status}"`, () => {
       expect(canReauthorize(status)).toBe(expected);
+    });
+  }
+});
+
+// Reset targets a LIVE grant the user wants to re-approve, so unlike
+// canReauthorize it must also return true for `authenticated`.
+describe('canResetAuthorization', () => {
+  const cases: Array<[OAuthStatusValue, boolean]> = [
+    ['authenticated', true],
+    ['disconnected', true],
+    ['auth_required', true],
+    ['needs_login', true],
+    ['connection_failed', true],
+    ['refreshing', false],
+  ];
+
+  for (const [status, expected] of cases) {
+    it(`returns ${expected} for status "${status}"`, () => {
+      expect(canResetAuthorization(status)).toBe(expected);
     });
   }
 });

--- a/src/lib/oauth/actions.ts
+++ b/src/lib/oauth/actions.ts
@@ -12,6 +12,16 @@ export function canReauthorize(status: OAuthStatusValue): boolean {
 }
 
 /**
+ * "Reset authorization" discards the existing grant and forces a fresh
+ * consent screen. Unlike re-authenticate (which targets broken auth states),
+ * the primary use case is a LIVE grant the user wants to re-approve — so
+ * `authenticated` is included alongside every re-authenticate state.
+ */
+export function canResetAuthorization(status: OAuthStatusValue): boolean {
+  return status === 'authenticated' || REAUTHORIZE_STATUSES.includes(status);
+}
+
+/**
  * `connection_failed` means the server is unreachable — the stored tokens are
  * likely still valid, so retry/refresh (not re-authentication) should be the
  * suggested first step in the UI.
@@ -62,11 +72,19 @@ export async function resetAuthorization(name: string, deps: ResetAuthorizationD
     await deps.openUrl(result.authorize_url);
     deps.onSuccess('Authorization reset — approve access on the consent screen to finish');
   } else if ('error' in result && result.error === 'discovery_unreachable') {
-    deps.onError("Couldn't reach the server to start authorization. Check your connection and try again.");
+    // Typed errors come from the start half of the reset: the relay already
+    // discarded the old grant, so the copy must not imply nothing happened.
+    deps.onError(
+      "Authorization was reset, but the new sign-in couldn't start: the server is unreachable. Re-authenticate when the connection is back.",
+    );
   } else if ('error' in result && result.error === 'discovery_failed') {
-    deps.onError('OAuth discovery failed. Go to Settings to configure OAuth server URL manually.');
+    deps.onError(
+      'Authorization was reset, but OAuth discovery failed. Go to Settings to configure the OAuth server URL, then re-authenticate.',
+    );
   } else if ('error' in result && result.error === 'dcr_unsupported') {
-    deps.onError('This server requires manual OAuth app registration. Go to Settings to enter your Client ID.');
+    deps.onError(
+      'Authorization was reset, but this server requires manual OAuth app registration. Go to Settings to enter your Client ID, then re-authenticate.',
+    );
   } else {
     deps.onError('Failed to reset authorization');
   }

--- a/src/lib/oauth/actions.ts
+++ b/src/lib/oauth/actions.ts
@@ -43,3 +43,32 @@ export async function reauthorize(name: string, deps: ReauthorizeDeps): Promise<
   }
 }
 
+export interface ResetAuthorizationDeps {
+  resetOAuth: (name: string) => Promise<OAuthStartResult>;
+  openUrl: (url: string) => Promise<void>;
+  onSuccess: (message: string) => void;
+  onError: (message: string) => void;
+}
+
+/**
+ * "Reset authorization": the relay discards the old grant (upstream revoke +
+ * local token delete) and returns a forced-consent authorize URL, so the
+ * provider re-shows its consent screen instead of silently reusing the prior
+ * grant.
+ */
+export async function resetAuthorization(name: string, deps: ResetAuthorizationDeps): Promise<void> {
+  const result = await deps.resetOAuth(name);
+  if ('authorize_url' in result) {
+    await deps.openUrl(result.authorize_url);
+    deps.onSuccess('Authorization reset — approve access on the consent screen to finish');
+  } else if ('error' in result && result.error === 'discovery_unreachable') {
+    deps.onError("Couldn't reach the server to start authorization. Check your connection and try again.");
+  } else if ('error' in result && result.error === 'discovery_failed') {
+    deps.onError('OAuth discovery failed. Go to Settings to configure OAuth server URL manually.');
+  } else if ('error' in result && result.error === 'dcr_unsupported') {
+    deps.onError('This server requires manual OAuth app registration. Go to Settings to enter your Client ID.');
+  } else {
+    deps.onError('Failed to reset authorization');
+  }
+}
+


### PR DESCRIPTION
Desktop half of "Reset authorization" — one in-app action that discards the old grant and forces the provider to show a fresh consent screen. Relay half: endara-ai/endara-relay#145.

## Changes

- `api.ts`: new `resetOAuth(name)` calling `POST /endpoints/{name}/oauth/reset`; shares a single `oauthFlowRequest()` helper with `startOAuth` (identical typed-error handling: `dcr_unsupported` / `discovery_failed` / `discovery_unreachable` returned, others thrown).
- `oauth/actions.ts`: new `resetAuthorization(name, deps)` action mirroring `reauthorize` — opens the returned authorize URL and the success toast explains a consent screen will appear. Typed-error toasts state that the reset already happened (the relay discards the grant before the start half can fail), pointing the user at re-authenticate once the underlying issue is fixed. New `canResetAuthorization(status)` helper: every re-authenticate status **plus `authenticated`**, since the primary reset use case is a live grant the user wants to re-approve.
- `AuthTab.svelte`: "Reset authorization" button (secondary, next to Re-authenticate), gated on a `canReset` derivation from `canResetAuthorization()` — visible while authenticated, unlike Re-authenticate. New `resetInProgress` flag folded into the shared `actionBusy` guard and all three handler early-returns, so no two OAuth flows can overlap.

## Tests

- `actions.test.ts`: `resetAuthorization` suite — endpoint name pass-through, URL open + consent toast, all three typed error paths (asserting the "was reset, but…" copy), generic fallback; `canResetAuthorization` status table including `authenticated: true`.
- `AuthTab.test.ts`: `actionBusy` mirror extended with the reset flag; busy-guard source contract updated to three buttons/handlers; source contract for the reset button wiring asserts the `canReset` derivation delegates to `canResetAuthorization()` and the button renders inside the `{#if canReset}` block.

Full suite: 1174 passed, 0 failed; svelte-check clean.
