### PR TITLE
feat: add Network Exposure settings with per-interface listen toggles

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1917,37 +1917,78 @@ async fn get_listen_ips() -> Result<Vec<String>, String> {
     Ok(read_listen_ips())
 }
 
+/// Mirror of the relay's `listen_ips` eligibility rules
+/// (`endara_relay::listen_ips::classify_listen_ip`): only RFC 1918 private,
+/// CGNAT (100.64.0.0/10), and IPv6 ULA (fc00::/7) addresses are eligible;
+/// an IPv4-mapped IPv6 address classifies as its embedded IPv4. Loopback,
+/// unspecified, link-local, public, and unparseable entries are all
+/// ineligible. The relay's bind-time filter and the UI's render filter
+/// enforce the same invariant; re-checking here keeps the on-disk config
+/// clean even if a future caller bypasses the UI helpers.
+fn eligible_listen_ip(s: &str) -> Option<std::net::IpAddr> {
+    use std::net::IpAddr;
+    fn eligible_v4(ip: std::net::Ipv4Addr) -> bool {
+        let octets = ip.octets();
+        // RFC 1918 or CGNAT 100.64.0.0/10 (RFC 6598).
+        ip.is_private() || (octets[0] == 100 && (octets[1] & 0b1100_0000) == 64)
+    }
+    let ip: IpAddr = s.trim().parse().ok()?;
+    let ok = match ip {
+        IpAddr::V4(v4) => eligible_v4(v4),
+        IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+            Some(mapped) => eligible_v4(mapped),
+            // Unique-local fc00::/7.
+            None => (v6.segments()[0] & 0xfe00) == 0xfc00,
+        },
+    };
+    ok.then_some(ip)
+}
+
 #[tauri::command]
 async fn set_listen_ips(ips: Vec<String>) -> Result<(), String> {
     let mut table = read_config().unwrap_or_else(|_| toml::Table::new());
 
-    // Ensure [relay] section exists. The relay's `RelayConfig` requires
-    // `machine_name`, so populate it from the system hostname when creating
-    // the section from scratch — otherwise the relay's next config reload
-    // would fail to deserialize.
     let relay = table
         .entry("relay")
-        .or_insert_with(|| {
-            let mut t = toml::Table::new();
-            let machine_name = hostname::get()
-                .ok()
-                .and_then(|h| h.into_string().ok())
-                .unwrap_or_else(|| "unknown".to_string());
-            t.insert(
-                "machine_name".to_string(),
-                toml::Value::String(machine_name),
-            );
-            toml::Value::Table(t)
-        })
+        .or_insert_with(|| toml::Value::Table(toml::Table::new()))
         .as_table_mut()
         .ok_or("Invalid [relay] section in config")?;
 
-    // De-duplicate while preserving first-seen order so repeated UI
-    // selections never produce duplicate entries on disk. An empty list is
-    // written as `[]`, which the relay treats as loopback-only.
+    // The relay's `RelayConfig` requires `machine_name`, so ensure it is
+    // present and non-empty — whether the [relay] section was just created
+    // or already existed without one — otherwise the relay's next config
+    // reload would fail to deserialize.
+    let has_machine_name = relay
+        .get("machine_name")
+        .and_then(|v| v.as_str())
+        .is_some_and(|s| !s.trim().is_empty());
+    if !has_machine_name {
+        let machine_name = hostname::get()
+            .ok()
+            .and_then(|h| h.into_string().ok())
+            .unwrap_or_else(|| "unknown".to_string());
+        relay.insert(
+            "machine_name".to_string(),
+            toml::Value::String(machine_name),
+        );
+    }
+
+    // Persist only eligible entries in their canonical textual form
+    // (`IpAddr`'s Display), dropping ineligible or unparseable strings with
+    // a log — defense in depth alongside the relay's bind-time filter. Then
+    // de-duplicate preserving first-seen order so repeated UI selections
+    // never produce duplicate entries on disk. An empty list is written as
+    // `[]`, which the relay treats as loopback-only.
     let mut seen = std::collections::HashSet::new();
     let deduped: Vec<toml::Value> = ips
         .into_iter()
+        .filter_map(|raw| match eligible_listen_ip(&raw) {
+            Some(ip) => Some(ip.to_string()),
+            None => {
+                log::warn!("set_listen_ips: dropping ineligible entry {raw:?}");
+                None
+            }
+        })
         .filter(|ip| seen.insert(ip.clone()))
         .map(toml::Value::String)
         .collect();
@@ -4397,6 +4438,103 @@ mod write_dirs_tests {
             .and_then(|v| v.as_array())
             .expect("listen_ips should be an empty array");
         assert!(ips.is_empty(), "empty list should persist as []");
+    }
+
+    #[test]
+    #[serial]
+    fn set_listen_ips_drops_ineligible_entries() {
+        let _home = HomeGuard::new();
+        let rt = rt();
+        write_config_str("[relay]\nmachine_name = \"x\"\n");
+
+        rt.block_on(set_listen_ips(vec![
+            "192.168.1.5".to_string(),
+            "0.0.0.0".to_string(),
+            "127.0.0.1".to_string(),
+            "8.8.8.8".to_string(),
+            "::".to_string(),
+            "fe80::1".to_string(),
+            "2001:db8::1".to_string(),
+            "not-an-ip".to_string(),
+            "fd00::1".to_string(),
+            "100.101.102.103".to_string(),
+        ]))
+        .expect("set listen_ips");
+
+        assert_eq!(
+            read_listen_ips(),
+            vec!["192.168.1.5", "fd00::1", "100.101.102.103"],
+            "only RFC 1918 / CGNAT / ULA entries should be persisted"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn set_listen_ips_canonicalizes_entries() {
+        let _home = HomeGuard::new();
+        let rt = rt();
+        write_config_str("[relay]\nmachine_name = \"x\"\n");
+
+        rt.block_on(set_listen_ips(vec![
+            " 10.0.0.7 ".to_string(),
+            "fd00:0:0:0:0:0:0:1".to_string(),
+            "FD00:0::1".to_string(),
+            "fd00::1".to_string(),
+        ]))
+        .expect("set listen_ips");
+
+        assert_eq!(
+            read_listen_ips(),
+            vec!["10.0.0.7", "fd00::1"],
+            "entries should be trimmed, canonicalized, and deduped by address"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn set_listen_ips_ensures_machine_name_in_existing_relay_section() {
+        let _home = HomeGuard::new();
+        let rt = rt();
+        write_config_str("[relay]\nlisten_ips = []\n");
+
+        rt.block_on(set_listen_ips(vec!["192.168.1.5".to_string()]))
+            .expect("set listen_ips");
+
+        let parsed: toml::Table =
+            toml::from_str(&read_config_str()).expect("re-parse config.toml as toml::Table");
+        let machine_name = parsed
+            .get("relay")
+            .and_then(|v| v.as_table())
+            .and_then(|t| t.get("machine_name"))
+            .and_then(|v| v.as_str())
+            .expect("machine_name should be inserted into the existing [relay] section");
+        assert!(
+            !machine_name.trim().is_empty(),
+            "machine_name should be non-empty, got {machine_name:?}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn set_listen_ips_preserves_existing_machine_name() {
+        let _home = HomeGuard::new();
+        let rt = rt();
+        write_config_str("[relay]\nmachine_name = \"my-box\"\n");
+
+        rt.block_on(set_listen_ips(vec!["192.168.1.5".to_string()]))
+            .expect("set listen_ips");
+
+        let parsed: toml::Table =
+            toml::from_str(&read_config_str()).expect("re-parse config.toml as toml::Table");
+        assert_eq!(
+            parsed
+                .get("relay")
+                .and_then(|v| v.as_table())
+                .and_then(|t| t.get("machine_name"))
+                .and_then(|v| v.as_str()),
+            Some("my-box"),
+            "an existing machine_name must not be overwritten"
+        );
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -484,6 +484,31 @@ fn read_write_dirs() -> Vec<String> {
         .unwrap_or_default()
 }
 
+/// Read `relay.listen_ips` from `~/.endara/config.toml`.
+/// Returns an empty list on any error, missing section, or missing key —
+/// matches the relay's own default (loopback-only).
+fn read_listen_ips() -> Vec<String> {
+    let Ok(parsed) = read_config() else {
+        return Vec::new();
+    };
+    // De-duplicate while preserving first-seen order: a hand-edited config
+    // with duplicate entries would otherwise produce duplicate keys in the
+    // UI's keyed `{#each}` list.
+    let mut seen = std::collections::HashSet::new();
+    parsed
+        .get("relay")
+        .and_then(|v| v.as_table())
+        .and_then(|t| t.get("listen_ips"))
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .filter(|s| seen.insert(s.clone()))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 /// Holds the relay sidecar child process handle.
 pub struct RelayState {
     child: Arc<Mutex<Option<tauri_plugin_shell::process::CommandChild>>>,
@@ -1883,6 +1908,55 @@ async fn set_write_dirs(dirs: Vec<String>) -> Result<(), String> {
     write_config(&table)
 }
 
+/// Get the list of extra IPs the relay listens on.
+/// Returns an empty list (the relay's own default, loopback-only) if the
+/// config is missing, malformed, has no `[relay]` section, or has no
+/// `listen_ips` field.
+#[tauri::command]
+async fn get_listen_ips() -> Result<Vec<String>, String> {
+    Ok(read_listen_ips())
+}
+
+#[tauri::command]
+async fn set_listen_ips(ips: Vec<String>) -> Result<(), String> {
+    let mut table = read_config().unwrap_or_else(|_| toml::Table::new());
+
+    // Ensure [relay] section exists. The relay's `RelayConfig` requires
+    // `machine_name`, so populate it from the system hostname when creating
+    // the section from scratch — otherwise the relay's next config reload
+    // would fail to deserialize.
+    let relay = table
+        .entry("relay")
+        .or_insert_with(|| {
+            let mut t = toml::Table::new();
+            let machine_name = hostname::get()
+                .ok()
+                .and_then(|h| h.into_string().ok())
+                .unwrap_or_else(|| "unknown".to_string());
+            t.insert(
+                "machine_name".to_string(),
+                toml::Value::String(machine_name),
+            );
+            toml::Value::Table(t)
+        })
+        .as_table_mut()
+        .ok_or("Invalid [relay] section in config")?;
+
+    // De-duplicate while preserving first-seen order so repeated UI
+    // selections never produce duplicate entries on disk. An empty list is
+    // written as `[]`, which the relay treats as loopback-only.
+    let mut seen = std::collections::HashSet::new();
+    let deduped: Vec<toml::Value> = ips
+        .into_iter()
+        .filter(|ip| seen.insert(ip.clone()))
+        .map(toml::Value::String)
+        .collect();
+
+    relay.insert("listen_ips".to_string(), toml::Value::Array(deduped));
+
+    write_config(&table)
+}
+
 /// Get the current update channel ("stable" or "beta").
 #[tauri::command]
 async fn get_update_channel() -> Result<String, String> {
@@ -2601,6 +2675,8 @@ pub fn run() {
             set_toon_output,
             get_write_dirs,
             set_write_dirs,
+            get_listen_ips,
+            set_listen_ips,
             get_config_path_display,
             get_buffered_relay_logs,
             get_update_channel,
@@ -3898,10 +3974,11 @@ mod toon_output_tests {
 
 #[cfg(test)]
 mod write_dirs_tests {
-    //! Round-trip coverage for `read_write_dirs` and `set_write_dirs`.
+    //! Round-trip coverage for `read_write_dirs` / `set_write_dirs` and the
+    //! structurally identical `read_listen_ips` / `set_listen_ips`.
     //! Mirrors `toon_output_tests` but pins the default to an empty list —
     //! a missing field, missing section, missing file, or malformed file all
-    //! resolve to no writable directories.
+    //! resolve to no writable directories (or no extra listen IPs).
     use super::*;
     use serial_test::serial;
     use tempfile::TempDir;
@@ -4176,6 +4253,150 @@ mod write_dirs_tests {
             .expect("args preserved");
         assert_eq!(args.len(), 1);
         assert_eq!(args[0].as_str(), Some("hi"));
+    }
+
+    #[test]
+    #[serial]
+    fn get_listen_ips_returns_entries_when_set() {
+        let _home = HomeGuard::new();
+        write_config_str(
+            "[relay]\nmachine_name = \"x\"\nlisten_ips = [\"192.168.1.5\", \"10.0.0.2\"]\n",
+        );
+        assert_eq!(read_listen_ips(), vec!["192.168.1.5", "10.0.0.2"]);
+    }
+
+    #[test]
+    #[serial]
+    fn get_listen_ips_returns_empty_when_field_missing() {
+        let _home = HomeGuard::new();
+        write_config_str("[relay]\nmachine_name = \"x\"\n");
+        assert!(read_listen_ips().is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn get_listen_ips_returns_empty_when_no_relay_section() {
+        let _home = HomeGuard::new();
+        write_config_str("[desktop]\nupdate_channel = \"stable\"\n");
+        assert!(read_listen_ips().is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn get_listen_ips_returns_empty_when_file_missing() {
+        let _home = HomeGuard::new();
+        // No config.toml written.
+        assert!(read_listen_ips().is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn get_listen_ips_returns_empty_when_file_malformed() {
+        let _home = HomeGuard::new();
+        write_config_str("not valid toml ====\n");
+        assert!(read_listen_ips().is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn get_listen_ips_deduplicates_preserving_order() {
+        let _home = HomeGuard::new();
+        write_config_str(
+            "[relay]\nmachine_name = \"x\"\nlisten_ips = [\"10.0.0.1\", \"10.0.0.2\", \"10.0.0.1\"]\n",
+        );
+        assert_eq!(read_listen_ips(), vec!["10.0.0.1", "10.0.0.2"]);
+    }
+
+    #[test]
+    #[serial]
+    fn set_listen_ips_roundtrips() {
+        let _home = HomeGuard::new();
+        let rt = rt();
+        write_config_str("[relay]\nmachine_name = \"x\"\n");
+
+        rt.block_on(set_listen_ips(vec![
+            "192.168.1.5".to_string(),
+            "10.0.0.2".to_string(),
+        ]))
+        .expect("set listen_ips");
+        assert_eq!(read_listen_ips(), vec!["192.168.1.5", "10.0.0.2"]);
+
+        rt.block_on(set_listen_ips(vec![]))
+            .expect("clear listen_ips");
+        assert!(read_listen_ips().is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn set_listen_ips_deduplicates_preserving_order() {
+        let _home = HomeGuard::new();
+        let rt = rt();
+        write_config_str("[relay]\nmachine_name = \"x\"\n");
+
+        rt.block_on(set_listen_ips(vec![
+            "10.0.0.1".to_string(),
+            "10.0.0.2".to_string(),
+            "10.0.0.1".to_string(),
+        ]))
+        .expect("set listen_ips");
+
+        assert_eq!(read_listen_ips(), vec!["10.0.0.1", "10.0.0.2"]);
+    }
+
+    #[test]
+    #[serial]
+    fn set_listen_ips_creates_missing_relay_section() {
+        let _home = HomeGuard::new();
+        let rt = rt();
+        write_config_str("[desktop]\nupdate_channel = \"stable\"\n");
+
+        rt.block_on(set_listen_ips(vec!["192.168.1.5".to_string()]))
+            .expect("set_listen_ips should succeed");
+
+        let toml_str = read_config_str();
+        let parsed: toml::Table =
+            toml::from_str(&toml_str).expect("re-parse config.toml as toml::Table");
+
+        let relay = parsed
+            .get("relay")
+            .and_then(|v| v.as_table())
+            .expect("[relay] section should exist");
+        let ips = relay
+            .get("listen_ips")
+            .and_then(|v| v.as_array())
+            .expect("listen_ips should be set");
+        assert_eq!(ips.len(), 1);
+        assert_eq!(ips[0].as_str(), Some("192.168.1.5"));
+        let machine_name = relay
+            .get("machine_name")
+            .and_then(|v| v.as_str())
+            .expect("machine_name should be set");
+        assert!(
+            !machine_name.is_empty(),
+            "machine_name should be non-empty, got {machine_name:?}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn set_listen_ips_empty_list_writes_empty_array() {
+        let _home = HomeGuard::new();
+        let rt = rt();
+        write_config_str("[relay]\nmachine_name = \"x\"\nlisten_ips = [\"10.0.0.1\"]\n");
+
+        rt.block_on(set_listen_ips(vec![]))
+            .expect("clear listen_ips");
+
+        let toml_str = read_config_str();
+        let parsed: toml::Table =
+            toml::from_str(&toml_str).expect("re-parse config.toml as toml::Table");
+        let ips = parsed
+            .get("relay")
+            .and_then(|v| v.as_table())
+            .and_then(|t| t.get("listen_ips"))
+            .and_then(|v| v.as_array())
+            .expect("listen_ips should be an empty array");
+        assert!(ips.is_empty(), "empty list should persist as []");
     }
 }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -85,6 +85,27 @@ export async function getConfig(): Promise<Record<string, unknown>> {
   return fetchJson<Record<string, unknown>>('/config');
 }
 
+/** One detected interface address eligible for `[relay] listen_ips`. */
+export interface NetworkInterfaceInfo {
+  /** OS interface name (e.g. `eth0`, `tailscale0`). */
+  name: string;
+  /** The address as an IP literal. */
+  ip: string;
+  family: 'v4' | 'v6';
+  /** "private" (RFC 1918), "cgnat" (100.64.0.0/10), or "ula" (fc00::/7). */
+  kind: 'private' | 'cgnat' | 'ula';
+}
+
+export interface NetworkInterfacesResponse {
+  interfaces: NetworkInterfaceInfo[];
+  /** Echo of `[relay] listen_ips` so the UI can render toggle state. */
+  listen_ips: string[];
+}
+
+export async function getNetworkInterfaces(): Promise<NetworkInterfacesResponse> {
+  return fetchJson<NetworkInterfacesResponse>('/network-interfaces');
+}
+
 export async function reloadConfig(): Promise<void> {
   await fetchJson('/config/reload', { method: 'POST' });
 }

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -15,7 +15,7 @@
   import type { UnlistenFn } from '@tauri-apps/api/event';
   import type { Theme, RelayStatus, ObservabilityConfig } from '$lib/types';
   import { invoke } from '@tauri-apps/api/core';
-  import { getStatus, getObservabilityConfig, putObservabilityConfig } from '$lib/api';
+  import { getStatus, getObservabilityConfig, putObservabilityConfig, getNetworkInterfaces } from '$lib/api';
   import {
     DEFAULT_OBSERVABILITY_CONFIG,
     OBSERVABILITY_NUMERIC_FIELDS,
@@ -25,6 +25,11 @@
     validateObservabilityConfig,
   } from '$lib/components/observability-settings-helpers';
   import { canRetryRelay, getSettingsStatusLabel, restartRelay } from '$lib/relaySidecarUi';
+  import {
+    buildNetworkExposureRows,
+    toggleListenIp,
+    type NetworkExposureRow,
+  } from '$lib/components/network-exposure-helpers';
   import { fetchJsExecutionMode, toggleJsExecutionMode } from '$lib/jsExecutionModeUi';
   import { fetchToonOutput, toggleToonOutput } from '$lib/toonOutputUi';
   import { fetchWriteDirs, addWriteDir, removeWriteDir } from '$lib/writeDirsUi';
@@ -170,6 +175,7 @@
       .catch((e) => console.error('[overlay] subscribe failed:', e));
     fetchUpdateChannel();
     loadObservabilityConfig();
+    loadNetworkExposure();
     invoke('get_config_path_display').then((p: unknown) => {
       if (typeof p === 'string') configFilePath = p;
     }).catch(() => {});
@@ -250,6 +256,52 @@
       console.error('Failed to load observability config:', e);
     } finally {
       obsLoading = false;
+    }
+  }
+
+  // Network exposure — detected interfaces merged with `[relay] listen_ips`.
+  // The relay only reports eligible (private/CGNAT/ULA) addresses and the
+  // merge helper filters configured entries the same way, so no loopback,
+  // unspecified, or public address can ever be rendered here.
+  let netRows = $state<NetworkExposureRow[]>([]);
+  let netListenIps = $state<string[]>([]);
+  let netLoading = $state(true);
+  let netUnavailable = $state(false);
+  let netBusyIp = $state<string | null>(null);
+  let netError = $state<string | null>(null);
+
+  async function loadNetworkExposure() {
+    netLoading = true;
+    netUnavailable = false;
+    try {
+      const res = await getNetworkInterfaces();
+      netListenIps = res.listen_ips;
+      netRows = buildNetworkExposureRows(res.interfaces, res.listen_ips);
+    } catch (e) {
+      netUnavailable = true;
+      console.error('Failed to load network interfaces:', e);
+    } finally {
+      netLoading = false;
+    }
+  }
+
+  // Flip one interface toggle: persist the new full list through the Tauri
+  // backend, then restart the relay (listeners are only bound at startup) so
+  // the change takes effect, then re-read state from the relay.
+  async function handleToggleListenIp(row: NetworkExposureRow) {
+    if (netBusyIp !== null) return;
+    netBusyIp = row.ip;
+    netError = null;
+    const next = toggleListenIp(netListenIps, row.ip, !row.enabled);
+    try {
+      await invoke('set_listen_ips', { ips: next });
+      await restartRelay(invoke);
+      await loadNetworkExposure();
+    } catch (e) {
+      netError = e instanceof Error ? e.message : String(e);
+      console.error('Failed to update listen IPs:', e);
+    } finally {
+      netBusyIp = null;
     }
   }
 
@@ -696,6 +748,73 @@
           </div>
         {/each}
       </div>
+    </div>
+
+    <!-- Network Exposure -->
+    <div class="pt-4 mt-4 border-t border-(--border)">
+      <div class="text-xs font-medium text-(--fg2) uppercase tracking-wide mb-2">Network Exposure</div>
+      <p class="text-xs text-(--fg2) mb-2">Choose which network interfaces the relay's MCP endpoint listens on.</p>
+
+      <div class="p-2 rounded bg-yellow-500/10 border border-yellow-500/20 mb-3">
+        <p class="text-xs text-yellow-600 dark:text-yellow-400 font-medium">Warning: enabling a non-loopback address exposes the MCP endpoint to other devices and users on that network, including potential attackers. Anyone who can reach it can invoke your configured tools.</p>
+      </div>
+
+      <div class="space-y-1.5">
+        <div class="flex items-center justify-between gap-2 px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface)">
+          <div class="min-w-0">
+            <span class="text-xs font-medium">Localhost</span>
+            <span class="text-xs font-mono ml-2 text-(--fg2)">127.0.0.1</span>
+            <span class="text-[0.65rem] text-(--fg2)/70 ml-2">always on</span>
+          </div>
+          <button
+            class="shrink-0 relative w-10 h-5 rounded-full bg-green-500 opacity-60 cursor-not-allowed"
+            disabled
+            role="switch"
+            aria-checked="true"
+            aria-label="Localhost listening (always on)"
+          >
+            <span class="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow translate-x-5"></span>
+          </button>
+        </div>
+
+        {#if netLoading}
+          <p class="text-xs text-(--fg2)">Detecting network interfaces…</p>
+        {:else if netUnavailable}
+          <p class="text-xs text-(--fg2)/70">Could not reach the relay to list network interfaces.</p>
+        {:else}
+          {#each netRows as row (row.ip)}
+            <div class="flex items-center justify-between gap-2 px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface)">
+              <div class="min-w-0">
+                <span class="text-xs font-medium">{row.name ?? 'Unknown interface'}</span>
+                <span class="text-xs font-mono ml-2 text-(--fg2)">{row.ip}</span>
+                {#if !row.detected}
+                  <span class="text-[0.65rem] px-1.5 py-0.5 rounded-full ml-2 bg-yellow-500/10 text-yellow-600 dark:text-yellow-400">not detected</span>
+                {/if}
+              </div>
+              <button
+                class="shrink-0 relative w-10 h-5 rounded-full transition-colors {row.enabled ? 'bg-green-500' : 'bg-gray-300 dark:bg-gray-600'} disabled:cursor-not-allowed disabled:opacity-60"
+                onclick={() => handleToggleListenIp(row)}
+                disabled={netBusyIp !== null}
+                role="switch"
+                aria-checked={row.enabled}
+                aria-label="Toggle listening on {row.ip}"
+              >
+                <span class="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform {row.enabled ? 'translate-x-5' : ''}"></span>
+              </button>
+            </div>
+          {:else}
+            <p class="text-xs text-(--fg2)/70">No eligible network interfaces detected.</p>
+          {/each}
+        {/if}
+      </div>
+
+      {#if netBusyIp !== null}
+        <p class="text-xs text-(--fg2) mt-2">Applying change and restarting the relay…</p>
+      {:else if netError}
+        <p class="text-xs text-red-600 dark:text-red-400 mt-2">Failed to apply change: {netError}</p>
+      {:else}
+        <p class="text-xs text-(--fg2)/70 mt-2">The relay restarts automatically when you change these toggles.</p>
+      {/if}
     </div>
 
     {#if buildInfo}

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -15,7 +15,7 @@
   import type { UnlistenFn } from '@tauri-apps/api/event';
   import type { Theme, RelayStatus, ObservabilityConfig } from '$lib/types';
   import { invoke } from '@tauri-apps/api/core';
-  import { getStatus, getObservabilityConfig, putObservabilityConfig, getNetworkInterfaces } from '$lib/api';
+  import { getStatus, getObservabilityConfig, putObservabilityConfig, getNetworkInterfaces, type NetworkInterfaceInfo } from '$lib/api';
   import {
     DEFAULT_OBSERVABILITY_CONFIG,
     OBSERVABILITY_NUMERIC_FIELDS,
@@ -265,21 +265,49 @@
   // unspecified, or public address can ever be rendered here.
   let netRows = $state<NetworkExposureRow[]>([]);
   let netListenIps = $state<string[]>([]);
+  let netInterfaces = $state<NetworkInterfaceInfo[]>([]);
   let netLoading = $state(true);
   let netUnavailable = $state(false);
   let netBusyIp = $state<string | null>(null);
   let netError = $state<string | null>(null);
 
-  async function loadNetworkExposure() {
-    netLoading = true;
-    netUnavailable = false;
+  // Fetch the interface list, retrying beyond fetchJson's built-in ~2s
+  // window when asked — after a relay restart the management socket may take
+  // several seconds to accept connections again.
+  async function fetchNetworkInterfacesRetrying(extraAttempts: number) {
+    for (let attempt = 0; ; attempt++) {
+      try {
+        return await getNetworkInterfaces();
+      } catch (e) {
+        if (attempt >= extraAttempts) throw e;
+        await new Promise((r) => setTimeout(r, 1500));
+      }
+    }
+  }
+
+  async function loadNetworkExposure(extraAttempts = 0) {
+    // Only blank the list with the loading placeholder on the first load;
+    // refetches keep the last-known rows visible until fresh data arrives.
+    if (netRows.length === 0) netLoading = true;
     try {
-      const res = await getNetworkInterfaces();
+      const res = await fetchNetworkInterfacesRetrying(extraAttempts);
+      netInterfaces = res.interfaces;
       netListenIps = res.listen_ips;
       netRows = buildNetworkExposureRows(res.interfaces, res.listen_ips);
+      netUnavailable = false;
     } catch (e) {
       netUnavailable = true;
       console.error('Failed to load network interfaces:', e);
+      // Fallback: read the configured list straight from config.toml so the
+      // user can still disable entries while the relay is unreachable. The
+      // last-known detected interfaces (possibly empty) keep their labels.
+      try {
+        const ips = await invoke<string[]>('get_listen_ips');
+        netListenIps = ips;
+        netRows = buildNetworkExposureRows(netInterfaces, ips);
+      } catch (fallbackErr) {
+        console.error('Failed to read listen_ips from config:', fallbackErr);
+      }
     } finally {
       netLoading = false;
     }
@@ -293,14 +321,23 @@
     netBusyIp = row.ip;
     netError = null;
     const next = toggleListenIp(netListenIps, row.ip, !row.enabled);
+    let persisted = false;
     try {
       await invoke('set_listen_ips', { ips: next });
+      persisted = true;
+      // Optimistically reflect the just-persisted list so the rows never
+      // blank out or show stale toggle state while the relay restarts.
+      netListenIps = next;
+      netRows = buildNetworkExposureRows(netInterfaces, next);
       await restartRelay(invoke);
-      await loadNetworkExposure();
     } catch (e) {
       netError = e instanceof Error ? e.message : String(e);
       console.error('Failed to update listen IPs:', e);
     } finally {
+      // Refetch config-derived state even when the restart failed, so the
+      // UI stays consistent with what was persisted to disk; use an
+      // extended retry window to ride out a slow relay start.
+      if (persisted) await loadNetworkExposure(4);
       netBusyIp = null;
     }
   }
@@ -779,9 +816,10 @@
 
         {#if netLoading}
           <p class="text-xs text-(--fg2)">Detecting network interfaces…</p>
-        {:else if netUnavailable}
-          <p class="text-xs text-(--fg2)/70">Could not reach the relay to list network interfaces.</p>
         {:else}
+          {#if netUnavailable}
+            <p class="text-xs text-(--fg2)/70">Could not reach the relay to list network interfaces. Showing addresses from the saved configuration; you can still turn them off.</p>
+          {/if}
           {#each netRows as row (row.ip)}
             <div class="flex items-center justify-between gap-2 px-3 py-1.5 rounded-lg border border-(--border) bg-(--surface)">
               <div class="min-w-0">
@@ -803,7 +841,9 @@
               </button>
             </div>
           {:else}
-            <p class="text-xs text-(--fg2)/70">No eligible network interfaces detected.</p>
+            {#if !netUnavailable}
+              <p class="text-xs text-(--fg2)/70">No eligible network interfaces detected.</p>
+            {/if}
           {/each}
         {/if}
       </div>

--- a/src/lib/components/network-exposure-helpers.test.ts
+++ b/src/lib/components/network-exposure-helpers.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildNetworkExposureRows,
   isRenderableListenIp,
+  normalizeListenIp,
   toggleListenIp,
 } from './network-exposure-helpers';
 import type { NetworkInterfaceInfo } from '$lib/api';
@@ -36,10 +37,48 @@ describe('isRenderableListenIp', () => {
     expect(isRenderableListenIp('')).toBe(false);
   });
 
+  it('rejects malformed IPv6 literals even when the first hextet looks ULA', () => {
+    expect(isRenderableListenIp('fd00:junk')).toBe(false);
+    expect(isRenderableListenIp('fc00:')).toBe(false);
+    expect(isRenderableListenIp('fd00::1::2')).toBe(false);
+    expect(isRenderableListenIp('fd00:1:2:3:4:5:6:7:8')).toBe(false);
+    expect(isRenderableListenIp('fd00:1:2:3:4:5:6')).toBe(false);
+    expect(isRenderableListenIp('fd00:12345::1')).toBe(false);
+  });
+
+  it('accepts valid ULA forms regardless of spelling', () => {
+    expect(isRenderableListenIp('fd00::1')).toBe(true);
+    expect(isRenderableListenIp('FD00::1')).toBe(true);
+    expect(isRenderableListenIp('fd00:0:0:0:0:0:0:1')).toBe(true);
+  });
+
   it('classifies IPv4-mapped IPv6 by the embedded IPv4 address', () => {
     expect(isRenderableListenIp('::ffff:192.168.1.10')).toBe(true);
     expect(isRenderableListenIp('::ffff:8.8.8.8')).toBe(false);
     expect(isRenderableListenIp('::ffff:127.0.0.1')).toBe(false);
+  });
+});
+
+describe('normalizeListenIp', () => {
+  it('canonicalizes equivalent IPv6 spellings to one RFC 5952 form', () => {
+    expect(normalizeListenIp('fd00::1')).toBe('fd00::1');
+    expect(normalizeListenIp('fd00:0::1')).toBe('fd00::1');
+    expect(normalizeListenIp('fd00:0:0:0:0:0:0:1')).toBe('fd00::1');
+    expect(normalizeListenIp('FD00:0000:0000:0000:0000:0000:0000:0001')).toBe('fd00::1');
+    expect(normalizeListenIp('fd12:3456:789a:1:2:3:4:5')).toBe('fd12:3456:789a:1:2:3:4:5');
+  });
+
+  it('trims whitespace and normalizes IPv4 octets', () => {
+    expect(normalizeListenIp(' 10.0.0.7 ')).toBe('10.0.0.7');
+    expect(normalizeListenIp('010.000.000.007')).toBe('10.0.0.7');
+    expect(normalizeListenIp(' ::ffff:192.168.1.10 ')).toBe('::ffff:192.168.1.10');
+  });
+
+  it('returns null for unparseable input', () => {
+    expect(normalizeListenIp('fd00:junk')).toBeNull();
+    expect(normalizeListenIp('fc00:')).toBeNull();
+    expect(normalizeListenIp('not-an-ip')).toBeNull();
+    expect(normalizeListenIp('')).toBeNull();
   });
 });
 
@@ -103,6 +142,14 @@ describe('buildNetworkExposureRows', () => {
     ]);
   });
 
+  it('matches non-canonical configured IPv6 against the detected canonical form', () => {
+    const ula: NetworkInterfaceInfo = { name: 'tailscale0', ip: 'fd00::1', family: 'v6', kind: 'ula' };
+    const rows = buildNetworkExposureRows([ula], ['fd00:0:0:0:0:0:0:1']);
+    expect(rows).toEqual([
+      { ip: 'fd00::1', name: 'tailscale0', kind: 'ula', detected: true, enabled: true },
+    ]);
+  });
+
   it('returns an empty list when nothing is detected or configured', () => {
     expect(buildNetworkExposureRows([], [])).toEqual([]);
   });
@@ -128,6 +175,16 @@ describe('toggleListenIp', () => {
 
   it('disabling an absent IP leaves the list unchanged', () => {
     expect(toggleListenIp(['10.0.0.7'], '192.168.1.5', false)).toEqual(['10.0.0.7']);
+  });
+
+  it('disabling removes non-canonical spellings of the same IPv6 address', () => {
+    expect(
+      toggleListenIp(['fd00:0:0:0:0:0:0:1', 'FD00:0::1', '10.0.0.7'], 'fd00::1', false),
+    ).toEqual(['10.0.0.7']);
+  });
+
+  it('enabling appends the canonical form and dedupes non-canonical spellings', () => {
+    expect(toggleListenIp(['fd00:0::1'], 'FD00::1', true)).toEqual(['fd00::1']);
   });
 
   it('does not mutate the input list', () => {

--- a/src/lib/components/network-exposure-helpers.test.ts
+++ b/src/lib/components/network-exposure-helpers.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildNetworkExposureRows,
+  isRenderableListenIp,
+  toggleListenIp,
+} from './network-exposure-helpers';
+import type { NetworkInterfaceInfo } from '$lib/api';
+
+const eth0: NetworkInterfaceInfo = { name: 'eth0', ip: '192.168.1.5', family: 'v4', kind: 'private' };
+const tailscale: NetworkInterfaceInfo = { name: 'tailscale0', ip: '100.101.102.103', family: 'v4', kind: 'cgnat' };
+
+describe('isRenderableListenIp', () => {
+  it('accepts RFC 1918, CGNAT, and ULA addresses', () => {
+    expect(isRenderableListenIp('10.0.0.1')).toBe(true);
+    expect(isRenderableListenIp('172.16.0.1')).toBe(true);
+    expect(isRenderableListenIp('172.31.255.254')).toBe(true);
+    expect(isRenderableListenIp('192.168.1.5')).toBe(true);
+    expect(isRenderableListenIp('100.64.0.1')).toBe(true);
+    expect(isRenderableListenIp('100.127.255.254')).toBe(true);
+    expect(isRenderableListenIp('fd12:3456:789a::1')).toBe(true);
+  });
+
+  it('rejects loopback, unspecified, link-local, and public addresses', () => {
+    expect(isRenderableListenIp('127.0.0.1')).toBe(false);
+    expect(isRenderableListenIp('0.0.0.0')).toBe(false);
+    expect(isRenderableListenIp('::')).toBe(false);
+    expect(isRenderableListenIp('::1')).toBe(false);
+    expect(isRenderableListenIp('169.254.1.1')).toBe(false);
+    expect(isRenderableListenIp('fe80::1')).toBe(false);
+    expect(isRenderableListenIp('8.8.8.8')).toBe(false);
+    expect(isRenderableListenIp('100.63.255.255')).toBe(false);
+    expect(isRenderableListenIp('172.32.0.1')).toBe(false);
+    expect(isRenderableListenIp('2001:db8::1')).toBe(false);
+    expect(isRenderableListenIp('not-an-ip')).toBe(false);
+    expect(isRenderableListenIp('')).toBe(false);
+  });
+
+  it('classifies IPv4-mapped IPv6 by the embedded IPv4 address', () => {
+    expect(isRenderableListenIp('::ffff:192.168.1.10')).toBe(true);
+    expect(isRenderableListenIp('::ffff:8.8.8.8')).toBe(false);
+    expect(isRenderableListenIp('::ffff:127.0.0.1')).toBe(false);
+  });
+});
+
+describe('buildNetworkExposureRows', () => {
+  it('marks detected interfaces enabled based on listen_ips membership', () => {
+    const rows = buildNetworkExposureRows([eth0, tailscale], ['100.101.102.103']);
+    expect(rows).toEqual([
+      { ip: '192.168.1.5', name: 'eth0', kind: 'private', detected: true, enabled: false },
+      { ip: '100.101.102.103', name: 'tailscale0', kind: 'cgnat', detected: true, enabled: true },
+    ]);
+  });
+
+  it('appends configured-but-undetected IPs as enabled "not detected" rows', () => {
+    const rows = buildNetworkExposureRows([eth0], ['100.101.102.103']);
+    expect(rows).toEqual([
+      { ip: '192.168.1.5', name: 'eth0', kind: 'private', detected: true, enabled: false },
+      { ip: '100.101.102.103', name: null, kind: null, detected: false, enabled: true },
+    ]);
+  });
+
+  it('never renders configured loopback, unspecified, or public IPs', () => {
+    const rows = buildNetworkExposureRows(
+      [eth0],
+      ['127.0.0.1', '0.0.0.0', '::', '8.8.8.8', 'garbage', '192.168.1.5'],
+    );
+    expect(rows).toEqual([
+      { ip: '192.168.1.5', name: 'eth0', kind: 'private', detected: true, enabled: true },
+    ]);
+  });
+
+  it('never renders ineligible DETECTED interfaces (defense in depth vs the API)', () => {
+    const rows = buildNetworkExposureRows(
+      [
+        { name: 'any0', ip: '0.0.0.0', family: 'v4', kind: 'private' },
+        { name: 'lo', ip: '127.0.0.1', family: 'v4', kind: 'private' },
+        { name: 'wan0', ip: '8.8.8.8', family: 'v4', kind: 'private' },
+      ],
+      [],
+    );
+    expect(rows).toEqual([]);
+  });
+
+  it('a detected 127.0.0.1 never duplicates the always-on Localhost row, even when configured', () => {
+    const rows = buildNetworkExposureRows(
+      [{ name: 'lo', ip: '127.0.0.1', family: 'v4', kind: 'private' }, eth0],
+      ['127.0.0.1'],
+    );
+    expect(rows).toEqual([
+      { ip: '192.168.1.5', name: 'eth0', kind: 'private', detected: true, enabled: false },
+    ]);
+  });
+
+  it('dedupes repeated interfaces and configured entries, trimming whitespace', () => {
+    const rows = buildNetworkExposureRows(
+      [eth0, eth0],
+      [' 10.0.0.7 ', '10.0.0.7'],
+    );
+    expect(rows).toEqual([
+      { ip: '192.168.1.5', name: 'eth0', kind: 'private', detected: true, enabled: false },
+      { ip: '10.0.0.7', name: null, kind: null, detected: false, enabled: true },
+    ]);
+  });
+
+  it('returns an empty list when nothing is detected or configured', () => {
+    expect(buildNetworkExposureRows([], [])).toEqual([]);
+  });
+});
+
+describe('toggleListenIp', () => {
+  it('enabling appends the IP to the configured list', () => {
+    expect(toggleListenIp(['10.0.0.7'], '192.168.1.5', true)).toEqual([
+      '10.0.0.7',
+      '192.168.1.5',
+    ]);
+  });
+
+  it('enabling an already-present IP does not duplicate it', () => {
+    expect(toggleListenIp(['192.168.1.5'], '192.168.1.5', true)).toEqual(['192.168.1.5']);
+  });
+
+  it('disabling removes every occurrence, preserving remaining order', () => {
+    expect(
+      toggleListenIp(['10.0.0.7', '192.168.1.5', ' 192.168.1.5 '], '192.168.1.5', false),
+    ).toEqual(['10.0.0.7']);
+  });
+
+  it('disabling an absent IP leaves the list unchanged', () => {
+    expect(toggleListenIp(['10.0.0.7'], '192.168.1.5', false)).toEqual(['10.0.0.7']);
+  });
+
+  it('does not mutate the input list', () => {
+    const input = ['10.0.0.7'];
+    toggleListenIp(input, '192.168.1.5', true);
+    toggleListenIp(input, '10.0.0.7', false);
+    expect(input).toEqual(['10.0.0.7']);
+  });
+});

--- a/src/lib/components/network-exposure-helpers.ts
+++ b/src/lib/components/network-exposure-helpers.ts
@@ -25,25 +25,38 @@ export interface NetworkExposureRow {
  * IPv6 ULA (fc00::/7) addresses may be rendered. Loopback, unspecified
  * (0.0.0.0 / ::), link-local, public, and unparseable entries are rejected
  * so the UI can never surface — let alone toggle on — an address the relay
- * itself refuses to bind.
+ * itself refuses to bind. IPv6 literals are fully parsed (hextet syntax,
+ * group count, at most one `::`), so a malformed string that merely starts
+ * with a ULA-looking hextet (`fd00:junk`, `fc00:`) is rejected too.
  */
 export function isRenderableListenIp(ip: string): boolean {
   const trimmed = ip.trim();
   const v4 = parseV4(trimmed);
   if (v4) return isEligibleV4(v4);
   // IPv4-mapped IPv6 (::ffff:a.b.c.d) classifies as its embedded IPv4.
-  const mappedMatch = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/i.exec(trimmed);
-  if (mappedMatch) {
-    const mapped = parseV4(mappedMatch[1]);
-    return mapped !== null && isEligibleV4(mapped);
-  }
+  const mapped = parseMappedV4(trimmed);
+  if (mapped) return isEligibleV4(mapped);
   // IPv6: eligible only for ULA fc00::/7 (first hextet & 0xfe00 == 0xfc00).
-  if (trimmed.includes(':')) {
-    const first = trimmed.split(':', 1)[0];
-    if (!/^[0-9a-f]{1,4}$/i.test(first)) return false;
-    return (parseInt(first, 16) & 0xfe00) === 0xfc00;
-  }
-  return false;
+  const segments = parseV6(trimmed);
+  return segments !== null && (segments[0] & 0xfe00) === 0xfc00;
+}
+
+/**
+ * Normalize an IP literal to a canonical textual form so that equivalent
+ * spellings compare equal: whitespace is trimmed, IPv4 octets lose leading
+ * zeros, and IPv6 is lowercased and compressed per RFC 5952 (`fd00:0::1`,
+ * `FD00:0:0:0:0:0:0:1`, and `fd00::1` all normalize to `fd00::1`). Returns
+ * null when the input is not a parseable IPv4/IPv6 literal. Used for both
+ * row comparison and the persisted `listen_ips` entries.
+ */
+export function normalizeListenIp(ip: string): string | null {
+  const trimmed = ip.trim();
+  const v4 = parseV4(trimmed);
+  if (v4) return v4.join('.');
+  const mapped = parseMappedV4(trimmed);
+  if (mapped) return `::ffff:${mapped.join('.')}`;
+  const segments = parseV6(trimmed);
+  return segments !== null ? formatV6(segments) : null;
 }
 
 function parseV4(s: string): [number, number, number, number] | null {
@@ -52,6 +65,64 @@ function parseV4(s: string): [number, number, number, number] | null {
   const octets = m.slice(1).map(Number);
   if (octets.some((o) => o > 255)) return null;
   return octets as [number, number, number, number];
+}
+
+function parseMappedV4(s: string): [number, number, number, number] | null {
+  const m = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/i.exec(s);
+  return m ? parseV4(m[1]) : null;
+}
+
+/**
+ * Parse an IPv6 literal into its 8 hextets, or null when malformed: every
+ * group must be 1-4 hex digits, at most one `::` (which must stand in for at
+ * least one zero group), and the group count must come out to exactly 8.
+ * Embedded-IPv4 tails (`fd00::1.2.3.4`) are not supported; the relay always
+ * reports pure-hex forms.
+ */
+function parseV6(s: string): number[] | null {
+  if (!s.includes(':')) return null;
+  const halves = s.split('::');
+  if (halves.length > 2) return null;
+  const parseGroups = (half: string): number[] | null => {
+    if (half === '') return [];
+    const groups = half.split(':');
+    const out: number[] = [];
+    for (const g of groups) {
+      if (!/^[0-9a-f]{1,4}$/i.test(g)) return null;
+      out.push(parseInt(g, 16));
+    }
+    return out;
+  };
+  const head = parseGroups(halves[0]);
+  if (head === null) return null;
+  if (halves.length === 1) return head.length === 8 ? head : null;
+  const tail = parseGroups(halves[1]);
+  if (tail === null) return null;
+  const fill = 8 - head.length - tail.length;
+  if (fill < 1) return null;
+  return [...head, ...new Array<number>(fill).fill(0), ...tail];
+}
+
+/** Format 8 hextets per RFC 5952: lowercase hex, longest zero run (≥2) as `::`. */
+function formatV6(segments: number[]): string {
+  let best = -1;
+  let bestLen = 0;
+  for (let i = 0; i < 8; ) {
+    if (segments[i] === 0) {
+      let j = i;
+      while (j < 8 && segments[j] === 0) j++;
+      if (j - i > bestLen) {
+        best = i;
+        bestLen = j - i;
+      }
+      i = j;
+    } else {
+      i++;
+    }
+  }
+  const hex = segments.map((seg) => seg.toString(16));
+  if (bestLen < 2) return hex.join(':');
+  return `${hex.slice(0, best).join(':')}::${hex.slice(best + bestLen).join(':')}`;
 }
 
 function isEligibleV4([a, b]: [number, number, number, number]): boolean {
@@ -69,7 +140,10 @@ function isEligibleV4([a, b]: [number, number, number, number]): boolean {
  * `detected: false` so the user can still turn them off. Entries from either
  * arm that are not renderable (loopback, 0.0.0.0, public, garbage) are
  * dropped — the relay already filters detected interfaces, but the helper
- * re-checks them as defense in depth; duplicates keep their first occurrence.
+ * re-checks them as defense in depth. All comparison, de-duping, and row keys
+ * use `normalizeListenIp`, so equivalent spellings (whitespace, IPv6 case or
+ * zero-compression variants) collapse into one row; duplicates keep their
+ * first occurrence.
  */
 export function buildNetworkExposureRows(
   interfaces: NetworkInterfaceInfo[],
@@ -77,21 +151,26 @@ export function buildNetworkExposureRows(
 ): NetworkExposureRow[] {
   const rows: NetworkExposureRow[] = [];
   const seen = new Set<string>();
-  const configured = new Set(listenIps.map((ip) => ip.trim()));
+  const configured = new Set(
+    listenIps
+      .map((ip) => normalizeListenIp(ip))
+      .filter((ip): ip is string => ip !== null),
+  );
   for (const iface of interfaces) {
-    if (seen.has(iface.ip) || !isRenderableListenIp(iface.ip)) continue;
-    seen.add(iface.ip);
+    const ip = normalizeListenIp(iface.ip);
+    if (ip === null || seen.has(ip) || !isRenderableListenIp(ip)) continue;
+    seen.add(ip);
     rows.push({
-      ip: iface.ip,
+      ip,
       name: iface.name,
       kind: iface.kind,
       detected: true,
-      enabled: configured.has(iface.ip),
+      enabled: configured.has(ip),
     });
   }
   for (const raw of listenIps) {
-    const ip = raw.trim();
-    if (seen.has(ip) || !isRenderableListenIp(ip)) continue;
+    const ip = normalizeListenIp(raw);
+    if (ip === null || seen.has(ip) || !isRenderableListenIp(ip)) continue;
     seen.add(ip);
     rows.push({ ip, name: null, kind: null, detected: false, enabled: true });
   }
@@ -100,14 +179,19 @@ export function buildNetworkExposureRows(
 
 /**
  * Compute the next `listen_ips` list after toggling `ip`. Enabling appends
- * (no duplicate); disabling removes every occurrence. Order of the remaining
- * entries is preserved.
+ * the normalized form (no duplicate); disabling removes every occurrence
+ * whose normalized form matches, so non-canonical spellings of the same
+ * address (e.g. `fd00:0::1` vs `fd00::1`) are removed too. Order of the
+ * remaining entries is preserved.
  */
 export function toggleListenIp(
   listenIps: string[],
   ip: string,
   enabled: boolean,
 ): string[] {
-  const without = listenIps.filter((entry) => entry.trim() !== ip);
-  return enabled ? [...without, ip] : without;
+  const target = normalizeListenIp(ip) ?? ip.trim();
+  const without = listenIps.filter(
+    (entry) => (normalizeListenIp(entry) ?? entry.trim()) !== target,
+  );
+  return enabled ? [...without, target] : without;
 }

--- a/src/lib/components/network-exposure-helpers.ts
+++ b/src/lib/components/network-exposure-helpers.ts
@@ -1,0 +1,113 @@
+// Pure helpers for the Settings "Network exposure" section: merge the
+// relay-detected interface list with the configured `[relay] listen_ips`
+// into displayable rows, and compute the next `listen_ips` list when a
+// toggle flips. Kept out of Settings.svelte so the logic is unit-testable.
+
+import type { NetworkInterfaceInfo } from '$lib/api';
+
+/** One row in the Network exposure list (loopback is rendered separately). */
+export interface NetworkExposureRow {
+  /** The address as an IP literal. */
+  ip: string;
+  /** OS interface name; null when the IP is configured but not detected. */
+  name: string | null;
+  /** "private" | "cgnat" | "ula"; null when not detected. */
+  kind: string | null;
+  /** False for configured-but-undetected entries (e.g. Tailscale down). */
+  detected: boolean;
+  /** Whether the IP is currently in `listen_ips`. */
+  enabled: boolean;
+}
+
+/**
+ * Mirror of the relay's `listen_ips` eligibility classifier
+ * (`endara_relay::listen_ips`): only RFC 1918, CGNAT (100.64.0.0/10), and
+ * IPv6 ULA (fc00::/7) addresses may be rendered. Loopback, unspecified
+ * (0.0.0.0 / ::), link-local, public, and unparseable entries are rejected
+ * so the UI can never surface — let alone toggle on — an address the relay
+ * itself refuses to bind.
+ */
+export function isRenderableListenIp(ip: string): boolean {
+  const trimmed = ip.trim();
+  const v4 = parseV4(trimmed);
+  if (v4) return isEligibleV4(v4);
+  // IPv4-mapped IPv6 (::ffff:a.b.c.d) classifies as its embedded IPv4.
+  const mappedMatch = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/i.exec(trimmed);
+  if (mappedMatch) {
+    const mapped = parseV4(mappedMatch[1]);
+    return mapped !== null && isEligibleV4(mapped);
+  }
+  // IPv6: eligible only for ULA fc00::/7 (first hextet & 0xfe00 == 0xfc00).
+  if (trimmed.includes(':')) {
+    const first = trimmed.split(':', 1)[0];
+    if (!/^[0-9a-f]{1,4}$/i.test(first)) return false;
+    return (parseInt(first, 16) & 0xfe00) === 0xfc00;
+  }
+  return false;
+}
+
+function parseV4(s: string): [number, number, number, number] | null {
+  const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(s);
+  if (!m) return null;
+  const octets = m.slice(1).map(Number);
+  if (octets.some((o) => o > 255)) return null;
+  return octets as [number, number, number, number];
+}
+
+function isEligibleV4([a, b]: [number, number, number, number]): boolean {
+  if (a === 10) return true; // 10.0.0.0/8
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16
+  if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT 100.64.0.0/10
+  return false;
+}
+
+/**
+ * Merge detected interfaces with the configured `listen_ips` into rows:
+ * detected interfaces first (API order) with `enabled` reflecting membership
+ * in `listenIps`, then configured-but-undetected IPs as enabled rows marked
+ * `detected: false` so the user can still turn them off. Entries from either
+ * arm that are not renderable (loopback, 0.0.0.0, public, garbage) are
+ * dropped — the relay already filters detected interfaces, but the helper
+ * re-checks them as defense in depth; duplicates keep their first occurrence.
+ */
+export function buildNetworkExposureRows(
+  interfaces: NetworkInterfaceInfo[],
+  listenIps: string[],
+): NetworkExposureRow[] {
+  const rows: NetworkExposureRow[] = [];
+  const seen = new Set<string>();
+  const configured = new Set(listenIps.map((ip) => ip.trim()));
+  for (const iface of interfaces) {
+    if (seen.has(iface.ip) || !isRenderableListenIp(iface.ip)) continue;
+    seen.add(iface.ip);
+    rows.push({
+      ip: iface.ip,
+      name: iface.name,
+      kind: iface.kind,
+      detected: true,
+      enabled: configured.has(iface.ip),
+    });
+  }
+  for (const raw of listenIps) {
+    const ip = raw.trim();
+    if (seen.has(ip) || !isRenderableListenIp(ip)) continue;
+    seen.add(ip);
+    rows.push({ ip, name: null, kind: null, detected: false, enabled: true });
+  }
+  return rows;
+}
+
+/**
+ * Compute the next `listen_ips` list after toggling `ip`. Enabling appends
+ * (no duplicate); disabling removes every occurrence. Order of the remaining
+ * entries is preserved.
+ */
+export function toggleListenIp(
+  listenIps: string[],
+  ip: string,
+  enabled: boolean,
+): string[] {
+  const without = listenIps.filter((entry) => entry.trim() !== ip);
+  return enabled ? [...without, ip] : without;
+}


### PR DESCRIPTION
## Summary
Desktop UI + backend for the relay's new opt-in listen_ips feature (companion to the endara-relay PR).

- New Tauri commands get_listen_ips / set_listen_ips persisting relay.listen_ips in ~/.endara/config.toml (ensures [relay] with machine_name fallback, dedupes, empty list = loopback-only)
- getNetworkInterfaces() API call via the management proxy
- New Network Exposure card in Settings:
  - Always-on, non-toggleable Localhost (127.0.0.1) row
  - One toggle row per detected eligible interface (private / CGNAT / IPv6 ULA)
  - Configured-but-undetected IPs render as enabled rows with a 'not detected' badge so they can be turned off
  - Persistent, unconditional warning that enabling a network IP exposes the MCP endpoint to other devices/users on that network, including potential attackers
  - Toggling persists the list, restarts the relay sidecar, then refetches
- Defense in depth: the render helpers filter BOTH detected and configured IPs, so 0.0.0.0, public IPs, and loopback duplicates can never render even if the API returned them.

## Testing
- npm test: 1172 passed (15 new helper tests incl. regression tests for the filtering invariants)
- svelte-check: 0 errors / 0 warnings
- src-tauri: cargo check + cargo test --lib 137/137 (10 new tests); no new clippy findings