### PR TITLE
feat(ui): soften destructive hint pill to "Makes changes"

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -188,7 +188,6 @@
 
   /* Desktop kit — hint pills (light) */
   --hint-read-bg: #D3F9D8; --hint-read-fg: #2B8A3E;
-  --hint-dest-bg: #FFE3E3; --hint-dest-fg: #C92A2A;
   --hint-warn-bg: #FFF3BF; --hint-warn-fg: #8A5D00;
 }
 
@@ -256,7 +255,6 @@
 
   /* Desktop kit — hint pills (dark) */
   --hint-read-bg: rgba(81, 207, 102, 0.15); --hint-read-fg: #69DB7C;
-  --hint-dest-bg: rgba(250, 82, 82, 0.18);  --hint-dest-fg: #FF8787;
   --hint-warn-bg: rgba(252, 196, 25, 0.16); --hint-warn-fg: #FCD34D;
 }
 

--- a/src/app.css
+++ b/src/app.css
@@ -189,6 +189,7 @@
   /* Desktop kit — hint pills (light) */
   --hint-read-bg: #D3F9D8; --hint-read-fg: #2B8A3E;
   --hint-dest-bg: #FFE3E3; --hint-dest-fg: #C92A2A;
+  --hint-warn-bg: #FFF3BF; --hint-warn-fg: #8A5D00;
 }
 
 /* ============================================================
@@ -256,6 +257,7 @@
   /* Desktop kit — hint pills (dark) */
   --hint-read-bg: rgba(81, 207, 102, 0.15); --hint-read-fg: #69DB7C;
   --hint-dest-bg: rgba(250, 82, 82, 0.18);  --hint-dest-fg: #FF8787;
+  --hint-warn-bg: rgba(252, 196, 25, 0.16); --hint-warn-fg: #FCD34D;
 }
 
 

--- a/src/lib/components/ToolsTab.svelte
+++ b/src/lib/components/ToolsTab.svelte
@@ -82,7 +82,7 @@
             <span class="hint-pill hint-read">Read-only</span>
           {/if}
           {#if tool.annotations?.destructiveHint === true}
-            <span class="hint-pill hint-dest">Destructive</span>
+            <span class="hint-pill hint-warn">Makes changes</span>
           {/if}
           {#if tool.annotations?.idempotentHint === true}
             <span class="hint-pill hint-read">Idempotent</span>
@@ -222,6 +222,10 @@
   .hint-dest {
     background: var(--hint-dest-bg);
     color: var(--hint-dest-fg);
+  }
+  .hint-warn {
+    background: var(--hint-warn-bg);
+    color: var(--hint-warn-fg);
   }
 
   /* Toggle (shared base + compact tool variant) */

--- a/src/lib/components/ToolsTab.svelte
+++ b/src/lib/components/ToolsTab.svelte
@@ -88,7 +88,7 @@
             <span class="hint-pill hint-read">Idempotent</span>
           {/if}
           {#if tool.annotations?.openWorldHint === true}
-            <span class="hint-pill hint-dest">Open-world</span>
+            <span class="hint-pill hint-warn">Open-world</span>
           {/if}
           <button
             class="tgl tool-tgl {tool.disabled ? 'tgl-off' : ''} {togglingTool === tool.name ? 'opacity-50' : ''}"
@@ -218,10 +218,6 @@
   .hint-read {
     background: var(--hint-read-bg);
     color: var(--hint-read-fg);
-  }
-  .hint-dest {
-    background: var(--hint-dest-bg);
-    color: var(--hint-dest-fg);
   }
   .hint-warn {
     background: var(--hint-warn-bg);

--- a/src/lib/components/UnifiedCatalog.svelte
+++ b/src/lib/components/UnifiedCatalog.svelte
@@ -90,7 +90,7 @@
               <span class="px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400">Read-only</span>
             {/if}
             {#if entry.annotations?.destructiveHint === true}
-              <span class="px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400">Destructive</span>
+              <span class="px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">Makes changes</span>
             {/if}
             {#if entry.annotations?.idempotentHint === true}
               <span class="px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">Idempotent</span>

--- a/src/lib/overlay/HintPill.svelte
+++ b/src/lib/overlay/HintPill.svelte
@@ -1,6 +1,6 @@
 <!--
   Hint pill rendered next to a server name on overlay cards. Tone is driven
-  by the annotation kind (destructive=danger, open-world=warn,
+  by the annotation kind (destructive=warn, open-world=warn,
   read-only/idempotent=muted). Styling lives in `overlay.css`.
 -->
 <script lang="ts">

--- a/src/lib/overlay/OverlayCard.test.ts
+++ b/src/lib/overlay/OverlayCard.test.ts
@@ -138,7 +138,7 @@ describe('OverlayCard — hint pills', () => {
       open_world: true,
       read_only: true,
     });
-    expect(hints.map((h) => h.label)).toEqual(['read-only', 'open-world', 'destructive']);
+    expect(hints.map((h) => h.label)).toEqual(['read-only', 'open-world', 'makes changes']);
   });
 
   it('renders zero pills when annotations is undefined', () => {

--- a/src/lib/overlay/overlay-helpers.test.ts
+++ b/src/lib/overlay/overlay-helpers.test.ts
@@ -83,7 +83,7 @@ describe('hintsForAnnotations', () => {
       'openworld',
       'destructive',
     ]);
-    expect(hints.find((h) => h.kind === 'destructive')?.tone).toBe('danger');
+    expect(hints.find((h) => h.kind === 'destructive')?.tone).toBe('warn');
     expect(hints.find((h) => h.kind === 'openworld')?.tone).toBe('warn');
     expect(hints.find((h) => h.kind === 'readonly')?.tone).toBe('muted');
   });

--- a/src/lib/overlay/overlay-helpers.ts
+++ b/src/lib/overlay/overlay-helpers.ts
@@ -33,7 +33,7 @@ const HINT_TABLE: Record<HintKind, HintMeta> = {
   readonly: { kind: 'readonly', label: 'read-only', tone: 'muted' },
   idempotent: { kind: 'idempotent', label: 'idempotent', tone: 'muted' },
   openworld: { kind: 'openworld', label: 'open-world', tone: 'warn' },
-  destructive: { kind: 'destructive', label: 'destructive', tone: 'danger' },
+  destructive: { kind: 'destructive', label: 'makes changes', tone: 'warn' },
 };
 
 /** Resolve hint pill metadata for an annotations payload. Returns ordered list. */

--- a/src/lib/overlay/overlay.css
+++ b/src/lib/overlay/overlay.css
@@ -11,6 +11,7 @@
   --tf-muted-fg: var(--fg3);
   --tf-warn-bg: rgba(250, 176, 5, 0.14);
   --tf-warn-fg: #8a5d00;
+  --tf-warn-border: rgba(250, 176, 5, 0.35);
   --tf-danger-bg: rgba(250, 82, 82, 0.14);
   --tf-danger-fg: #b42a2a;
   --tf-chip-bg: rgba(0, 0, 0, 0.04);
@@ -27,6 +28,7 @@
   --tf-muted-fg: var(--slate-700);
   --tf-warn-bg: rgba(252, 196, 25, 0.16);
   --tf-warn-fg: #fcd34d;
+  --tf-warn-border: rgba(252, 196, 25, 0.35);
   --tf-danger-bg: rgba(255, 107, 107, 0.18);
   --tf-danger-fg: #ff9b9b;
   --tf-chip-bg: rgba(255, 255, 255, 0.05);
@@ -130,7 +132,7 @@
 .tf-card-front[data-clickable='false'] { cursor: default; }
 .tf-card-front:hover { transform: translateY(-1px); }
 .tf-card-front:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-.tf-card-front[data-destructive='true'] { border-color: rgba(250, 82, 82, 0.35); }
+.tf-card-front[data-destructive='true'] { border-color: var(--tf-warn-border); }
 
 .tf-accent-bar { position: absolute; left: 0; top: 0; bottom: 0; width: 3px; }
 .tf-card-body { padding: 12px 14px; display: flex; flex-direction: column; gap: 6px; }


### PR DESCRIPTION
## Summary

Softens the "Destructive" MCP tool hint pill to **"Makes changes"** with a warn (amber) tone instead of danger (red), across all three surfaces that render tool annotation hints:

- **Tools tab** (`ToolsTab.svelte`): pill text `Destructive` → `Makes changes`, new `.hint-warn` class backed by new `--hint-warn-bg`/`--hint-warn-fg` tokens (light + dark) in `app.css`.
- **Unified catalog** (`UnifiedCatalog.svelte`): red Tailwind pill → amber.
- **Overlay cards** (`overlay-helpers.ts` / `HintPill.svelte` / `overlay.css`): `destructive` hint label `destructive` → `makes changes`, tone `danger` → `warn`; destructive card border now uses a new `--tf-warn-border` token instead of hardcoded red.

## Rationale

`destructiveHint` merely means a tool may modify state — red "Destructive" reads as far more alarming than warranted and made ordinary write-capable tools look dangerous.

## Testing

- Updated `overlay-helpers.test.ts` and `OverlayCard.test.ts` for the new label/tone.
- `npm test`: 1197 passed, 39 skipped.
