### PR TITLE
fix(observability): eliminate ~2s tab-switch stall (bound payload DOM, cap call-list growth)

### DIFF
--- a/src/lib/components/Observability.svelte
+++ b/src/lib/components/Observability.svelte
@@ -48,6 +48,11 @@
   type LoadState = 'loading' | 'ready' | 'unavailable';
 
   const PAGE_SIZE = 100;
+  // Ceiling on rows accumulated by the live-refresh merge, so `calls` doesn't
+  // grow without bound over a long session. Explicit "Load more" pages are
+  // never truncated: the effective cap is max(this, current list length), so
+  // live merges only ever trim back down to what the user deliberately loaded.
+  const LIVE_MAX_ROWS = 1000;
 
   let loadState = $state<LoadState>('loading');
   let errorMessage = $state<string | null>(null);
@@ -293,8 +298,11 @@
         buckets = aggRes.buckets;
         // Live merge: incoming first-page rows win for any UID we already
         // have, but the cursor for "Load more" is anchored to the original
-        // first-page tail — fresh terminal events don't reset it.
-        calls = mergeCalls(calls, callsRes.calls);
+        // first-page tail — fresh terminal events don't reset it. Capped at
+        // max(LIVE_MAX_ROWS, current length) so live events can't grow the
+        // list unboundedly, while rows the user explicitly paged in via
+        // "Load more" are never silently dropped.
+        calls = mergeCalls(calls, callsRes.calls, Math.max(LIVE_MAX_ROWS, calls.length));
       } catch {
         // Transient relay hiccup — keep the current view, next event retries.
       }

--- a/src/lib/components/Observability.svelte
+++ b/src/lib/components/Observability.svelte
@@ -33,6 +33,8 @@
     distinctValues,
     prettyJson,
     parseJsonTree,
+    expandToDepth,
+    INLINE_PAYLOAD_MAX_CHARS,
     type CallsFilterUi,
     type StatusFilter,
   } from './observability-helpers';
@@ -360,31 +362,58 @@
     invoke('unsubscribe_tool_call_events').catch(() => {});
   });
 
-  const reqPretty = $derived(detail?.payloads ? prettyJson(detail.payloads.request) : null);
-  const respPretty = $derived(detail?.payloads ? prettyJson(detail.payloads.response) : null);
+  // Inline (side panel) payload views use the small INLINE_PAYLOAD_MAX_CHARS
+  // budget: the panel stays mounted (display:none) in the keep-alive tab, so
+  // an oversized tree or <pre> would pay full style/layout on every tab
+  // switch. Full-size viewing goes through the pop-out modal below, which is
+  // unmounted when closed.
+  const reqPretty = $derived(
+    detail?.payloads ? prettyJson(detail.payloads.request, INLINE_PAYLOAD_MAX_CHARS) : null,
+  );
+  const respPretty = $derived(
+    detail?.payloads ? prettyJson(detail.payloads.response, INLINE_PAYLOAD_MAX_CHARS) : null,
+  );
   // Prefer the collapsible JSON tree when the payload parses as a JSON
   // object/array within the size guard; otherwise fall back to the raw <pre>.
-  const reqTree = $derived(detail?.payloads ? parseJsonTree(detail.payloads.request) : { ok: false } as const);
-  const respTree = $derived(detail?.payloads ? parseJsonTree(detail.payloads.response) : { ok: false } as const);
+  const reqTree = $derived(
+    detail?.payloads
+      ? parseJsonTree(detail.payloads.request, INLINE_PAYLOAD_MAX_CHARS)
+      : { ok: false } as const,
+  );
+  const respTree = $derived(
+    detail?.payloads
+      ? parseJsonTree(detail.payloads.response, INLINE_PAYLOAD_MAX_CHARS)
+      : { ok: false } as const,
+  );
+
+  // Bound the JSON trees' initial expansion to root + one level (deeper nodes
+  // expand on click). The library defaults to `allExpanded`, which mounts tens
+  // of thousands of DOM nodes for a large payload — the direct cause of the
+  // multi-second tab-switch stalls this budget exists to prevent.
+  const payloadExpandDepth = expandToDepth(2);
 
   // Parameterize the single pop-out modal by which side is open. Falls back to
   // the response values when nothing is expanded (the modal block is guarded so
   // these are never read in that case).
   const expandedLabel = $derived(expandedPayload === 'request' ? 'Request' : 'Response');
-  const expandedTree = $derived(expandedPayload === 'request' ? reqTree : respTree);
-  const expandedPretty = $derived(expandedPayload === 'request' ? reqPretty : respPretty);
   const expandedTruncated = $derived(
     expandedPayload === 'request'
       ? detail?.payloads?.request_truncated
       : detail?.payloads?.response_truncated,
   );
-  // Raw source for whichever payload the modal currently shows, used by the
-  // modal's copy button so the clipboard receives the complete JSON.
+  // Raw source for whichever payload the modal currently shows: feeds the
+  // modal's own full-size parse below and its copy button (so the clipboard
+  // receives the complete JSON).
   const expandedRaw = $derived(
     expandedPayload === 'request'
       ? (detail?.payloads?.request ?? '')
       : (detail?.payloads?.response ?? ''),
   );
+  // The modal parses at the full default (200k) caps, independent of the small
+  // inline budget. It is unmounted when closed, so this cost is only paid
+  // while the pop-out is open.
+  const expandedTree = $derived(expandedPayload ? parseJsonTree(expandedRaw) : { ok: false } as const);
+  const expandedPretty = $derived(expandedPayload ? prettyJson(expandedRaw) : null);
 
   // Expiry notice text: reflect the configured payload window when known,
   // otherwise a neutral wording that doesn't assert a specific number.
@@ -769,10 +798,10 @@
                   </div>
                   {#if reqTree.ok}
                     <div class="json-tree max-h-64 overflow-auto rounded border border-(--border) bg-(--surface-sunken) p-2 text-[11px]">
-                      <JsonView data={reqTree.value} style={defaultStyles} />
+                      <JsonView data={reqTree.value} style={defaultStyles} shouldExpandNode={payloadExpandDepth} />
                     </div>
                   {:else}
-                    <pre class="max-h-64 overflow-auto rounded border border-(--border) bg-(--surface-sunken) p-2 font-mono text-[11px] whitespace-pre-wrap break-words text-(--fg1)">{reqPretty?.text}{reqPretty?.truncated ? '\n… (display truncated)' : ''}</pre>
+                    <pre class="max-h-64 overflow-auto rounded border border-(--border) bg-(--surface-sunken) p-2 font-mono text-[11px] whitespace-pre-wrap break-words text-(--fg1)">{reqPretty?.text}{reqPretty?.truncated ? '\n… (display truncated — expand for the full payload)' : ''}</pre>
                   {/if}
                 </div>
                 <div>
@@ -852,10 +881,10 @@
                   </div>
                   {#if respTree.ok}
                     <div class="json-tree max-h-64 overflow-auto rounded border border-(--border) bg-(--surface-sunken) p-2 text-[11px]">
-                      <JsonView data={respTree.value} style={defaultStyles} />
+                      <JsonView data={respTree.value} style={defaultStyles} shouldExpandNode={payloadExpandDepth} />
                     </div>
                   {:else}
-                    <pre class="max-h-64 overflow-auto rounded border border-(--border) bg-(--surface-sunken) p-2 font-mono text-[11px] whitespace-pre-wrap break-words text-(--fg1)">{respPretty?.text}{respPretty?.truncated ? '\n… (display truncated)' : ''}</pre>
+                    <pre class="max-h-64 overflow-auto rounded border border-(--border) bg-(--surface-sunken) p-2 font-mono text-[11px] whitespace-pre-wrap break-words text-(--fg1)">{respPretty?.text}{respPretty?.truncated ? '\n… (display truncated — expand for the full payload)' : ''}</pre>
                   {/if}
                 </div>
               {/if}
@@ -960,7 +989,7 @@
       <div class="min-h-0 flex-1 overflow-auto p-4">
         {#if expandedTree.ok}
           <div class="json-tree text-[12px]">
-            <JsonView data={expandedTree.value} style={defaultStyles} />
+            <JsonView data={expandedTree.value} style={defaultStyles} shouldExpandNode={payloadExpandDepth} />
           </div>
         {:else}
           <pre class="font-mono text-[12px] whitespace-pre-wrap break-words text-(--fg1)">{expandedPretty?.text}{expandedPretty?.truncated ? '\n… (display truncated)' : ''}</pre>

--- a/src/lib/components/observability-helpers.test.ts
+++ b/src/lib/components/observability-helpers.test.ts
@@ -18,6 +18,8 @@ import {
   distinctValues,
   prettyJson,
   parseJsonTree,
+  expandToDepth,
+  INLINE_PAYLOAD_MAX_CHARS,
   type CallsFilterUi,
 } from './observability-helpers';
 
@@ -334,5 +336,43 @@ describe('parseJsonTree', () => {
     expect(parseJsonTree('42')).toEqual({ ok: false });
     expect(parseJsonTree('"a string"')).toEqual({ ok: false });
     expect(parseJsonTree('{"a":1}', 3)).toEqual({ ok: false });
+  });
+});
+
+describe('inline payload budget', () => {
+  it('is far below the default 200k caps', () => {
+    expect(INLINE_PAYLOAD_MAX_CHARS).toBe(20_000);
+    expect(INLINE_PAYLOAD_MAX_CHARS).toBeLessThan(200_000);
+  });
+
+  it('parseJsonTree rejects payloads over the inline budget but accepts them at the default cap', () => {
+    const mid = JSON.stringify({ a: 'x'.repeat(INLINE_PAYLOAD_MAX_CHARS) });
+    expect(parseJsonTree(mid, INLINE_PAYLOAD_MAX_CHARS)).toEqual({ ok: false });
+    expect(parseJsonTree(mid).ok).toBe(true);
+  });
+
+  it('prettyJson truncates the inline view to the inline budget', () => {
+    const mid = JSON.stringify({ a: 'x'.repeat(INLINE_PAYLOAD_MAX_CHARS) });
+    const out = prettyJson(mid, INLINE_PAYLOAD_MAX_CHARS);
+    expect(out.truncated).toBe(true);
+    expect(out.text.length).toBeLessThanOrEqual(INLINE_PAYLOAD_MAX_CHARS);
+    expect(prettyJson(mid).truncated).toBe(false);
+  });
+});
+
+describe('expandToDepth', () => {
+  it('expands only levels below the given depth (root = level 0)', () => {
+    const depth2 = expandToDepth(2);
+    expect(depth2(0)).toBe(true);
+    expect(depth2(1)).toBe(true);
+    expect(depth2(2)).toBe(false);
+    expect(depth2(3)).toBe(false);
+  });
+
+  it('depth 0 collapses everything; depth 1 matches collapseAllNested semantics', () => {
+    expect(expandToDepth(0)(0)).toBe(false);
+    const depth1 = expandToDepth(1);
+    expect(depth1(0)).toBe(true);
+    expect(depth1(1)).toBe(false);
   });
 });

--- a/src/lib/components/observability-helpers.test.ts
+++ b/src/lib/components/observability-helpers.test.ts
@@ -237,6 +237,54 @@ describe('live event merging', () => {
     expect(merged[1].tool).toBe('new');
   });
 
+  it('mergeCalls without a cap keeps all rows', () => {
+    const existing = [call({ requestUid: 'a', tsStart: 1000 })];
+    const incoming = [call({ requestUid: 'b', tsStart: 2000 })];
+    expect(mergeCalls(existing, incoming)).toHaveLength(2);
+  });
+
+  it('mergeCalls caps to the newest maxRows rows', () => {
+    const existing = [
+      call({ requestUid: 'a', tsStart: 1000 }),
+      call({ requestUid: 'b', tsStart: 2000 }),
+    ];
+    const incoming = [
+      call({ requestUid: 'c', tsStart: 4000 }),
+      call({ requestUid: 'd', tsStart: 3000 }),
+    ];
+    const merged = mergeCalls(existing, incoming, 3);
+    expect(merged.map((c) => c.requestUid)).toEqual(['c', 'd', 'b']);
+  });
+
+  it('mergeCalls cap still lets incoming rows refresh surviving UIDs', () => {
+    const existing = [
+      call({ requestUid: 'a', tsStart: 1000 }),
+      call({ requestUid: 'b', tsStart: 2000, tool: 'old' }),
+    ];
+    const incoming = [
+      call({ requestUid: 'b', tsStart: 2000, tool: 'new' }),
+      call({ requestUid: 'c', tsStart: 3000 }),
+    ];
+    const merged = mergeCalls(existing, incoming, 2);
+    expect(merged.map((c) => c.requestUid)).toEqual(['c', 'b']);
+    expect(merged[1].tool).toBe('new');
+  });
+
+  it('mergeCalls ignores non-positive or non-finite caps', () => {
+    const existing = [call({ requestUid: 'a', tsStart: 1000 })];
+    const incoming = [call({ requestUid: 'b', tsStart: 2000 })];
+    expect(mergeCalls(existing, incoming, 0)).toHaveLength(2);
+    expect(mergeCalls(existing, incoming, -5)).toHaveLength(2);
+    expect(mergeCalls(existing, incoming, NaN)).toHaveLength(2);
+    expect(mergeCalls(existing, incoming, Infinity)).toHaveLength(2);
+  });
+
+  it('mergeCalls cap at exactly the merged length keeps everything', () => {
+    const existing = [call({ requestUid: 'a', tsStart: 1000 })];
+    const incoming = [call({ requestUid: 'b', tsStart: 2000 })];
+    expect(mergeCalls(existing, incoming, 2)).toHaveLength(2);
+  });
+
   it('distinctValues returns sorted unique field values', () => {
     const calls = [call({ serverName: 'b' }), call({ serverName: 'a' }), call({ serverName: 'a' })];
     expect(distinctValues(calls, 'serverName')).toEqual(['a', 'b']);

--- a/src/lib/components/observability-helpers.ts
+++ b/src/lib/components/observability-helpers.ts
@@ -185,16 +185,24 @@ export function isTerminalEvent(event: ToolCallEvent | unknown): boolean {
 
 /**
  * Merge two call lists, dedupe by `requestUid` (incoming wins so a refetch
- * refreshes existing rows), and sort newest-first by `tsStart`.
+ * refreshes existing rows), and sort newest-first by `tsStart`. An optional
+ * `maxRows` cap bounds the result: when the merged list exceeds it, only the
+ * newest `maxRows` rows are kept (the tail — the oldest rows — is dropped).
+ * Non-positive/non-finite caps are ignored.
  */
 export function mergeCalls(
   existing: readonly CallSummaryDto[],
   incoming: readonly CallSummaryDto[],
+  maxRows?: number,
 ): CallSummaryDto[] {
   const byUid = new Map<string, CallSummaryDto>();
   for (const c of existing) byUid.set(c.requestUid, c);
   for (const c of incoming) byUid.set(c.requestUid, c);
-  return [...byUid.values()].sort((a, b) => b.tsStart - a.tsStart);
+  const merged = [...byUid.values()].sort((a, b) => b.tsStart - a.tsStart);
+  if (maxRows !== undefined && Number.isFinite(maxRows) && maxRows > 0 && merged.length > maxRows) {
+    return merged.slice(0, maxRows);
+  }
+  return merged;
 }
 
 /** Distinct, sorted values of one field across a call list (for filter menus). */

--- a/src/lib/components/observability-helpers.ts
+++ b/src/lib/components/observability-helpers.ts
@@ -242,6 +242,26 @@ export function parseJsonTree(
 }
 
 /**
+ * Character budget for the INLINE (side-panel) payload views. Deliberately far
+ * below the 200k default caps used by the pop-out modal: the drill-through
+ * panel stays mounted (display:none) in the keep-alive tab, so every tab
+ * switch pays style/layout for whatever DOM it holds. 20k keeps that cost
+ * negligible; the expand pop-out (unmounted when closed) renders up to the
+ * full default caps on demand.
+ */
+export const INLINE_PAYLOAD_MAX_CHARS = 20_000;
+
+/**
+ * `shouldExpandNode` strategy for the payload JSON trees: auto-expand only the
+ * first `maxDepth` levels (root = level 0). Bounds the initially-rendered DOM
+ * so a large payload doesn't mount tens of thousands of nodes up front —
+ * deeper levels still expand on click.
+ */
+export function expandToDepth(maxDepth: number): (level: number) => boolean {
+  return (level: number) => level < maxDepth;
+}
+
+/**
  * Absolute ceiling on the input size we are willing to `JSON.parse` +
  * re-stringify. Past this, even an effectively-unlimited `maxChars` (the copy
  * path passes `Number.MAX_SAFE_INTEGER`) must not parse, or the multi-megabyte


### PR DESCRIPTION
## Problem

Switching into or out of the Observability tab stalled the main thread for ~2s. Top-level tabs are kept alive with display:none, so every switch pays a full style/layout pass over the hidden tab's DOM. Two unbounded DOM/memory sources made that cost explode:

1. The drill-through panel's JSON payload views used the library default shouldExpandNode = allExpanded, so a payload near the 200k-char cap rendered as a fully expanded tree (tens of thousands of DOM nodes) that stayed mounted in the hidden tab.
2. Live refresh merged every new page into the in-memory calls array without a cap, so the call table could grow unboundedly over a long session.

## Changes

- fix(observability): bound drill-through payload DOM (3b5660f)
  - Inline (side-panel) payload views now use a 20k-char budget (INLINE_PAYLOAD_MAX_CHARS) instead of 200k.
  - All JSON trees use shouldExpandNode = expandToDepth(2) instead of fully expanded; deeper levels expand on click.
  - The pop-out modal keeps the full 200k caps, derives its own trees, and is unmounted when closed.
  - Copy buttons (inline and modal) still copy the FULL pretty-printed payload.
- fix(observability): cap in-memory call list growth from live refresh (eac05dc)
  - mergeCalls takes an optional maxRows cap (keeps newest by tsStart; invalid caps ignored).
  - Live refresh merges with max(LIVE_MAX_ROWS=1000, current length), so explicit Load-more pages are never truncated; nextCursor semantics unchanged.

## Verification

- npm test: 1207 passed, 39 skipped (includes new unit tests for the inline budget, expandToDepth semantics, and mergeCalls cap edge cases).
- npm run check (svelte-check): 0 errors, 0 warnings.
- Independent verifier agent reviewed both commits against the task definitions and approved.
