### PR TITLE
feat(ui): virtualize the Observability call list

### DIFF
--- a/src/lib/components/Observability.svelte
+++ b/src/lib/components/Observability.svelte
@@ -631,8 +631,13 @@
             aria-rowcount={calls.length + 1}
             class="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-(--border) text-[12px]"
           >
-            <div role="rowgroup" class="shrink-0">
-              <div role="row" class="{callListGrid} bg-(--hd-bg) text-(--fg2)">
+            <!-- scrollbar-gutter:stable on both the header container and the
+                 scroller keeps the two grids the same width when a classic
+                 (non-overlay) scrollbar is visible. The header container needs
+                 scrollable overflow for the gutter to be reserved; it never
+                 actually scrolls (single row, shrink-0). -->
+            <div role="rowgroup" class="shrink-0 overflow-y-auto [scrollbar-gutter:stable]">
+              <div role="row" aria-rowindex={1} class="{callListGrid} bg-(--hd-bg) text-(--fg2)">
                 <div role="columnheader" class="px-2 py-1.5 text-left font-medium">Time</div>
                 <div role="columnheader" class="px-2 py-1.5 text-left font-medium">Server</div>
                 <div role="columnheader" class="px-2 py-1.5 text-left font-medium">Tool</div>
@@ -645,7 +650,8 @@
               items={calls}
               getKey={(c) => c.requestUid}
               followTail={false}
-              class="min-h-0 flex-1"
+              role="rowgroup"
+              class="min-h-0 flex-1 [scrollbar-gutter:stable]"
             >
               {#snippet row(c, index)}
                 {@const st = callStatus(c)}
@@ -657,7 +663,7 @@
                   tabindex="0"
                   aria-rowindex={index + 2}
                   data-request-uid={c.requestUid}
-                  class="{callListGrid} cursor-pointer border-t border-(--border) hover:bg-(--surface-hover) {selectedUid === c.requestUid ? 'bg-(--accent-tint)' : ''}"
+                  class="{callListGrid} cursor-pointer border-t border-(--border) hover:bg-(--surface-hover) focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-(--accent) {selectedUid === c.requestUid ? 'bg-(--accent-tint)' : ''}"
                   onclick={() => openDetail(c.requestUid)}
                   onkeydown={(e) => {
                     if (e.key === 'Enter' || e.key === ' ') {

--- a/src/lib/components/Observability.svelte
+++ b/src/lib/components/Observability.svelte
@@ -647,11 +647,15 @@
               followTail={false}
               class="min-h-0 flex-1"
             >
-              {#snippet row(c, _index)}
+              {#snippet row(c, index)}
                 {@const st = callStatus(c)}
+                <!-- aria-rowindex is 1-based over the whole table: the header
+                     row is rowindex 1, so data row i is i + 2 (matches the
+                     aria-rowcount of calls.length + 1 above). -->
                 <div
                   role="row"
                   tabindex="0"
+                  aria-rowindex={index + 2}
                   data-request-uid={c.requestUid}
                   class="{callListGrid} cursor-pointer border-t border-(--border) hover:bg-(--surface-hover) {selectedUid === c.requestUid ? 'bg-(--accent-tint)' : ''}"
                   onclick={() => openDetail(c.requestUid)}

--- a/src/lib/components/Observability.svelte
+++ b/src/lib/components/Observability.svelte
@@ -37,6 +37,7 @@
     type StatusFilter,
   } from './observability-helpers';
   import Sparkline from './Sparkline.svelte';
+  import VirtualLogList from './VirtualLogList.svelte';
   import { JsonView, defaultStyles } from '@humanspeak/svelte-json-view-lite';
   import { focusTrap } from '$lib/actions/focusTrap';
 
@@ -101,6 +102,13 @@
 
   const globalSeries = $derived(globalBuckets(buckets));
   const serverOptions = $derived(distinctValues(calls, 'serverName'));
+
+  // Shared column template for the virtualized call list. Header + rows are
+  // separate CSS grids (absolutely-positioned virtual rows can't live in a
+  // <tbody>), so they align by using the exact same template. Widths mirror
+  // the old table: Time w-20, Server w-28, Tool flexible, Status w-24,
+  // Duration w-20, Bytes w-28.
+  const callListGrid = 'grid grid-cols-[5rem_7rem_minmax(0,1fr)_6rem_5rem_7rem]';
 
   async function loadAggregates() {
     const since = windowMinutes > 0 ? Date.now() - windowMinutes * 60_000 : undefined;
@@ -226,7 +234,7 @@
     await openDetail(requestUid);
     await tick();
     document
-      .querySelector(`tr[data-request-uid="${CSS.escape(requestUid)}"]`)
+      .querySelector(`[data-request-uid="${CSS.escape(requestUid)}"]`)
       ?.scrollIntoView({ block: 'center' });
   }
 
@@ -577,42 +585,61 @@
             <p class="text-[13px] text-(--fg3)">No calls match the current filters.</p>
           </div>
         {:else}
-          <div class="min-h-0 flex-1 overflow-y-auto rounded-lg border border-(--border)">
-            <table class="w-full table-fixed text-[12px]">
-              <thead class="sticky top-0 z-10 bg-(--hd-bg) text-(--fg2)">
-                <tr>
-                  <th class="w-20 px-2 py-1.5 text-left font-medium">Time</th>
-                  <th class="w-28 px-2 py-1.5 text-left font-medium">Server</th>
-                  <th class="px-2 py-1.5 text-left font-medium">Tool</th>
-                  <th class="w-24 px-2 py-1.5 text-left font-medium">Status</th>
-                  <th class="w-20 px-2 py-1.5 text-right font-medium">Duration</th>
-                  <th class="w-28 px-2 py-1.5 text-right font-medium">Bytes (in/out)</th>
-                </tr>
-              </thead>
-              <tbody>
-                {#each calls as c (c.requestUid)}
-                  {@const st = callStatus(c)}
-                  <tr
-                    data-request-uid={c.requestUid}
-                    class="cursor-pointer border-t border-(--border) hover:bg-(--surface-hover) {selectedUid === c.requestUid ? 'bg-(--accent-tint)' : ''}"
-                    onclick={() => openDetail(c.requestUid)}
-                  >
-                    <td class="px-2 py-1.5 text-(--fg2)">{formatTime(c.tsStart)}</td>
-                    <td class="truncate px-2 py-1.5 text-(--fg1)" title={c.serverName}>{c.serverName}</td>
-                    <td class="truncate px-2 py-1.5 font-mono text-(--fg1)" title={c.tool}>{c.tool}</td>
-                    <td class="px-2 py-1.5">
-                      <span
-                        class="block max-w-full truncate {st.ok ? 'text-(--healthy)' : 'text-(--offline)'}"
-                        title={c.errorMessage ?? st.label}>{st.label}</span>
-                    </td>
-                    <td class="px-2 py-1.5 text-right text-(--fg2)">{formatDuration(c.durationMs)}</td>
-                    <td class="px-2 py-1.5 text-right text-(--fg3)">
-                      {formatBytes(c.requestBytes)} / {formatBytes(c.responseBytes)}
-                    </td>
-                  </tr>
-                {/each}
-              </tbody>
-            </table>
+          <!-- Virtualized rows (top-anchored): only the visible window
+               (+ overscan) is mounted. The header row lives OUTSIDE the
+               scrolling container so it stays fixed above the rows. -->
+          <div
+            role="table"
+            aria-label="Proxied tool calls"
+            aria-rowcount={calls.length + 1}
+            class="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-(--border) text-[12px]"
+          >
+            <div role="rowgroup" class="shrink-0">
+              <div role="row" class="{callListGrid} bg-(--hd-bg) text-(--fg2)">
+                <div role="columnheader" class="px-2 py-1.5 text-left font-medium">Time</div>
+                <div role="columnheader" class="px-2 py-1.5 text-left font-medium">Server</div>
+                <div role="columnheader" class="px-2 py-1.5 text-left font-medium">Tool</div>
+                <div role="columnheader" class="px-2 py-1.5 text-left font-medium">Status</div>
+                <div role="columnheader" class="px-2 py-1.5 text-right font-medium">Duration</div>
+                <div role="columnheader" class="px-2 py-1.5 text-right font-medium">Bytes (in/out)</div>
+              </div>
+            </div>
+            <VirtualLogList
+              items={calls}
+              getKey={(c) => c.requestUid}
+              followTail={false}
+              class="min-h-0 flex-1"
+            >
+              {#snippet row(c, _index)}
+                {@const st = callStatus(c)}
+                <div
+                  role="row"
+                  tabindex="0"
+                  data-request-uid={c.requestUid}
+                  class="{callListGrid} cursor-pointer border-t border-(--border) hover:bg-(--surface-hover) {selectedUid === c.requestUid ? 'bg-(--accent-tint)' : ''}"
+                  onclick={() => openDetail(c.requestUid)}
+                  onkeydown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      openDetail(c.requestUid);
+                    }
+                  }}
+                >
+                  <div role="cell" class="truncate px-2 py-1.5 text-(--fg2)">{formatTime(c.tsStart)}</div>
+                  <div role="cell" class="truncate px-2 py-1.5 text-(--fg1)" title={c.serverName}>{c.serverName}</div>
+                  <div role="cell" class="truncate px-2 py-1.5 font-mono text-(--fg1)" title={c.tool}>{c.tool}</div>
+                  <div role="cell" class="px-2 py-1.5">
+                    <span
+                      class="block max-w-full truncate {st.ok ? 'text-(--healthy)' : 'text-(--offline)'}"
+                      title={c.errorMessage ?? st.label}>{st.label}</span>
+                  </div>
+                  <div role="cell" class="px-2 py-1.5 text-right text-(--fg2)">{formatDuration(c.durationMs)}</div>
+                  <div role="cell" class="truncate px-2 py-1.5 text-right text-(--fg3)">
+                    {formatBytes(c.requestBytes)} / {formatBytes(c.responseBytes)}
+                  </div>
+                </div>
+              {/snippet}
+            </VirtualLogList>
           </div>
           {#if nextCursor}
             <div class="mt-2 flex justify-center">

--- a/src/lib/components/VirtualLogList.svelte
+++ b/src/lib/components/VirtualLogList.svelte
@@ -85,12 +85,11 @@
   // notifies on flips.
   let reportedInitialPinned = false;
   $effect(() => {
+    // followTail is read tracked (like scrollEl) so toggling the prop after
+    // mount re-evaluates the effect; pinned stays untracked.
+    const follow = followTail;
     if (
-      !shouldReportInitialPinned(
-        scrollEl !== undefined,
-        reportedInitialPinned,
-        untrack(() => followTail),
-      )
+      !shouldReportInitialPinned(scrollEl !== undefined, reportedInitialPinned, follow)
     )
       return;
     reportedInitialPinned = true;
@@ -104,12 +103,15 @@
   $effect(() => {
     const count = items.length;
     const store = virtualizer;
+    // followTail is read tracked so flipping the prop re-runs tail-follow;
+    // pinned stays untracked (scroll flips must not retrigger this effect).
+    const follow = followTail;
     if (
       !shouldStickToBottom(
         untrack(() => pinned),
         count,
         scrollEl?.clientHeight ?? 0,
-        untrack(() => followTail),
+        follow,
       )
     )
       return;

--- a/src/lib/components/VirtualLogList.svelte
+++ b/src/lib/components/VirtualLogList.svelte
@@ -9,6 +9,7 @@
     becameVisible,
     isPinnedToBottom,
     itemKeyAt,
+    shouldRepinOnUnhide,
     shouldReportInitialPinned,
     shouldStickToBottom,
   } from './virtual-log-list-helpers';
@@ -29,6 +30,12 @@
     row: Snippet<[T, number]>;
     /** Called when the pinned-to-bottom state flips (isAtBottom semantics). */
     onscrollstate?: (pinned: boolean) => void;
+    /**
+     * Tail-pinned log semantics (default). When false the list is a plain
+     * top-anchored virtualized list: no tail-follow on item changes, no
+     * re-pin on unhide, no initial pinned report.
+     */
+    followTail?: boolean;
     /** Extra classes for the scroll container (sizing, colors, ...). */
     class?: string;
   };
@@ -39,6 +46,7 @@
     overscan = DEFAULT_OVERSCAN,
     row,
     onscrollstate,
+    followTail = true,
     class: className = '',
   }: Props = $props();
 
@@ -77,7 +85,14 @@
   // notifies on flips.
   let reportedInitialPinned = false;
   $effect(() => {
-    if (!shouldReportInitialPinned(scrollEl !== undefined, reportedInitialPinned)) return;
+    if (
+      !shouldReportInitialPinned(
+        scrollEl !== undefined,
+        reportedInitialPinned,
+        untrack(() => followTail),
+      )
+    )
+      return;
     reportedInitialPinned = true;
     onscrollstate?.(untrack(() => pinned));
   });
@@ -89,7 +104,15 @@
   $effect(() => {
     const count = items.length;
     const store = virtualizer;
-    if (!shouldStickToBottom(untrack(() => pinned), count, scrollEl?.clientHeight ?? 0)) return;
+    if (
+      !shouldStickToBottom(
+        untrack(() => pinned),
+        count,
+        scrollEl?.clientHeight ?? 0,
+        untrack(() => followTail),
+      )
+    )
+      return;
     tick().then(() => {
       if (!pinned) return;
       const inst = get(store);
@@ -129,7 +152,7 @@
       prevHeight = nextHeight;
       if (!shown) return;
       get(store).measure();
-      if (pinned) {
+      if (shouldRepinOnUnhide(pinned, followTail)) {
         tick().then(() => {
           const inst = get(store);
           inst.scrollToOffset(inst.getTotalSize(), { align: 'end' });

--- a/src/lib/components/VirtualLogList.svelte
+++ b/src/lib/components/VirtualLogList.svelte
@@ -36,6 +36,13 @@
      * re-pin on unhide, no initial pinned report.
      */
     followTail?: boolean;
+    /**
+     * ARIA role for the scroll container (e.g. "rowgroup" when the rows are
+     * ARIA table rows). The internal spacer/positioner divs are marked
+     * role="presentation" so the owned-element chain (table → rowgroup →
+     * row) stays intact for assistive tech.
+     */
+    role?: string;
     /** Extra classes for the scroll container (sizing, colors, ...). */
     class?: string;
   };
@@ -47,6 +54,7 @@
     row,
     onscrollstate,
     followTail = true,
+    role = undefined,
     class: className = '',
   }: Props = $props();
 
@@ -193,13 +201,14 @@
   }
 </script>
 
-<div bind:this={scrollEl} onscroll={handleScroll} class="overflow-y-auto {className}">
-  <div class="relative w-full" style:height="{$virtualizer.getTotalSize()}px">
+<div bind:this={scrollEl} onscroll={handleScroll} {role} class="overflow-y-auto {className}">
+  <div role="presentation" class="relative w-full" style:height="{$virtualizer.getTotalSize()}px">
     {#each $virtualizer.getVirtualItems() as vItem, i (vItem.key)}
       {@const item = items[vItem.index]}
       <div
         bind:this={rowEls[i]}
         data-index={vItem.index}
+        role="presentation"
         class="absolute top-0 left-0 w-full"
         style:transform="translateY({vItem.start}px)"
       >

--- a/src/lib/components/observability-helpers.test.ts
+++ b/src/lib/components/observability-helpers.test.ts
@@ -377,6 +377,9 @@ describe('virtualized call list window (large "Load more" backlog)', () => {
     expect(mounted).toBe(viewportHeight / DEFAULT_ROW_ESTIMATE_PX + 2 * DEFAULT_OVERSCAN);
   });
 
+  // NOTE: this documents the pure mirror's model, not the component's literal
+  // hidden-tab DOM — the real TanStack virtualizer still mounts ~1 + overscan
+  // rows at clientHeight === 0 (its range math never yields an empty window).
   it('mounts nothing while the tab is hidden (zero-height viewport)', () => {
     const range = computeMountedRange({ ...base, count, scrollOffset: 0, viewportHeight: 0 });
     expect(range).toBeNull();

--- a/src/lib/components/observability-helpers.test.ts
+++ b/src/lib/components/observability-helpers.test.ts
@@ -2,6 +2,11 @@ import { describe, it, expect, vi } from 'vitest';
 
 import type { CallSummaryDto, AggregateBucketDto } from '$lib/types';
 import {
+  DEFAULT_OVERSCAN,
+  DEFAULT_ROW_ESTIMATE_PX,
+  computeMountedRange,
+} from './virtual-log-list-helpers';
+import {
   buildCallsFilter,
   formatDuration,
   formatBytes,
@@ -286,5 +291,44 @@ describe('parseJsonTree', () => {
     expect(parseJsonTree('42')).toEqual({ ok: false });
     expect(parseJsonTree('"a string"')).toEqual({ ok: false });
     expect(parseJsonTree('{"a":1}', 3)).toEqual({ ok: false });
+  });
+});
+
+// The Observability call list renders rows through VirtualLogList in
+// top-anchored mode (followTail: false). The test env is Node (no jsdom), so
+// — per the established pattern (see RelayLogs.test.ts) — the mounted-row
+// assertions run against computeMountedRange, the pure mirror of the
+// virtualizer's windowing math under the list's actual estimate/overscan
+// configuration.
+describe('virtualized call list window (large "Load more" backlog)', () => {
+  const base = { rowHeight: DEFAULT_ROW_ESTIMATE_PX, overscan: DEFAULT_OVERSCAN };
+  const count = 500;
+
+  it('mounts only the top window (+overscan) on first render (top-anchored)', () => {
+    const viewportHeight = 600;
+    const range = computeMountedRange({ ...base, count, scrollOffset: 0, viewportHeight });
+    expect(range!.start).toBe(0);
+    const mounted = range!.end - range!.start + 1;
+    expect(mounted).toBe(viewportHeight / DEFAULT_ROW_ESTIMATE_PX + DEFAULT_OVERSCAN);
+    expect(mounted).toBeLessThan(count / 10);
+  });
+
+  it('keeps the mounted subset windowed while scrolled mid-list', () => {
+    const viewportHeight = 600;
+    const range = computeMountedRange({
+      ...base,
+      count,
+      scrollOffset: (count / 2) * DEFAULT_ROW_ESTIMATE_PX,
+      viewportHeight,
+    });
+    expect(range!.start).toBeGreaterThan(0);
+    expect(range!.end).toBeLessThan(count - 1);
+    const mounted = range!.end - range!.start + 1;
+    expect(mounted).toBe(viewportHeight / DEFAULT_ROW_ESTIMATE_PX + 2 * DEFAULT_OVERSCAN);
+  });
+
+  it('mounts nothing while the tab is hidden (zero-height viewport)', () => {
+    const range = computeMountedRange({ ...base, count, scrollOffset: 0, viewportHeight: 0 });
+    expect(range).toBeNull();
   });
 });

--- a/src/lib/components/virtual-log-list-helpers.test.ts
+++ b/src/lib/components/virtual-log-list-helpers.test.ts
@@ -6,6 +6,7 @@ import {
   computeMountedRange,
   isPinnedToBottom,
   itemKeyAt,
+  shouldRepinOnUnhide,
   shouldReportInitialPinned,
   shouldStickToBottom,
 } from './virtual-log-list-helpers';
@@ -74,6 +75,15 @@ describe('shouldStickToBottom (bottom-pinned behavior)', () => {
   it('skips the dead scroll work while hidden (0-height viewport)', () => {
     expect(shouldStickToBottom(true, 10, 0)).toBe(false);
   });
+
+  it('defaults to tail-follow mode when followTail is omitted', () => {
+    expect(shouldStickToBottom(true, 10, 400)).toBe(shouldStickToBottom(true, 10, 400, true));
+  });
+
+  it('never follows the tail in top-anchored mode (followTail = false)', () => {
+    expect(shouldStickToBottom(true, 10, 400, false)).toBe(false);
+    expect(shouldStickToBottom(false, 10, 400, false)).toBe(false);
+  });
 });
 
 describe('shouldReportInitialPinned (parent resync after {#if} remounts)', () => {
@@ -87,6 +97,31 @@ describe('shouldReportInitialPinned (parent resync after {#if} remounts)', () =>
 
   it('reports only once per instance', () => {
     expect(shouldReportInitialPinned(true, true)).toBe(false);
+  });
+
+  it('defaults to tail-follow mode when followTail is omitted', () => {
+    expect(shouldReportInitialPinned(true, false)).toBe(shouldReportInitialPinned(true, false, true));
+  });
+
+  it('never reports in top-anchored mode (followTail = false)', () => {
+    expect(shouldReportInitialPinned(true, false, false)).toBe(false);
+  });
+});
+
+describe('shouldRepinOnUnhide (visibility ResizeObserver re-pin)', () => {
+  it('re-pins while pinned in tail-follow mode', () => {
+    expect(shouldRepinOnUnhide(true)).toBe(true);
+    expect(shouldRepinOnUnhide(true, true)).toBe(true);
+  });
+
+  it('does not re-pin when the user scrolled away', () => {
+    expect(shouldRepinOnUnhide(false)).toBe(false);
+    expect(shouldRepinOnUnhide(false, true)).toBe(false);
+  });
+
+  it('never re-pins in top-anchored mode (followTail = false)', () => {
+    expect(shouldRepinOnUnhide(true, false)).toBe(false);
+    expect(shouldRepinOnUnhide(false, false)).toBe(false);
   });
 });
 

--- a/src/lib/components/virtual-log-list-helpers.ts
+++ b/src/lib/components/virtual-log-list-helpers.ts
@@ -50,18 +50,19 @@ export function isPinnedToBottom(
 
 /**
  * Whether the list should follow the tail after `items` changed (append,
- * wholesale replace). Only when the user is pinned and there is something to
- * scroll to — a Clear (count 0) has nothing to follow — and the viewport has
- * a real height: under a `display:none` ancestor `clientHeight` is 0 and any
- * scroll work is a dead no-op (the visibility ResizeObserver re-pins on
- * unhide instead).
+ * wholesale replace). Only in tail-follow mode (`followTail`), when the user
+ * is pinned and there is something to scroll to — a Clear (count 0) has
+ * nothing to follow — and the viewport has a real height: under a
+ * `display:none` ancestor `clientHeight` is 0 and any scroll work is a dead
+ * no-op (the visibility ResizeObserver re-pins on unhide instead).
  */
 export function shouldStickToBottom(
   pinned: boolean,
   count: number,
   viewportHeight: number,
+  followTail = true,
 ): boolean {
-  return pinned && count > 0 && viewportHeight > 0;
+  return followTail && pinned && count > 0 && viewportHeight > 0;
 }
 
 /**
@@ -69,13 +70,24 @@ export function shouldStickToBottom(
  * parent. `handleScroll` only notifies on flips, so after an `{#if}` remount
  * a fresh list (pinned = true) would leave a parent holding a stale value
  * (e.g. a stuck "Go to end" button). Report once, as soon as the scroll
- * element is bound.
+ * element is bound. Top-anchored mode (`followTail = false`) has no
+ * tail-pinned contract to resync, so it never reports.
  */
 export function shouldReportInitialPinned(
   hasScrollEl: boolean,
   alreadyReported: boolean,
+  followTail = true,
 ): boolean {
-  return hasScrollEl && !alreadyReported;
+  return followTail && hasScrollEl && !alreadyReported;
+}
+
+/**
+ * Whether the visibility ResizeObserver should re-pin to the bottom after
+ * the list becomes visible again (0 → non-zero viewport height). Only in
+ * tail-follow mode and while the user is still pinned.
+ */
+export function shouldRepinOnUnhide(pinned: boolean, followTail = true): boolean {
+  return followTail && pinned;
 }
 
 /**


### PR DESCRIPTION
## Summary

The Observability tab rendered every loaded call as a plain table row; pagination (Load more) plus live merges grow the DOM without bound (6k+ mounted rows observed). This PR renders the call list through the shared VirtualLogList so only the visible window (+ overscan) of rows is mounted.

## Changes

- VirtualLogList: new followTail prop. Default true preserves the exact tail-pinned log semantics (LogsTab / RelayLogs unchanged, no props passed). followTail=false yields a top-anchored list: no tail-follow on item changes, no re-pin on unhide, no initial pinned report. Branching lives in the pure helpers (shouldStickToBottom, shouldReportInitialPinned, new shouldRepinOnUnhide) with unit tests for both modes.
- Observability: the table becomes an accessible CSS-grid layout (role=table/rowgroup/row/columnheader/cell, aria-rowcount) because absolutely-positioned virtual rows cannot live in tbody. The header is fixed outside the scroll container; column template 5rem/7rem/minmax(0,1fr)/6rem/5rem/7rem matches the old widths and alignment. Rows keyed by requestUid.
- Preserved behavior: row click opens the drill-through, selected highlight, hover, status tooltip, Load more + calls-shown footer, empty state, data-request-uid attribute and focusCall selector, and live merges cannot reset scroll position.

## Testing

- cd packages/desktop and run: pnpm test — 1207 passed (incl. 7 new helper-mode tests and 3 new computeMountedRange windowing tests asserting only a bounded subset mounts for a 500-row list)
- pnpm check — 0 errors (one pre-existing tsconfig warning)
- Manual DOM smoke not run (Tauri app not runnable headless); covered by the pure-helper windowing tests