### PR TITLE
fix(ui): re-anchor scroll on live prepends in top-anchored virtual lists

### DIFF
--- a/src/lib/components/VirtualLogList.svelte
+++ b/src/lib/components/VirtualLogList.svelte
@@ -98,7 +98,9 @@
   // and scrollTop 0 capture nothing (see captureScrollAnchor).
   let pendingAnchor: ScrollAnchor | null = null;
   $effect.pre(() => {
-    void items.length;
+    // Track the items reference: consumers replace the array on change (see
+    // the Props doc), so this reruns on every merge, prepend, or eviction.
+    void items;
     const follow = followTail;
     const el = scrollEl;
     if (!el) {
@@ -124,7 +126,8 @@
   // the row vanished (evicted by the consumer's live cap) or nothing moved
   // (append-only merge), this is a no-op.
   $effect(() => {
-    void items.length;
+    // Track the items reference (same replacement contract as the capture).
+    void items;
     const store = virtualizer;
     const anchor = pendingAnchor;
     pendingAnchor = null;

--- a/src/lib/components/VirtualLogList.svelte
+++ b/src/lib/components/VirtualLogList.svelte
@@ -7,11 +7,15 @@
     DEFAULT_OVERSCAN,
     DEFAULT_ROW_ESTIMATE_PX,
     becameVisible,
+    captureScrollAnchor,
+    findIndexByKey,
     isPinnedToBottom,
     itemKeyAt,
+    restoredScrollTop,
     shouldRepinOnUnhide,
     shouldReportInitialPinned,
     shouldStickToBottom,
+    type ScrollAnchor,
   } from './virtual-log-list-helpers';
 
   // Shared virtualized log list built on @tanstack/svelte-virtual. Renders
@@ -79,12 +83,57 @@
     });
   });
 
+  // Top-anchored re-anchor, part 1 (capture): live merges PREPEND rows and
+  // the transform-positioned virtual rows defeat native scroll anchoring, so
+  // content under the cursor would shift down on every merge. Before the new
+  // items render ($effect.pre runs ahead of DOM updates and the count-sync
+  // effect below, so getVirtualItems() still reflects the OLD layout),
+  // remember the first visible row's key + viewport offset. Tail-follow mode
+  // and scrollTop 0 capture nothing (see captureScrollAnchor).
+  let pendingAnchor: ScrollAnchor | null = null;
+  $effect.pre(() => {
+    void items.length;
+    const follow = followTail;
+    const el = scrollEl;
+    if (!el) {
+      pendingAnchor = null;
+      return;
+    }
+    const rows = get(virtualizer)
+      .getVirtualItems()
+      .map((v) => ({ key: String(v.key), start: v.start, end: v.end }));
+    pendingAnchor = captureScrollAnchor(follow, el.scrollTop, rows);
+  });
+
   // Keep options in sync when items grow/shrink/are replaced, without
   // recreating the virtualizer (which would drop its measurement cache).
   $effect(() => {
     const count = items.length;
     const os = overscan;
     get(virtualizer).setOptions({ count, overscan: os });
+  });
+
+  // Top-anchored re-anchor, part 2 (restore): after the merge rendered,
+  // scroll so the captured row sits at the same viewport offset again. If
+  // the row vanished (evicted by the consumer's live cap) or nothing moved
+  // (append-only merge), this is a no-op.
+  $effect(() => {
+    void items.length;
+    const store = virtualizer;
+    const anchor = pendingAnchor;
+    pendingAnchor = null;
+    if (!anchor) return;
+    tick().then(() => {
+      const el = scrollEl;
+      if (!el) return;
+      const inst = get(store);
+      // Refresh the measurement cache before reading row offsets.
+      inst.getVirtualItems();
+      const index = findIndexByKey(items, anchor.key, getKey);
+      const newStart = index === -1 ? null : (inst.measurementsCache[index]?.start ?? null);
+      const target = restoredScrollTop(anchor, newStart, el.scrollTop);
+      if (target !== null) inst.scrollToOffset(target);
+    });
   });
 
   // Report the initial pinned state once the scroll element is bound, so a

--- a/src/lib/components/VirtualLogList.svelte
+++ b/src/lib/components/VirtualLogList.svelte
@@ -24,7 +24,13 @@
   // drive their auto-scroll and "Go to end" affordances.
 
   type Props = {
-    /** Rows to render. Only the windowed subset is mounted. */
+    /**
+     * Rows to render. Only the windowed subset is mounted. Must be REPLACED
+     * (new array) on change, never mutated in place: the effects below track
+     * the prop reference, so an in-place mutation (same array, same length)
+     * is invisible to the count sync, tail-follow, and scroll re-anchoring.
+     * Every consumer already does this (mergeCalls & co. return new arrays).
+     */
     items: readonly T[];
     /** Stable string key per item — wired into the virtualizer's getItemKey. */
     getKey: (item: T, index: number) => string;

--- a/src/lib/components/virtual-log-list-helpers.test.ts
+++ b/src/lib/components/virtual-log-list-helpers.test.ts
@@ -3,9 +3,12 @@ import { describe, it, expect } from 'vitest';
 import {
   DEFAULT_OVERSCAN,
   becameVisible,
+  captureScrollAnchor,
   computeMountedRange,
+  findIndexByKey,
   isPinnedToBottom,
   itemKeyAt,
+  restoredScrollTop,
   shouldRepinOnUnhide,
   shouldReportInitialPinned,
   shouldStickToBottom,
@@ -122,6 +125,81 @@ describe('shouldRepinOnUnhide (visibility ResizeObserver re-pin)', () => {
   it('never re-pins in top-anchored mode (followTail = false)', () => {
     expect(shouldRepinOnUnhide(true, false)).toBe(false);
     expect(shouldRepinOnUnhide(false, false)).toBe(false);
+  });
+});
+
+describe('captureScrollAnchor (top-anchored prepend compensation)', () => {
+  // Three contiguous 30px rows starting at 60px — as produced by
+  // getVirtualItems() for a mid-list scroll position with overscan.
+  const rows = [
+    { key: 'c', start: 60, end: 90 },
+    { key: 'd', start: 90, end: 120 },
+    { key: 'e', start: 120, end: 150 },
+  ];
+
+  it('never captures in tail-follow mode (followTail = true)', () => {
+    expect(captureScrollAnchor(true, 100, rows)).toBeNull();
+  });
+
+  it('never captures when pinned to the top (scrollTop = 0)', () => {
+    expect(captureScrollAnchor(false, 0, rows)).toBeNull();
+  });
+
+  it('never captures with no rendered rows', () => {
+    expect(captureScrollAnchor(false, 100, [])).toBeNull();
+  });
+
+  it('anchors on the first row still visible, skipping rows fully above', () => {
+    // scrollTop 95: row c (end 90) is fully above, d (90–120) straddles.
+    expect(captureScrollAnchor(false, 95, rows)).toEqual({ key: 'd', viewportOffset: -5 });
+  });
+
+  it('captures a zero offset when a row edge aligns with the viewport top', () => {
+    expect(captureScrollAnchor(false, 90, rows)).toEqual({ key: 'd', viewportOffset: 0 });
+  });
+
+  it('falls back to the last row when every row is above the scroll position', () => {
+    expect(captureScrollAnchor(false, 500, rows)).toEqual({ key: 'e', viewportOffset: -380 });
+  });
+});
+
+describe('findIndexByKey (anchor relocation after a merge)', () => {
+  const getKey = (item: { uid: string }) => item.uid;
+
+  it('finds the shifted index after a prepend', () => {
+    const merged = [{ uid: 'new-1' }, { uid: 'new-2' }, { uid: 'a' }, { uid: 'b' }];
+    expect(findIndexByKey(merged, 'a', getKey)).toBe(2);
+  });
+
+  it('returns -1 when the anchor row was evicted (live cap)', () => {
+    expect(findIndexByKey([{ uid: 'x' }], 'gone', getKey)).toBe(-1);
+    expect(findIndexByKey([] as { uid: string }[], 'gone', getKey)).toBe(-1);
+  });
+});
+
+describe('restoredScrollTop (offset restore)', () => {
+  const anchor = { key: 'd', viewportOffset: -5 };
+
+  it('puts the anchor row back at the captured viewport offset', () => {
+    // Two 30px rows prepended: the anchor row moved from start 90 to 150.
+    // scrollTop must become 150 − (−5) = 155 to keep it 5px above the top.
+    expect(restoredScrollTop(anchor, 150, 95)).toBe(155);
+  });
+
+  it('is a no-op when nothing moved (append-only merge)', () => {
+    expect(restoredScrollTop(anchor, 90, 95)).toBeNull();
+  });
+
+  it('is a no-op when the anchor row is gone (evicted by the live cap)', () => {
+    expect(restoredScrollTop(anchor, null, 95)).toBeNull();
+  });
+
+  it('clamps at the top when the anchor moved above the captured offset', () => {
+    // Anchor sat 10px below the viewport top but now starts at 5px: the raw
+    // target (5 − 10 = −5) clamps to 0.
+    expect(restoredScrollTop({ key: 'd', viewportOffset: 10 }, 5, 95)).toBe(0);
+    // Already at 0 and the target clamps to 0 → no-op.
+    expect(restoredScrollTop({ key: 'd', viewportOffset: 10 }, 5, 0)).toBeNull();
   });
 });
 

--- a/src/lib/components/virtual-log-list-helpers.ts
+++ b/src/lib/components/virtual-log-list-helpers.ts
@@ -99,6 +99,80 @@ export function becameVisible(prevHeight: number, nextHeight: number): boolean {
   return prevHeight === 0 && nextHeight > 0;
 }
 
+/** Key + geometry of a rendered virtual row, as needed for anchor capture. */
+export interface AnchorRow {
+  key: string;
+  /** Top edge offset within the scroll content (px). */
+  start: number;
+  /** Bottom edge offset within the scroll content (px). */
+  end: number;
+}
+
+/** A captured scroll anchor: which row to hold steady, and where it was. */
+export interface ScrollAnchor {
+  /** Stable key of the anchor row (from getItemKey). */
+  key: string;
+  /** Anchor row's top edge relative to the viewport top (start − scrollTop). */
+  viewportOffset: number;
+}
+
+/**
+ * Capture the row to re-anchor on before an items change applies, in
+ * top-anchored mode. Live merges PREPEND rows (e.g. Observability's
+ * `mergeCalls` sorts newest-first) and the absolutely-positioned virtual rows
+ * defeat native scroll anchoring (`overflow-anchor`), so without compensation
+ * the content under the cursor shifts down by the prepended height.
+ *
+ * Returns `null` when no re-anchoring should happen: tail-follow mode has its
+ * own pinning contract, and at `scrollTop` 0 the user is reading the newest
+ * rows, where prepends SHOULD push the view content down. Otherwise the
+ * anchor is the first row still visible at the current scroll position
+ * (overscan rows fully above the viewport are skipped), with its offset
+ * relative to the viewport top so a partially scrolled-past row is restored
+ * to the exact same position.
+ */
+export function captureScrollAnchor(
+  followTail: boolean,
+  scrollTop: number,
+  rows: readonly AnchorRow[],
+): ScrollAnchor | null {
+  if (followTail || scrollTop <= 0 || rows.length === 0) return null;
+  const anchor = rows.find((r) => r.end > scrollTop) ?? rows[rows.length - 1];
+  return { key: anchor.key, viewportOffset: anchor.start - scrollTop };
+}
+
+/**
+ * Index of the item whose key matches, or -1. Used to relocate the anchor
+ * row after a merge changed the items array (prepends shift every index).
+ */
+export function findIndexByKey<T>(
+  items: readonly T[],
+  key: string,
+  getKey: (item: T, index: number) => string,
+): number {
+  for (let i = 0; i < items.length; i++) {
+    if (getKey(items[i], i) === key) return i;
+  }
+  return -1;
+}
+
+/**
+ * Post-update scrollTop that puts the anchored row back at its captured
+ * viewport offset. Returns `null` when no correction should be applied: the
+ * anchor row is gone (`newStart` null — e.g. evicted by the live row cap) or
+ * the current scroll position is already right (pure appends, no-op merges).
+ * Clamped at 0; the caller's scrollToOffset clamps the far end.
+ */
+export function restoredScrollTop(
+  anchor: ScrollAnchor,
+  newStart: number | null,
+  currentScrollTop: number,
+): number | null {
+  if (newStart === null) return null;
+  const target = Math.max(0, newStart - anchor.viewportOffset);
+  return target === currentScrollTop ? null : target;
+}
+
 export interface MountedRangeInput {
   /** Total number of items in the list. */
   count: number;


### PR DESCRIPTION
Follow-up to #158, addressing the review thread on scroll position during live merges (https://github.com/endara-ai/endara-desktop/pull/158#discussion_r3873006736).

## Problem

The Observability call list renders through `VirtualLogList` in top-anchored mode (`followTail={false}`). Live refresh merges incoming first-page rows via `mergeCalls`, which sorts newest-first — so new rows **prepend**. Nothing compensated `scrollTop`, and the absolutely/transform-positioned virtual rows defeat native browser scroll anchoring (`overflow-anchor`) that the old plain table benefited from on Chromium-based WebView2. Result: a user scrolled mid-list reading older calls saw the content under the cursor shift down by the prepended height on every terminal-event burst (most visible on Windows; macOS WKWebView never had native anchoring).

## Fix

Re-anchor around item keys when `followTail === false` and `scrollTop > 0`:

- **Capture** (`$effect.pre`, runs before the DOM updates and before the count-sync effect, so the virtualizer still reflects the old layout): record the first visible row's key and its offset relative to the viewport top (`captureScrollAnchor`).
- **Restore** (after `tick()`): find the anchor key's new index (`findIndexByKey`), read its new start offset from the virtualizer's measurement cache, and scroll so the same row sits at the same viewport offset (`restoredScrollTop`).

Measured row heights are keyed by item key in `@tanstack/virtual-core`, so the anchor's new offset is consistent before/after a prepend and the correction is exact for the visible region.

No-op by construction when:

- `followTail` is true — tail-pinned views (LogsTab, RelayLogs) are completely unaffected; capture never happens.
- `scrollTop === 0` — the user is reading the newest rows, where prepends should push content down.
- the merge only appends (Load more) — the anchor's offset is unchanged, so the computed target equals the current `scrollTop`.
- the anchor row was evicted by the `LIVE_MAX_ROWS` cap from #157 — no correction rather than a guess.

The decision logic lives in `virtual-log-list-helpers.ts` as pure functions, per the existing extracted-helpers + Node-env vitest pattern. No data-layer changes (`mergeCalls`, cursors, `LIVE_MAX_ROWS` untouched).

## Testing

- `pnpm test`: 1229 passed, 39 skipped — includes new suites for `captureScrollAnchor` (no capture in tail-follow mode / at top / with no rows; skips overscan rows fully above the viewport; exact viewport-offset capture), `findIndexByKey` (shifted index after prepend, eviction → -1), and `restoredScrollTop` (offset restore, append no-op, eviction no-op, top clamp).
- `pnpm check`: 0 errors (1 pre-existing `tsconfig` 'node' types warning, baseline).
