### PR TITLE
fix(ui): harden re-anchor effects against tail-follow overhead and stale async restores

### DIFF
--- a/src/lib/components/VirtualLogList.svelte
+++ b/src/lib/components/VirtualLogList.svelte
@@ -103,7 +103,10 @@
     void items;
     const follow = followTail;
     const el = scrollEl;
-    if (!el) {
+    // Bail before touching the virtualizer when re-anchoring cannot apply
+    // (tail-follow mode, or reading the newest rows at the top), so
+    // frequently-updating tail-pinned log views skip getVirtualItems().
+    if (!el || follow || el.scrollTop <= 0) {
       pendingAnchor = null;
       return;
     }
@@ -132,13 +135,20 @@
     const anchor = pendingAnchor;
     pendingAnchor = null;
     if (!anchor) return;
+    // Snapshot the items/key fn this anchor was captured against so the
+    // async callback below never mixes a stale anchor with a newer array.
+    const itemsAtCapture = items;
+    const keyOf = getKey;
     tick().then(() => {
+      // A newer merge landed before this tick resolved; its own effect run
+      // owns the restore now — don't apply a correction from stale state.
+      if (items !== itemsAtCapture) return;
       const el = scrollEl;
       if (!el) return;
       const inst = get(store);
       // Refresh the measurement cache before reading row offsets.
       inst.getVirtualItems();
-      const index = findIndexByKey(items, anchor.key, getKey);
+      const index = findIndexByKey(itemsAtCapture, anchor.key, keyOf);
       const newStart = index === -1 ? null : (inst.measurementsCache[index]?.start ?? null);
       const target = restoredScrollTop(anchor, newStart, el.scrollTop);
       if (target !== null) inst.scrollToOffset(target);


### PR DESCRIPTION
Follow-up to #159, addressing the two Copilot review comments that landed while it sat in the merge queue (https://github.com/endara-ai/endara-desktop/pull/159#discussion_r3876836076 and https://github.com/endara-ai/endara-desktop/pull/159#discussion_r3876836103).

## Changes

1. **Early bail in the capture `$effect.pre`** — when `followTail` is true or `scrollTop <= 0`, the effect now clears `pendingAnchor` and returns before calling `getVirtualItems()`. Previously it always built the rows array and let `captureScrollAnchor` return null; frequently-updating tail-pinned log views (LogsTab, RelayLogs) now skip that work entirely. `captureScrollAnchor` keeps its own guards, so the helper contract (and its tests) are unchanged.

2. **Snapshot `items`/`getKey` for the async restore** — the `tick()` callback previously closed over the reactive `items` and `getKey`, so a second merge arriving before the promise resolved could relocate the anchor against a newer array than the one that produced it (and fight the newer run's own restore). The effect now snapshots both at capture-application time, and the callback bails if `items` has been replaced since — the newer run owns the restore.

## Testing

- `vitest run`: 1229 passed, 39 skipped (helper behavior unchanged; the bail conditions mirror `captureScrollAnchor`'s existing tested guards).
- `svelte-check`: 0 errors (1 pre-existing tsconfig 'node' types warning, baseline).
