### PR TITLE
fix(desktop): relaunch after update via detached LaunchServices helper on macOS

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2679,7 +2679,8 @@ pub fn run() {
     let channel = read_update_channel();
     let autostarted = is_autostarted();
     let dev = is_dev_mode();
-    let relaunched_from = relaunch::relaunched_from(std::env::args());
+    let relaunched_from =
+        relaunch::relaunched_from(std::env::args_os().map(|a| a.to_string_lossy().into_owned()));
     let exit_version = version.clone();
 
     // Set to `true` by the `RunEvent::ExitRequested` arm when the app is asked to

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod api_proxy;
 mod overlay;
+mod relaunch;
 mod sse;
 mod tray;
 mod webview_recovery;
@@ -32,6 +33,11 @@ const BETA_UPDATE_URL: &str = "https://endara-ai.github.io/endara-desktop/latest
 /// macOS race condition between exit and relaunch described in Tauri issues
 /// #11392 and #1692.
 const RESTART_EXIT_CODE: i32 = 42;
+
+/// Upper bound for the relay `child.kill()` fallback in the `RunEvent::Exit`
+/// arm. The tokio mutex may be held by a task on the still-live app runtime;
+/// an unbounded join there would hang the process before the relaunch.
+const EXIT_TEARDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 
 /// Timeout for the pre-flight JSON manifest fetch performed before delegating
 /// to `tauri-plugin-updater`. Chosen to be larger than typical CDN latency yet
@@ -2613,8 +2619,22 @@ fn set_tray_health(app: AppHandle, state: &str, detail: Option<String>) {
     }
 }
 
+/// Route panics through the file logger. tao dispatches `LoopDestroyed` outside
+/// its panic guard, so a panic in the `RunEvent::Exit` arm would otherwise only
+/// reach stderr and leave no trace in `Endara Desktop.log`.
+fn install_panic_log_hook() {
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        log::error!("panic: {info}");
+        log::logger().flush();
+        default_hook(info);
+    }));
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    install_panic_log_hook();
+
     // Capture `config.toml` existence BEFORE any code path (read_config,
     // read_port_from_config, the relay sidecar spawn) has had a chance to
     // touch the file. The overlay migration helper in Phase 5 uses this to
@@ -2659,6 +2679,8 @@ pub fn run() {
     let channel = read_update_channel();
     let autostarted = is_autostarted();
     let dev = is_dev_mode();
+    let relaunched_from = relaunch::relaunched_from(std::env::args());
+    let exit_version = version.clone();
 
     // Set to `true` by the `RunEvent::ExitRequested` arm when the app is asked to
     // exit with `RESTART_EXIT_CODE` (via the `restart_after_update` command); the
@@ -2741,12 +2763,13 @@ pub fn run() {
         ])
         .setup(move |app| {
             log::info!(
-                "desktop starting version={} commit={} channel={} autostarted={} is_dev={}",
+                "desktop starting version={} commit={} channel={} autostarted={} is_dev={} relaunched_from={}",
                 version,
                 commit,
                 channel,
                 autostarted,
-                dev
+                dev,
+                relaunched_from.as_deref().unwrap_or("none")
             );
 
             // Resolve the overlay's persisted settings BEFORE building the
@@ -3024,13 +3047,19 @@ pub fn run() {
                 if code == Some(RESTART_EXIT_CODE) {
                     restart_requested = true;
                 }
+                log::info!(
+                    "app exit requested code={:?} restart_requested={}",
+                    code,
+                    restart_requested
+                );
             }
             RunEvent::Exit => {
-                log::info!("app exit");
+                log::info!("app exit restart_requested={}", restart_requested);
                 // Release the macOS click-catcher panel while still on the main
                 // thread (the event loop has stopped, so a dispatched teardown
                 // would never run).
                 overlay::destroy_click_catcher(app);
+                log::info!("[exit] click-catcher released");
                 // Suppress any in-flight supervisor logic so the upcoming SIGTERM
                 // is treated as an intentional shutdown, then abort a pending
                 // auto-restart task if one is sleeping out its backoff window.
@@ -3057,10 +3086,14 @@ pub fn run() {
                         }
                     }
                 }
+                log::info!("[exit] relay SIGTERM step done");
                 // Also try the async child.kill() as fallback, in a separate thread
-                // to avoid deadlocking on the tokio runtime during shutdown.
+                // to avoid deadlocking on the tokio runtime during shutdown. The
+                // wait is bounded: if the tokio mutex is held elsewhere we move on
+                // and let process exit reap the sidecar rather than hang here.
                 let child_handle = child_handle.clone();
-                let _ = std::thread::spawn(move || {
+                let (done_tx, done_rx) = std::sync::mpsc::channel::<()>();
+                std::thread::spawn(move || {
                     if let Ok(rt) = tokio::runtime::Runtime::new() {
                         rt.block_on(async {
                             let mut guard = child_handle.lock().await;
@@ -3069,16 +3102,37 @@ pub fn run() {
                             }
                         });
                     }
-                })
-                .join();
+                    let _ = done_tx.send(());
+                });
+                match done_rx.recv_timeout(EXIT_TEARDOWN_TIMEOUT) {
+                    Ok(()) => log::info!("[exit] relay child.kill step done"),
+                    Err(e) => log::warn!(
+                        "[exit] relay child.kill step did not finish within {:?} ({e}); continuing",
+                        EXIT_TEARDOWN_TIMEOUT
+                    ),
+                }
                 // If this exit was a restart request, relaunch now that the event
                 // loop has stopped and the relay sidecar has been torn down. Doing
                 // it here (rather than at request time) is the macOS-safe workaround
-                // for the exit/relaunch race in Tauri issues #11392 and #1692.
+                // for the exit/relaunch race in Tauri issues #11392 and #1692. The
+                // spawn is owned by `relaunch` (not `tauri::process::restart`) so
+                // the strategy, argv and result are all logged, and so macOS goes
+                // through a detached helper + LaunchServices instead of exec'ing
+                // the just-swapped binary from the dying parent.
                 if restart_requested {
-                    log::info!("restarting app after update");
-                    app.cleanup_before_exit();
-                    tauri::process::restart(&app.env());
+                    log::info!("restarting app after update version={}", exit_version);
+                    let cleanup =
+                        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                            app.cleanup_before_exit()
+                        }));
+                    match cleanup {
+                        Ok(()) => log::info!("[exit] cleanup_before_exit done"),
+                        Err(_) => log::error!("[exit] cleanup_before_exit panicked; continuing"),
+                    }
+                    let spawned = relaunch::spawn(&app.env(), &exit_version);
+                    log::info!("[exit] relaunch spawned={spawned}; exiting parent");
+                    log::logger().flush();
+                    std::process::exit(0);
                 }
             }
             _ => {}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3091,7 +3091,9 @@ pub fn run() {
                 // Also try the async child.kill() as fallback, in a separate thread
                 // to avoid deadlocking on the tokio runtime during shutdown. The
                 // wait is bounded: if the tokio mutex is held elsewhere we move on
-                // and let process exit reap the sidecar rather than hang here.
+                // rather than hang here. Process exit does NOT reap the sidecar;
+                // the SIGTERM above is the real kill, and a sidecar that survives
+                // it shows up as a pre-flight port conflict on the next launch.
                 let child_handle = child_handle.clone();
                 let (done_tx, done_rx) = std::sync::mpsc::channel::<()>();
                 std::thread::spawn(move || {

--- a/src-tauri/src/relaunch.rs
+++ b/src-tauri/src/relaunch.rs
@@ -9,16 +9,15 @@
 //! LaunchServices (`open -n`). Everything else (non-bundle/dev runs, other
 //! platforms) falls back to a direct `Command` spawn.
 //!
-//! Launch arguments are never propagated: a relaunched instance is a normal
-//! foreground launch carrying only the [`RELAUNCHED_FROM_FLAG`] marker.
+//! Launch arguments are never propagated: the child's argv is built
+//! explicitly and contains only the [`RELAUNCHED_FROM_FLAG`] marker, so a
+//! relaunched instance is always a normal foreground launch (in particular,
+//! `--autostarted` — which would bring it up hidden, in accessory mode — is
+//! not inherited). The original argv is only logged.
 
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-
-/// Launch-mode flags that must not survive a relaunch (e.g. `--autostarted`
-/// would bring the updated instance up hidden, in accessory mode).
-const STRIPPED_LAUNCH_FLAGS: &[&str] = &["--autostarted"];
 
 /// Marker passed to the relaunched instance so startup logging can identify
 /// it: `--relaunched-from=<previous version>`.
@@ -65,28 +64,13 @@ impl RelaunchStrategy {
     }
 }
 
-/// Build the argv (without argv[0]) for the relaunched instance: every
-/// original launch flag is dropped and the relaunch marker is appended.
-pub fn relaunch_args(original: &[OsString], previous_version: &str) -> Vec<OsString> {
-    let mut args: Vec<OsString> = original
-        .iter()
-        .filter(|a| !is_stripped_launch_flag(a))
-        .filter(|a| !starts_with(a, RELAUNCHED_FROM_FLAG))
-        .filter(|a| !starts_with(a, "-psn_"))
-        .cloned()
-        .collect();
-    args.push(OsString::from(format!(
+/// Build the argv (without argv[0]) for the relaunched instance. This is an
+/// allowlist: nothing from the original launch is carried over; the only
+/// argument is the relaunch marker.
+pub fn relaunch_args(previous_version: &str) -> Vec<OsString> {
+    vec![OsString::from(format!(
         "{RELAUNCHED_FROM_FLAG}{previous_version}"
-    )));
-    args
-}
-
-fn is_stripped_launch_flag(arg: &OsStr) -> bool {
-    STRIPPED_LAUNCH_FLAGS.iter().any(|f| arg == *f)
-}
-
-fn starts_with(arg: &OsStr, prefix: &str) -> bool {
-    arg.to_str().is_some_and(|s| s.starts_with(prefix))
+    ))]
 }
 
 /// The version recorded by [`relaunch_args`], if this process was relaunched
@@ -194,12 +178,11 @@ pub fn spawn(env: &tauri::Env, previous_version: &str) -> bool {
             return false;
         }
     };
-    let original: Vec<OsString> = env.args_os.iter().skip(1).cloned().collect();
-    let args = relaunch_args(&original, previous_version);
+    let args = relaunch_args(previous_version);
     log::info!(
         "[relaunch] exe={} original_args={:?} relaunch_args={:?}",
         exe.display(),
-        original,
+        env.args_os.iter().skip(1).collect::<Vec<_>>(),
         args
     );
 
@@ -258,26 +241,20 @@ mod tests {
     }
 
     #[test]
-    fn relaunch_args_strips_autostarted_and_adds_marker() {
-        let args = relaunch_args(&os(&["--autostarted"]), "0.1.13-rc.15");
-        assert_eq!(args, os(&["--relaunched-from=0.1.13-rc.15"]));
-    }
-
-    #[test]
-    fn relaunch_args_strips_stale_marker_and_psn() {
-        let args = relaunch_args(
-            &os(&["--relaunched-from=0.1.12", "-psn_0_12345", "--keep"]),
-            "0.1.13",
-        );
-        assert_eq!(args, os(&["--keep", "--relaunched-from=0.1.13"]));
-    }
-
-    #[test]
-    fn relaunch_args_empty_input_yields_only_marker() {
+    fn relaunch_args_is_only_the_marker() {
         assert_eq!(
-            relaunch_args(&[], "1.0.0"),
-            os(&["--relaunched-from=1.0.0"])
+            relaunch_args("0.1.13-rc.15"),
+            os(&["--relaunched-from=0.1.13-rc.15"])
         );
+    }
+
+    #[test]
+    fn relaunch_args_never_carries_original_launch_flags() {
+        let args = relaunch_args("0.1.13");
+        for flag in ["--autostarted", "-psn_0_12345", "--relaunched-from=0.1.12"] {
+            assert!(!args.iter().any(|a| a == flag), "{flag} must not appear");
+        }
+        assert_eq!(args.len(), 1);
     }
 
     #[test]
@@ -419,23 +396,32 @@ mod tests {
         }
 
         let mut parent = Command::new("sleep").arg("1").spawn().unwrap();
+        let parent_pid = parent.id();
+        // Reap the parent concurrently so it does not linger as a zombie
+        // (`kill -0` succeeds on zombies, which would mask exit detection).
+        let reaper = std::thread::spawn(move || parent.wait());
         let script = helper_script().replace("/usr/bin/open", fake_open.to_str().unwrap());
         let start = Instant::now();
         let status = Command::new("/bin/sh")
             .arg("-c")
             .arg(script)
             .arg("endara-relaunch")
-            .arg(parent.id().to_string())
+            .arg(parent_pid.to_string())
             .arg("/Applications/Endara Desktop.app")
             .arg("--relaunched-from=1.0.0")
             .status()
             .unwrap();
+        let elapsed = start.elapsed();
         assert!(status.success());
         assert!(
-            start.elapsed() >= std::time::Duration::from_millis(500),
-            "helper returned before the parent exited"
+            elapsed >= std::time::Duration::from_millis(500),
+            "helper returned before the parent exited ({elapsed:?})"
         );
-        parent.wait().unwrap();
+        assert!(
+            elapsed < std::time::Duration::from_secs(10),
+            "helper did not detect parent exit; hit the poll cap ({elapsed:?})"
+        );
+        reaper.join().unwrap().unwrap();
         let recorded = std::fs::read_to_string(&marker).unwrap();
         assert_eq!(
             recorded,

--- a/src-tauri/src/relaunch.rs
+++ b/src-tauri/src/relaunch.rs
@@ -157,6 +157,23 @@ pub fn command(strategy: &RelaunchStrategy) -> Command {
     cmd
 }
 
+/// Summarise the original launch argv (without argv[0]) for logging without
+/// recording it verbatim: only the names of `-`/`--` flags are kept (anything
+/// after `=` is dropped) and positional arguments are counted, not shown.
+pub fn summarize_original_args<'a>(args: impl IntoIterator<Item = &'a OsStr>) -> String {
+    let mut flags = Vec::new();
+    let mut positional = 0usize;
+    for arg in args {
+        let arg = arg.to_string_lossy();
+        if arg.starts_with('-') {
+            flags.push(arg.split('=').next().unwrap_or_default().to_string());
+        } else {
+            positional += 1;
+        }
+    }
+    format!("flags={flags:?} positional={positional}")
+}
+
 /// Describe the argv of `cmd` for logging.
 pub fn describe(cmd: &Command) -> String {
     let mut parts = vec![cmd.get_program().to_string_lossy().into_owned()];
@@ -180,9 +197,9 @@ pub fn spawn(env: &tauri::Env, previous_version: &str) -> bool {
     };
     let args = relaunch_args(previous_version);
     log::info!(
-        "[relaunch] exe={} original_args={:?} relaunch_args={:?}",
+        "[relaunch] exe={} original_args={{{}}} relaunch_args={:?}",
         exe.display(),
-        env.args_os.iter().skip(1).collect::<Vec<_>>(),
+        summarize_original_args(env.args_os.iter().skip(1).map(OsString::as_os_str)),
         args
     );
 
@@ -255,6 +272,31 @@ mod tests {
             assert!(!args.iter().any(|a| a == flag), "{flag} must not appear");
         }
         assert_eq!(args.len(), 1);
+    }
+
+    #[test]
+    fn summarize_original_args_keeps_flag_names_only() {
+        let args = os(&[
+            "--autostarted",
+            "--relaunched-from=0.1.12",
+            "/Users/me/secret file.txt",
+            "-psn_0_12345",
+        ]);
+        let summary = summarize_original_args(args.iter().map(OsString::as_os_str));
+        assert_eq!(
+            summary,
+            r#"flags=["--autostarted", "--relaunched-from", "-psn_0_12345"] positional=1"#
+        );
+        assert!(!summary.contains("0.1.12"));
+        assert!(!summary.contains("secret"));
+    }
+
+    #[test]
+    fn summarize_original_args_empty() {
+        assert_eq!(
+            summarize_original_args(std::iter::empty::<&OsStr>()),
+            "flags=[] positional=0"
+        );
     }
 
     #[test]

--- a/src-tauri/src/relaunch.rs
+++ b/src-tauri/src/relaunch.rs
@@ -426,10 +426,7 @@ mod tests {
         let fake_open = fake_open_dir.join("open");
         std::fs::write(
             &fake_open,
-            format!(
-                "#!/bin/sh\nprintf '%s\\n' \"$@\" > '{}'\n",
-                marker.display()
-            ),
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$FAKE_MARKER\"\n",
         )
         .unwrap();
         {
@@ -442,9 +439,13 @@ mod tests {
         // Reap the parent concurrently so it does not linger as a zombie
         // (`kill -0` succeeds on zombies, which would mask exit detection).
         let reaper = std::thread::spawn(move || parent.wait());
-        let script = helper_script().replace("/usr/bin/open", fake_open.to_str().unwrap());
+        // Paths reach the scripts via the environment so a temp dir containing
+        // spaces or shell metacharacters cannot break them.
+        let script = helper_script().replace("/usr/bin/open", "\"$FAKE_OPEN\"");
         let start = Instant::now();
         let status = Command::new("/bin/sh")
+            .env("FAKE_OPEN", &fake_open)
+            .env("FAKE_MARKER", &marker)
             .arg("-c")
             .arg(script)
             .arg("endara-relaunch")

--- a/src-tauri/src/relaunch.rs
+++ b/src-tauri/src/relaunch.rs
@@ -157,21 +157,27 @@ pub fn command(strategy: &RelaunchStrategy) -> Command {
     cmd
 }
 
+/// Launch flags the app itself knows about; the only argv content that is ever
+/// written to the log (by name, never with a value).
+const KNOWN_LAUNCH_FLAGS: &[&str] = &["--autostarted", "--relaunched-from", "-psn"];
+
 /// Summarise the original launch argv (without argv[0]) for logging without
-/// recording it verbatim: only the names of `-`/`--` flags are kept (anything
-/// after `=` is dropped) and positional arguments are counted, not shown.
+/// recording it verbatim: arguments matching [`KNOWN_LAUNCH_FLAGS`] are logged
+/// by flag name only; everything else is counted, not shown.
 pub fn summarize_original_args<'a>(args: impl IntoIterator<Item = &'a OsStr>) -> String {
     let mut flags = Vec::new();
-    let mut positional = 0usize;
+    let mut other = 0usize;
     for arg in args {
         let arg = arg.to_string_lossy();
-        if arg.starts_with('-') {
-            flags.push(arg.split('=').next().unwrap_or_default().to_string());
-        } else {
-            positional += 1;
+        match KNOWN_LAUNCH_FLAGS.iter().find(|f| {
+            arg.strip_prefix(*f)
+                .is_some_and(|rest| rest.is_empty() || rest.starts_with(['=', '_']))
+        }) {
+            Some(flag) => flags.push(*flag),
+            None => other += 1,
         }
     }
-    format!("flags={flags:?} positional={positional}")
+    format!("flags={flags:?} other={other}")
 }
 
 /// Describe the argv of `cmd` for logging.
@@ -275,27 +281,31 @@ mod tests {
     }
 
     #[test]
-    fn summarize_original_args_keeps_flag_names_only() {
+    fn summarize_original_args_keeps_known_flag_names_only() {
         let args = os(&[
             "--autostarted",
             "--relaunched-from=0.1.12",
             "/Users/me/secret file.txt",
             "-psn_0_12345",
+            "--token=abc",
+            "-/Users/me/odd",
+            "--autostarted-extra",
         ]);
         let summary = summarize_original_args(args.iter().map(OsString::as_os_str));
         assert_eq!(
             summary,
-            r#"flags=["--autostarted", "--relaunched-from", "-psn_0_12345"] positional=1"#
+            r#"flags=["--autostarted", "--relaunched-from", "-psn"] other=4"#
         );
-        assert!(!summary.contains("0.1.12"));
-        assert!(!summary.contains("secret"));
+        for leaked in ["0.1.12", "secret", "12345", "token", "abc", "odd", "extra"] {
+            assert!(!summary.contains(leaked), "{leaked} leaked into {summary}");
+        }
     }
 
     #[test]
     fn summarize_original_args_empty() {
         assert_eq!(
             summarize_original_args(std::iter::empty::<&OsStr>()),
-            "flags=[] positional=0"
+            "flags=[] other=0"
         );
     }
 

--- a/src-tauri/src/relaunch.rs
+++ b/src-tauri/src/relaunch.rs
@@ -31,7 +31,8 @@ const HELPER_MAX_POLLS: u32 = 150;
 /// `$1` = parent pid, `$2` = bundle path, `$3..` = app arguments. Passing the
 /// values as parameters (rather than interpolating them) avoids any quoting
 /// of paths containing spaces such as `/Applications/Endara Desktop.app`.
-const HELPER_SCRIPT_TEMPLATE: &str = r#"pid="$1"; bundle="$2"; shift 2
+const HELPER_SCRIPT_TEMPLATE: &str = r#"PATH=/usr/bin:/bin; export PATH
+pid="$1"; bundle="$2"; shift 2
 i=0
 while kill -0 "$pid" 2>/dev/null && [ "$i" -lt @MAX_POLLS@ ]; do sleep 0.2; i=$((i+1)); done
 if [ "$#" -gt 0 ]; then exec /usr/bin/open -n "$bundle" --args "$@"; fi
@@ -157,8 +158,9 @@ pub fn command(strategy: &RelaunchStrategy) -> Command {
     cmd
 }
 
-/// Launch flags the app itself knows about; the only argv content that is ever
-/// written to the log (by name, never with a value).
+/// Launch flags the app itself knows about. When summarising the *original*
+/// launch argv for the log, these are the only arguments recorded (by name,
+/// never with a value); everything else is counted.
 const KNOWN_LAUNCH_FLAGS: &[&str] = &["--autostarted", "--relaunched-from", "-psn"];
 
 /// Summarise the original launch argv (without argv[0]) for logging without
@@ -400,6 +402,7 @@ mod tests {
     #[test]
     fn helper_script_waits_for_parent_then_opens_bundle() {
         let script = helper_script();
+        assert!(script.starts_with("PATH=/usr/bin:/bin; export PATH\n"));
         assert!(script.contains(r#"kill -0 "$pid""#));
         assert!(script.contains(&format!("-lt {HELPER_MAX_POLLS}")));
         assert!(script.contains(r#"exec /usr/bin/open -n "$bundle" --args "$@""#));

--- a/src-tauri/src/relaunch.rs
+++ b/src-tauri/src/relaunch.rs
@@ -1,0 +1,445 @@
+//! Post-update relaunch.
+//!
+//! On macOS the updater swaps the `.app` bundle underneath the running
+//! process. Exec'ing the swapped binary directly from the exiting parent is
+//! unreliable: the child can be killed by dyld/code-signature validation
+//! before it reaches `setup`, and `spawn()` reports success regardless. The
+//! macOS strategy therefore starts a small detached `/bin/sh` helper that
+//! waits for this process to exit and then relaunches the bundle through
+//! LaunchServices (`open -n`). Everything else (non-bundle/dev runs, other
+//! platforms) falls back to a direct `Command` spawn.
+//!
+//! Launch arguments are never propagated: a relaunched instance is a normal
+//! foreground launch carrying only the [`RELAUNCHED_FROM_FLAG`] marker.
+
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+/// Launch-mode flags that must not survive a relaunch (e.g. `--autostarted`
+/// would bring the updated instance up hidden, in accessory mode).
+const STRIPPED_LAUNCH_FLAGS: &[&str] = &["--autostarted"];
+
+/// Marker passed to the relaunched instance so startup logging can identify
+/// it: `--relaunched-from=<previous version>`.
+pub const RELAUNCHED_FROM_FLAG: &str = "--relaunched-from=";
+
+/// Upper bound the helper waits for the parent to exit before relaunching
+/// anyway (150 × 200 ms = 30 s), so a reused PID cannot wedge it forever.
+const HELPER_MAX_POLLS: u32 = 150;
+
+/// Shell script run by the macOS helper. Positional parameters:
+/// `$1` = parent pid, `$2` = bundle path, `$3..` = app arguments. Passing the
+/// values as parameters (rather than interpolating them) avoids any quoting
+/// of paths containing spaces such as `/Applications/Endara Desktop.app`.
+const HELPER_SCRIPT_TEMPLATE: &str = r#"pid="$1"; bundle="$2"; shift 2
+i=0
+while kill -0 "$pid" 2>/dev/null && [ "$i" -lt @MAX_POLLS@ ]; do sleep 0.2; i=$((i+1)); done
+if [ "$#" -gt 0 ]; then exec /usr/bin/open -n "$bundle" --args "$@"; fi
+exec /usr/bin/open -n "$bundle""#;
+
+pub fn helper_script() -> String {
+    HELPER_SCRIPT_TEMPLATE.replace("@MAX_POLLS@", &HELPER_MAX_POLLS.to_string())
+}
+
+/// How the relaunch will be performed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RelaunchStrategy {
+    /// Detached `/bin/sh` helper: wait for `parent_pid` to exit, then
+    /// `open -n <bundle> --args <args>`.
+    LaunchServices {
+        bundle: PathBuf,
+        parent_pid: u32,
+        args: Vec<OsString>,
+    },
+    /// `Command::new(exe).args(args).spawn()`.
+    Direct { exe: PathBuf, args: Vec<OsString> },
+}
+
+impl RelaunchStrategy {
+    pub fn name(&self) -> &'static str {
+        match self {
+            RelaunchStrategy::LaunchServices { .. } => "launch_services_helper",
+            RelaunchStrategy::Direct { .. } => "direct_spawn",
+        }
+    }
+}
+
+/// Build the argv (without argv[0]) for the relaunched instance: every
+/// original launch flag is dropped and the relaunch marker is appended.
+pub fn relaunch_args(original: &[OsString], previous_version: &str) -> Vec<OsString> {
+    let mut args: Vec<OsString> = original
+        .iter()
+        .filter(|a| !is_stripped_launch_flag(a))
+        .filter(|a| !starts_with(a, RELAUNCHED_FROM_FLAG))
+        .filter(|a| !starts_with(a, "-psn_"))
+        .cloned()
+        .collect();
+    args.push(OsString::from(format!(
+        "{RELAUNCHED_FROM_FLAG}{previous_version}"
+    )));
+    args
+}
+
+fn is_stripped_launch_flag(arg: &OsStr) -> bool {
+    STRIPPED_LAUNCH_FLAGS.iter().any(|f| arg == *f)
+}
+
+fn starts_with(arg: &OsStr, prefix: &str) -> bool {
+    arg.to_str().is_some_and(|s| s.starts_with(prefix))
+}
+
+/// The version recorded by [`relaunch_args`], if this process was relaunched
+/// after an update.
+pub fn relaunched_from(args: impl IntoIterator<Item = String>) -> Option<String> {
+    args.into_iter()
+        .find_map(|a| a.strip_prefix(RELAUNCHED_FROM_FLAG).map(str::to_string))
+}
+
+/// `<X>.app` for an executable at `<X>.app/Contents/MacOS/<bin>`, else `None`.
+pub fn bundle_root(exe: &Path) -> Option<PathBuf> {
+    let macos_dir = exe.parent()?;
+    if macos_dir.file_name() != Some(OsStr::new("MacOS")) {
+        return None;
+    }
+    let contents_dir = macos_dir.parent()?;
+    if contents_dir.file_name() != Some(OsStr::new("Contents")) {
+        return None;
+    }
+    let bundle = contents_dir.parent()?;
+    if bundle.extension() != Some(OsStr::new("app")) {
+        return None;
+    }
+    Some(bundle.to_path_buf())
+}
+
+/// Choose the strategy for `exe`. `use_launch_services` is `true` on macOS
+/// (callers pass `cfg!(target_os = "macos")`); it only takes effect when
+/// `exe` lives inside an `.app` bundle.
+pub fn plan(
+    exe: &Path,
+    parent_pid: u32,
+    args: Vec<OsString>,
+    use_launch_services: bool,
+) -> RelaunchStrategy {
+    if use_launch_services {
+        if let Some(bundle) = bundle_root(exe) {
+            return RelaunchStrategy::LaunchServices {
+                bundle,
+                parent_pid,
+                args,
+            };
+        }
+    }
+    RelaunchStrategy::Direct {
+        exe: exe.to_path_buf(),
+        args,
+    }
+}
+
+/// The process to spawn for `strategy`. Stdio is detached so the child never
+/// holds our pipes; on unix it is also placed in its own process group so it
+/// outlives us regardless of how we exit.
+pub fn command(strategy: &RelaunchStrategy) -> Command {
+    let mut cmd = match strategy {
+        RelaunchStrategy::LaunchServices {
+            bundle,
+            parent_pid,
+            args,
+        } => {
+            let mut cmd = Command::new("/bin/sh");
+            cmd.arg("-c")
+                .arg(helper_script())
+                .arg("endara-relaunch")
+                .arg(parent_pid.to_string())
+                .arg(bundle)
+                .args(args);
+            cmd
+        }
+        RelaunchStrategy::Direct { exe, args } => {
+            let mut cmd = Command::new(exe);
+            cmd.args(args);
+            cmd
+        }
+    };
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        cmd.process_group(0);
+    }
+    cmd
+}
+
+/// Describe the argv of `cmd` for logging.
+pub fn describe(cmd: &Command) -> String {
+    let mut parts = vec![cmd.get_program().to_string_lossy().into_owned()];
+    parts.extend(cmd.get_args().map(|a| a.to_string_lossy().into_owned()));
+    format!("{parts:?}")
+}
+
+/// Plan and spawn the relaunch, logging every step. The current executable is
+/// resolved through Tauri (the path canonicalised at process start) and the
+/// original launch args come from `env.args_os`.
+///
+/// If the LaunchServices helper fails to spawn, falls back to a direct spawn
+/// before giving up. Returns whether any spawn succeeded.
+pub fn spawn(env: &tauri::Env, previous_version: &str) -> bool {
+    let exe = match tauri::process::current_binary(env) {
+        Ok(path) => path,
+        Err(e) => {
+            log::error!("[relaunch] cannot resolve current executable error={e}");
+            return false;
+        }
+    };
+    let original: Vec<OsString> = env.args_os.iter().skip(1).cloned().collect();
+    let args = relaunch_args(&original, previous_version);
+    log::info!(
+        "[relaunch] exe={} original_args={:?} relaunch_args={:?}",
+        exe.display(),
+        original,
+        args
+    );
+
+    let primary = plan(
+        &exe,
+        std::process::id(),
+        args.clone(),
+        cfg!(target_os = "macos"),
+    );
+    if try_spawn(&primary) {
+        return true;
+    }
+    let fallback = RelaunchStrategy::Direct { exe, args };
+    if fallback == primary {
+        return false;
+    }
+    log::warn!(
+        "[relaunch] primary strategy failed; trying {}",
+        fallback.name()
+    );
+    try_spawn(&fallback)
+}
+
+fn try_spawn(strategy: &RelaunchStrategy) -> bool {
+    let mut cmd = command(strategy);
+    log::info!(
+        "[relaunch] strategy={} spawning {}",
+        strategy.name(),
+        describe(&cmd)
+    );
+    match cmd.spawn() {
+        Ok(child) => {
+            log::info!(
+                "[relaunch] strategy={} spawned pid={}",
+                strategy.name(),
+                child.id()
+            );
+            true
+        }
+        Err(e) => {
+            log::error!(
+                "[relaunch] strategy={} spawn failed error={e}",
+                strategy.name()
+            );
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn os(args: &[&str]) -> Vec<OsString> {
+        args.iter().map(OsString::from).collect()
+    }
+
+    #[test]
+    fn relaunch_args_strips_autostarted_and_adds_marker() {
+        let args = relaunch_args(&os(&["--autostarted"]), "0.1.13-rc.15");
+        assert_eq!(args, os(&["--relaunched-from=0.1.13-rc.15"]));
+    }
+
+    #[test]
+    fn relaunch_args_strips_stale_marker_and_psn() {
+        let args = relaunch_args(
+            &os(&["--relaunched-from=0.1.12", "-psn_0_12345", "--keep"]),
+            "0.1.13",
+        );
+        assert_eq!(args, os(&["--keep", "--relaunched-from=0.1.13"]));
+    }
+
+    #[test]
+    fn relaunch_args_empty_input_yields_only_marker() {
+        assert_eq!(
+            relaunch_args(&[], "1.0.0"),
+            os(&["--relaunched-from=1.0.0"])
+        );
+    }
+
+    #[test]
+    fn relaunched_from_parses_marker() {
+        let args = vec![
+            "app".to_string(),
+            "--relaunched-from=0.1.13-rc.15".to_string(),
+        ];
+        assert_eq!(relaunched_from(args).as_deref(), Some("0.1.13-rc.15"));
+        assert_eq!(relaunched_from(vec!["app".to_string()]), None);
+    }
+
+    #[test]
+    fn bundle_root_detects_app_bundle() {
+        let exe = Path::new("/Applications/Endara Desktop.app/Contents/MacOS/Endara Desktop");
+        assert_eq!(
+            bundle_root(exe),
+            Some(PathBuf::from("/Applications/Endara Desktop.app"))
+        );
+    }
+
+    #[test]
+    fn bundle_root_rejects_non_bundle_layouts() {
+        assert_eq!(bundle_root(Path::new("/usr/local/bin/endara")), None);
+        assert_eq!(
+            bundle_root(Path::new("/tmp/target/debug/Contents/MacOS/endara")),
+            None
+        );
+        assert_eq!(
+            bundle_root(Path::new("/x/Foo.app/Contents/bin/endara")),
+            None
+        );
+    }
+
+    #[test]
+    fn plan_uses_launch_services_only_for_macos_bundles() {
+        let bundle_exe =
+            Path::new("/Applications/Endara Desktop.app/Contents/MacOS/Endara Desktop");
+        let args = os(&["--relaunched-from=1"]);
+        assert_eq!(
+            plan(bundle_exe, 4242, args.clone(), true),
+            RelaunchStrategy::LaunchServices {
+                bundle: PathBuf::from("/Applications/Endara Desktop.app"),
+                parent_pid: 4242,
+                args: args.clone(),
+            }
+        );
+        assert_eq!(
+            plan(bundle_exe, 4242, args.clone(), false),
+            RelaunchStrategy::Direct {
+                exe: bundle_exe.to_path_buf(),
+                args: args.clone(),
+            }
+        );
+        let dev_exe = Path::new("/repo/target/debug/endara-desktop");
+        assert_eq!(
+            plan(dev_exe, 4242, args.clone(), true),
+            RelaunchStrategy::Direct {
+                exe: dev_exe.to_path_buf(),
+                args,
+            }
+        );
+    }
+
+    #[test]
+    fn launch_services_command_passes_values_as_positional_params() {
+        let strategy = RelaunchStrategy::LaunchServices {
+            bundle: PathBuf::from("/Applications/Endara Desktop.app"),
+            parent_pid: 4242,
+            args: os(&["--relaunched-from=1.0.0"]),
+        };
+        let cmd = command(&strategy);
+        assert_eq!(cmd.get_program(), "/bin/sh");
+        let argv: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(argv[0], "-c");
+        assert_eq!(argv[1], helper_script());
+        assert_eq!(
+            &argv[2..],
+            &[
+                "endara-relaunch",
+                "4242",
+                "/Applications/Endara Desktop.app",
+                "--relaunched-from=1.0.0"
+            ]
+        );
+    }
+
+    #[test]
+    fn helper_script_waits_for_parent_then_opens_bundle() {
+        let script = helper_script();
+        assert!(script.contains(r#"kill -0 "$pid""#));
+        assert!(script.contains(&format!("-lt {HELPER_MAX_POLLS}")));
+        assert!(script.contains(r#"exec /usr/bin/open -n "$bundle" --args "$@""#));
+        assert!(script.ends_with(r#"exec /usr/bin/open -n "$bundle""#));
+        assert!(
+            !script.contains("@MAX_POLLS@"),
+            "unsubstituted placeholder: {script}"
+        );
+    }
+
+    #[test]
+    fn direct_command_uses_exe_and_args() {
+        let strategy = RelaunchStrategy::Direct {
+            exe: PathBuf::from("/opt/endara/endara-desktop"),
+            args: os(&["--relaunched-from=1.0.0"]),
+        };
+        let cmd = command(&strategy);
+        assert_eq!(cmd.get_program(), "/opt/endara/endara-desktop");
+        assert_eq!(
+            cmd.get_args().collect::<Vec<_>>(),
+            vec![OsStr::new("--relaunched-from=1.0.0")]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn helper_script_relaunches_after_parent_exits() {
+        use std::time::Instant;
+
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("relaunched");
+        let fake_open_dir = dir.path().join("bin");
+        std::fs::create_dir(&fake_open_dir).unwrap();
+        let fake_open = fake_open_dir.join("open");
+        std::fs::write(
+            &fake_open,
+            format!(
+                "#!/bin/sh\nprintf '%s\\n' \"$@\" > '{}'\n",
+                marker.display()
+            ),
+        )
+        .unwrap();
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&fake_open, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        let mut parent = Command::new("sleep").arg("1").spawn().unwrap();
+        let script = helper_script().replace("/usr/bin/open", fake_open.to_str().unwrap());
+        let start = Instant::now();
+        let status = Command::new("/bin/sh")
+            .arg("-c")
+            .arg(script)
+            .arg("endara-relaunch")
+            .arg(parent.id().to_string())
+            .arg("/Applications/Endara Desktop.app")
+            .arg("--relaunched-from=1.0.0")
+            .status()
+            .unwrap();
+        assert!(status.success());
+        assert!(
+            start.elapsed() >= std::time::Duration::from_millis(500),
+            "helper returned before the parent exited"
+        );
+        parent.wait().unwrap();
+        let recorded = std::fs::read_to_string(&marker).unwrap();
+        assert_eq!(
+            recorded,
+            "-n\n/Applications/Endara Desktop.app\n--args\n--relaunched-from=1.0.0\n"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

On macOS, clicking **Restart Now** after the in-app updater installed v0.1.13-rc.15 closed the app but never brought it back. The bundle swap itself had succeeded (a manual reopen ran rc.15), but the user was left with no running instance.

## Root cause

`restart_after_update` exits with code 42, and the `RunEvent::Exit` arm called `tauri::process::restart`, which directly `exec`s the current binary path from the exiting parent. After the updater has swapped the `.app` bundle, that path points at the **just-replaced** binary. The log for the failing session shows `restarting app after update` with no spawn error, yet no child `desktop starting` line and a single instance in `ps`: the child was spawned but killed by dyld/code-signature validation before plugin init. Two contributing hazards were also present: launch args (`--autostarted`) were re-passed to the child, so a successful relaunch from a LaunchAgent session would have come back hidden in accessory mode; and the Exit arm did an unbounded `join()` on the relay teardown thread, which could hang before the spawn ever happened.

## Fix

New module `src-tauri/src/relaunch.rs`; `lib.rs` uses it instead of `tauri::process::restart`.

- **Detached LaunchServices helper (macOS, bundled run).** The parent spawns `/bin/sh -c <script> endara-relaunch <parent pid> <bundle> <args…>` in its own process group with null stdio. The script waits for the parent PID to exit (`kill -0` loop, 200 ms cadence, 30 s cap so a reused PID cannot wedge it), then `exec /usr/bin/open -n "<bundle>" --args "$@"`. LaunchServices launches the fresh bundle from a live process, after the parent is gone. Bundle path and args are passed as positional parameters, so `/Applications/Endara Desktop.app` needs no quoting.
- **Direct spawn fallback.** Non-bundle (dev) runs, non-macOS, and a failed helper spawn fall back to `Command::new(exe)` in its own process group. Non-macOS relaunch semantics are otherwise unchanged.
- **Allowlist argv.** The relaunched instance receives only `--relaunched-from=<previous version>`; the original argv is logged but never forwarded (fixes the `--autostarted` inheritance). Startup logs `relaunched_from=<version|none>` on the existing `desktop starting` line.
- **Exit-path logging + panic hook.** `ExitRequested` logs `code` and `restart_requested`; each teardown step in the Exit arm is bracketed (`[exit] …`); `[relaunch] …` logs exe, original args, relaunch args, chosen strategy, exact spawn argv, and the spawn result (child pid or error); the logger is flushed before `exit(0)`. A panic hook writes panics to the log file before the default hook runs.
- **Bounded teardown.** The relay `child.kill()` thread is no longer joined; the main thread waits on a channel with a 3 s timeout and proceeds to the relaunch regardless. `cleanup_before_exit()` is wrapped in `catch_unwind` so a poisoned mutex cannot prevent the relaunch.

Unchanged: updater download/install flow, the `restart_after_update` command and its exit-code-42 contract with the frontend.

## Tests

`cargo test` (151 passed), `cargo fmt --check` clean, `cargo clippy --all-targets` unchanged vs `main` (11 pre-existing `webview_recovery` warnings). New `relaunch::tests` cover the argv allowlist, `--relaunched-from` parsing, bundle-root detection, strategy selection, command construction, and an end-to-end shell test that runs the real helper script against a `sleep 1` parent and a fake `open`, asserting it waits for the parent to exit and calls `open -n <bundle> --args --relaunched-from=…`.

The macOS branch is `cfg!`-selected at runtime rather than `#[cfg]`-gated, so it compiles and is unit-tested on Linux; only `process_group(0)` is `#[cfg(unix)]`. CI only runs `cargo check` on macOS, so **none of this is exercised end-to-end on macOS by CI**.

## Manual macOS test matrix (required before promoting rc.16)

Run on Intel and aarch64. Setup: install rc.N from the `.dmg` into `/Applications`, publish rc.N+1 to the beta channel.

| # | Launch mode of rc.N | Steps | Expected |
|---|---|---|---|
| a | Normal (Finder/Dock) | Check for update → Download → **Restart Now** | exactly one `Endara Desktop` process; main window visible + Dock icon; log shows `desktop starting version=<rc.N+1> … autostarted=false relaunched_from=<rc.N>` |
| b | LaunchAgent (`--autostarted`; log out/in or `launchctl kickstart`) | same | same as (a) — relaunched instance must NOT be hidden/accessory (`autostarted=false` in its startup line) |
| c | Tray-only (main window closed → hidden) | same, from tray/menu | same as (a): window visible after relaunch |

For every row, `grep -n -E 'app exit requested|app exit |\[exit\]|\[relaunch\]|restarting app after update|desktop starting|panic' ~/Library/Logs/ai.endara.desktop/'Endara Desktop.log'` must show, in order: `app exit requested code=Some(42) restart_requested=true` → `app exit restart_requested=true` → the four `[exit] …` step lines → `restarting app after update version=<rc.N>` → `[relaunch] exe=… relaunch_args=["--relaunched-from=<rc.N>"]` → `[relaunch] strategy=launch_services_helper spawning ["/bin/sh", "-c", …]` → `[relaunch] … spawned pid=<helper pid>` → `[exit] relaunch spawned=true; exiting parent` → new `desktop starting version=<rc.N+1> … relaunched_from=<rc.N>`.

Optional fault injection: hold the relay child mutex during exit and confirm `[exit] relay child.kill step did not finish within 3s` appears and the relaunch still happens.

## Known follow-up (non-blocking)

The helper's stdio is `/dev/null`, so if `open -n` itself fails (e.g. Gatekeeper refusing the new bundle) the failure is not observable in the app log; the parent only records that the helper spawned. Redirecting the helper's stderr to a file under the log directory is a candidate follow-up.
