### PR TITLE
feat(desktop): GitHub catalog entry uses remote HTTP server with bearer PAT

### DIFF
--- a/src/lib/catalog-http.live.test.ts
+++ b/src/lib/catalog-http.live.test.ts
@@ -18,6 +18,12 @@ const remoteEntries = CATALOG_SERVERS.filter(
   (e) => (e.transport === 'http' || e.transport === 'sse') && !!e.url
 );
 
+// Subset that can be probed anonymously: entries requiring a config var
+// (e.g. GitHub's bearer-header PAT) reject an unauthenticated `tools/list`.
+const anonymousRemoteEntries = remoteEntries.filter(
+  (e) => !e.envVars.some((ev) => ev.required)
+);
+
 const MCP_PROTOCOL_VERSION = '2025-03-26';
 
 interface JsonRpcResponse {
@@ -108,17 +114,18 @@ async function listTools(url: string): Promise<any> {
 // --- Live tests (network, run on demand with RUN_LIVE_TESTS=1) ---
 
 describe.skipIf(!RUN_LIVE)('live HTTP catalog tools listing', () => {
-  // Today the catalog has zero plain-http/sse entries with a URL; this
-  // placeholder keeps the suite green while proving the filter ran.
+  // The anonymous subset may be empty (e.g. only GitHub, which needs a PAT);
+  // this placeholder keeps the suite green while proving the filter ran.
   it('filters http/sse catalog entries with a url', () => {
     expect(Array.isArray(remoteEntries)).toBe(true);
     for (const entry of remoteEntries) {
       expect(entry.url, `${entry.id}: url should be non-empty`).toBeTruthy();
     }
+    expect(Array.isArray(anonymousRemoteEntries)).toBe(true);
   });
 
-  if (remoteEntries.length > 0) {
-    it.each(remoteEntries.map((e) => [e.id, e.url!]))(
+  if (anonymousRemoteEntries.length > 0) {
+    it.each(anonymousRemoteEntries.map((e) => [e.id, e.url!]))(
       'tools/list for %s (%s) returns tools',
       async (_id, url) => {
         const result = await listTools(url);

--- a/src/lib/catalog.test.ts
+++ b/src/lib/catalog.test.ts
@@ -31,6 +31,16 @@ describe('CATALOG_SERVERS validation', () => {
     }
   });
 
+  it('stdio entries declare no header-targeted config vars', () => {
+    // `CatalogEnvVar.header` is only meaningful for http/sse; a header-typed
+    // var on a stdio entry would be silently dropped (stdio sends no headers).
+    for (const entry of CATALOG_SERVERS.filter((e) => e.transport === 'stdio')) {
+      for (const ev of entry.envVars) {
+        expect(ev.header, `${entry.id}: ${ev.name} declares a header target on a stdio entry`).toBeUndefined();
+      }
+    }
+  });
+
   it('http/sse entries have a non-empty url', () => {
     for (const entry of CATALOG_SERVERS.filter((e) => e.transport !== 'stdio')) {
       expect(entry.url, `${entry.id}: missing url`).toBeTruthy();

--- a/src/lib/catalog.test.ts
+++ b/src/lib/catalog.test.ts
@@ -19,9 +19,47 @@ describe('CATALOG_SERVERS validation', () => {
       expect(entry.id, `entry missing id`).toBeTruthy();
       expect(entry.name, `${entry.id}: missing name`).toBeTruthy();
       expect(entry.description, `${entry.id}: missing description`).toBeTruthy();
-      expect(entry.command, `${entry.id}: missing command`).toBeTruthy();
       expect(entry.icon, `${entry.id}: missing icon`).toBeTruthy();
     }
+  });
+
+  it('stdio entries have a command and a non-empty args array', () => {
+    for (const entry of CATALOG_SERVERS.filter((e) => e.transport === 'stdio')) {
+      expect(entry.command, `${entry.id}: missing command`).toBeTruthy();
+      expect(entry.args, `${entry.id}: args should be an array`).toBeInstanceOf(Array);
+      expect(entry.args!.length, `${entry.id}: args should not be empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it('http/sse entries have a non-empty url', () => {
+    for (const entry of CATALOG_SERVERS.filter((e) => e.transport !== 'stdio')) {
+      expect(entry.url, `${entry.id}: missing url`).toBeTruthy();
+      expect(entry.url!.trim().length, `${entry.id}: url should not be blank`).toBeGreaterThan(0);
+    }
+  });
+
+  it('no entry references the deprecated stdio GitHub server', () => {
+    for (const entry of CATALOG_SERVERS) {
+      expect(entry.args ?? [], `${entry.id}: references @modelcontextprotocol/server-github`).not.toContain(
+        '@modelcontextprotocol/server-github'
+      );
+    }
+  });
+
+  it('GitHub entry is the remote HTTP server with a bearer-header PAT', () => {
+    const github = CATALOG_SERVERS.find((e) => e.id === 'github');
+    expect(github).toBeDefined();
+    expect(github!.transport).toBe('http');
+    expect(github!.url).toBe('https://api.githubcopilot.com/mcp/');
+    expect(github!.command).toBeUndefined();
+    expect(github!.args).toBeUndefined();
+    expect(github!.envVars).toHaveLength(1);
+    const pat = github!.envVars[0];
+    expect(pat.label).toBe('Personal Access Token');
+    expect(pat.required).toBe(true);
+    expect(pat.secret).toBe(true);
+    expect(pat.helpUrl).toBe('https://github.com/settings/tokens');
+    expect(pat.header).toEqual({ name: 'Authorization', valuePrefix: 'Bearer ' });
   });
 
   it('no duplicate IDs', () => {
@@ -50,12 +88,6 @@ describe('CATALOG_SERVERS validation', () => {
     }
   });
 
-  it('all entries have a non-empty args array', () => {
-    for (const entry of CATALOG_SERVERS) {
-      expect(entry.args, `${entry.id}: args should be an array`).toBeInstanceOf(Array);
-      expect(entry.args.length, `${entry.id}: args should not be empty`).toBeGreaterThan(0);
-    }
-  });
 });
 
 // --- Slow tests (network, run on demand with RUN_LIVE_TESTS=1) ---
@@ -93,7 +125,7 @@ function collectHelpUrls(): { id: string; url: string }[] {
 }
 
 describe.skipIf(!RUN_LIVE)('live package validation', () => {
-  it.each(npxEntries.map((e) => [e.id, extractNpmPackage(e.args)]))(
+  it.each(npxEntries.map((e) => [e.id, extractNpmPackage(e.args ?? [])]))(
     'npm package for %s (%s) exists',
     async (_id, pkg) => {
       expect(pkg).toBeTruthy();
@@ -103,7 +135,7 @@ describe.skipIf(!RUN_LIVE)('live package validation', () => {
     15_000
   );
 
-  it.each(uvxEntries.map((e) => [e.id, extractPypiPackage(e.args)]))(
+  it.each(uvxEntries.map((e) => [e.id, extractPypiPackage(e.args ?? [])]))(
     'pypi package for %s (%s) exists',
     async (_id, pkg) => {
       expect(pkg).toBeTruthy();

--- a/src/lib/catalog.ts
+++ b/src/lib/catalog.ts
@@ -4,6 +4,12 @@ export interface CatalogEnvVar {
   required: boolean;
   secret: boolean;
   helpUrl?: string;
+  /**
+   * When set, the configured value is sent as the HTTP header `name` (prefixed
+   * with `valuePrefix`, e.g. `"Bearer "`) instead of as an environment variable.
+   * Only meaningful for `http`/`sse` entries.
+   */
+  header?: { name: string; valuePrefix?: string };
 }
 
 export interface CatalogServer {
@@ -13,10 +19,12 @@ export interface CatalogServer {
   icon: string;
   category: 'developer' | 'search' | 'productivity' | 'data';
   transport: 'stdio' | 'sse' | 'http';
-  /** Remote endpoint URL for `http`/`sse` transports (unused for `stdio`). */
+  /** Remote endpoint URL. Required for `http`/`sse` transports (unused for `stdio`). */
   url?: string;
-  command: string;
-  args: string[];
+  /** Executable to spawn. Required for `stdio` transports (unused for `http`/`sse`). */
+  command?: string;
+  /** Arguments passed to `command`. Required for `stdio` transports (unused for `http`/`sse`). */
+  args?: string[];
   envVars: CatalogEnvVar[];
   userArgs?: { label: string; placeholder: string; type?: 'directory' | 'file' }[];
   /**
@@ -56,11 +64,17 @@ export const CATALOG_SERVERS: CatalogServer[] = [
     description: 'Interact with GitHub repositories, issues, pull requests, and more.',
     icon: '<svg viewBox="0 0 20 20" fill="currentColor"><path d="M10 1.5a8.5 8.5 0 0 0-2.69 16.56c.43.08.58-.18.58-.4v-1.54c-2.37.52-2.87-1.01-2.87-1.01-.39-.99-.95-1.25-.95-1.25-.78-.53.06-.52.06-.52.86.06 1.31.88 1.31.88.76 1.3 2 .93 2.49.71.08-.55.3-.93.54-1.14-1.89-.21-3.88-.94-3.88-4.2 0-.93.33-1.69.88-2.28-.09-.22-.38-1.08.08-2.25 0 0 .72-.23 2.35.87a8.18 8.18 0 0 1 4.28 0c1.63-1.1 2.35-.87 2.35-.87.46 1.17.17 2.03.08 2.25.55.59.88 1.35.88 2.28 0 3.27-1.99 3.99-3.89 4.2.31.26.58.78.58 1.58v2.34c0 .22.15.49.58.4A8.5 8.5 0 0 0 10 1.5Z"/></svg>',
     category: 'developer',
-    transport: 'stdio',
-    command: 'npx',
-    args: ['-y', '@modelcontextprotocol/server-github'],
+    transport: 'http',
+    url: 'https://api.githubcopilot.com/mcp/',
     envVars: [
-      { name: 'GITHUB_PERSONAL_ACCESS_TOKEN', label: 'Personal Access Token', required: true, secret: true, helpUrl: 'https://github.com/settings/tokens' },
+      {
+        name: 'GITHUB_PERSONAL_ACCESS_TOKEN',
+        label: 'Personal Access Token',
+        required: true,
+        secret: true,
+        helpUrl: 'https://github.com/settings/tokens',
+        header: { name: 'Authorization', valuePrefix: 'Bearer ' },
+      },
     ],
   },
   {

--- a/src/lib/components/AddEndpointModal.svelte
+++ b/src/lib/components/AddEndpointModal.svelte
@@ -20,6 +20,7 @@
     buildMountExample,
     buildOrgBoundEndpointParams,
     buildCatalogEnvAndHeaders,
+    mergeHeaders,
     type AddEndpointFieldErrors,
     type AddEndpointFormSnapshot,
     type MountRow,
@@ -455,12 +456,10 @@
     }
     if (Object.keys(env).length > 0) params.env = env;
 
-    // Build headers: catalog header-typed vars + custom headers (custom wins)
+    // Build headers: catalog header-typed vars + custom headers (custom wins,
+    // matched case-insensitively)
     if (transport !== 'stdio') {
-      const headers: Record<string, string> = { ...catalogValues.headers };
-      for (const h of headerVars.filter((h) => h.key.trim())) {
-        headers[h.key.trim()] = h.value;
-      }
+      const headers = mergeHeaders(catalogValues.headers, headerVars);
       if (Object.keys(headers).length > 0) params.headers = headers;
     }
 
@@ -541,11 +540,25 @@
       return;
     }
 
+    // Catalog env/header values are needed both to gate the OAuth probe below
+    // and to build the add params further down.
+    const catalogValues = selectedCatalog
+      ? buildCatalogEnvAndHeaders(selectedCatalog, catalogEnvValues)
+      : { env: {}, headers: {} };
+    const hasCatalogHeaderCredentials = Object.keys(catalogValues.headers).length > 0;
+
     // Add-time OAuth detection (http/sse only). Best-effort + non-blocking:
     // probe the entered URL and, if the server advertises OAuth, surface the
     // opt-out escalation prompt instead of adding. Any probe failure / timeout
     // / `oauth_supported:false` silently falls through to the plain add below.
-    if (!opts?.skipProbe && (transport === 'http' || transport === 'sse')) {
+    // Skipped when the catalog entry already supplies header credentials (e.g.
+    // the GitHub bearer PAT): the user has chosen that auth model, and the
+    // escalation prompt would misdescribe the add as unauthenticated.
+    if (
+      !opts?.skipProbe &&
+      !hasCatalogHeaderCredentials &&
+      (transport === 'http' || transport === 'sse')
+    ) {
       submitting = true;
       let probe: OAuthProbeResult = { oauth_supported: false };
       try {
@@ -634,9 +647,6 @@
     }
 
     // Build env: catalog env vars + custom env vars
-    const catalogValues = selectedCatalog
-      ? buildCatalogEnvAndHeaders(selectedCatalog, catalogEnvValues)
-      : { env: {}, headers: {} };
     const env: Record<string, string> = { ...catalogValues.env };
     const filteredEnv = envVars.filter((e) => e.key.trim());
     for (const e of filteredEnv) {
@@ -646,13 +656,10 @@
       params.env = env;
     }
 
-    // Build headers: catalog header-typed vars + custom headers (custom wins)
+    // Build headers: catalog header-typed vars + custom headers (custom wins,
+    // matched case-insensitively)
     if (transport !== 'stdio') {
-      const headers: Record<string, string> = { ...catalogValues.headers };
-      const filteredHeaders = headerVars.filter((h) => h.key.trim());
-      for (const h of filteredHeaders) {
-        headers[h.key.trim()] = h.value;
-      }
+      const headers = mergeHeaders(catalogValues.headers, headerVars);
       if (Object.keys(headers).length > 0) {
         params.headers = headers;
       }

--- a/src/lib/components/AddEndpointModal.svelte
+++ b/src/lib/components/AddEndpointModal.svelte
@@ -19,6 +19,7 @@
     hasMountRowErrors,
     buildMountExample,
     buildOrgBoundEndpointParams,
+    buildCatalogEnvAndHeaders,
     type AddEndpointFieldErrors,
     type AddEndpointFormSnapshot,
     type MountRow,
@@ -336,6 +337,7 @@
     transport = server.transport;
     command = server.command ?? '';
     args = (server.args ?? []).join(' ');
+    url = server.url ?? '';
     selectedOrganization = '';
     catalogEnvValues = {};
     userArgValues = server.userArgs ? server.userArgs.map(() => '') : [];
@@ -443,22 +445,19 @@
       params.url = url.trim();
     }
 
-    // Build env
-    const env: Record<string, string> = {};
-    if (selectedCatalog) {
-      for (const ev of selectedCatalog.envVars) {
-        const val = catalogEnvValues[ev.name] ?? '';
-        if (val.trim()) env[ev.name] = val.trim();
-      }
-    }
+    // Build env: catalog env vars + custom env vars
+    const catalogValues = selectedCatalog
+      ? buildCatalogEnvAndHeaders(selectedCatalog, catalogEnvValues)
+      : { env: {}, headers: {} };
+    const env: Record<string, string> = { ...catalogValues.env };
     for (const e of envVars.filter((e) => e.key.trim())) {
       env[e.key.trim()] = e.value;
     }
     if (Object.keys(env).length > 0) params.env = env;
 
-    // Build headers
+    // Build headers: catalog header-typed vars + custom headers (custom wins)
     if (transport !== 'stdio') {
-      const headers: Record<string, string> = {};
+      const headers: Record<string, string> = { ...catalogValues.headers };
       for (const h of headerVars.filter((h) => h.key.trim())) {
         headers[h.key.trim()] = h.value;
       }
@@ -635,13 +634,10 @@
     }
 
     // Build env: catalog env vars + custom env vars
-    const env: Record<string, string> = {};
-    if (selectedCatalog) {
-      for (const ev of selectedCatalog.envVars) {
-        const val = catalogEnvValues[ev.name] ?? '';
-        if (val.trim()) env[ev.name] = val.trim();
-      }
-    }
+    const catalogValues = selectedCatalog
+      ? buildCatalogEnvAndHeaders(selectedCatalog, catalogEnvValues)
+      : { env: {}, headers: {} };
+    const env: Record<string, string> = { ...catalogValues.env };
     const filteredEnv = envVars.filter((e) => e.key.trim());
     for (const e of filteredEnv) {
       env[e.key.trim()] = e.value;
@@ -650,9 +646,9 @@
       params.env = env;
     }
 
-    // Build headers from key-value pairs
+    // Build headers: catalog header-typed vars + custom headers (custom wins)
     if (transport !== 'stdio') {
-      const headers: Record<string, string> = {};
+      const headers: Record<string, string> = { ...catalogValues.headers };
       const filteredHeaders = headerVars.filter((h) => h.key.trim());
       for (const h of filteredHeaders) {
         headers[h.key.trim()] = h.value;

--- a/src/lib/components/AddEndpointModal.svelte
+++ b/src/lib/components/AddEndpointModal.svelte
@@ -334,8 +334,8 @@
     prefix = sanitizeName(server.name);
     description = server.description;
     transport = server.transport;
-    command = server.command;
-    args = server.args.join(' ');
+    command = server.command ?? '';
+    args = (server.args ?? []).join(' ');
     selectedOrganization = '';
     catalogEnvValues = {};
     userArgValues = server.userArgs ? server.userArgs.map(() => '') : [];

--- a/src/lib/components/AddEndpointModal.test.ts
+++ b/src/lib/components/AddEndpointModal.test.ts
@@ -22,6 +22,7 @@ import {
   buildOrgBoundEndpointParams,
   orgBindingApplies,
   buildCatalogEnvAndHeaders,
+  mergeHeaders,
   MOUNT_EXAMPLE_FALLBACK_HOST,
   type AddEndpointFieldErrors,
   type AddEndpointFormSnapshot,
@@ -1095,6 +1096,57 @@ describe('buildCatalogEnvAndHeaders', () => {
   });
 });
 
+describe('mergeHeaders', () => {
+  const seeded = { Authorization: 'Bearer ghp_abc' };
+
+  it('returns the seeded headers unchanged when there are no custom rows', () => {
+    expect(mergeHeaders(seeded, [])).toEqual(seeded);
+  });
+
+  it('adds custom rows that do not collide with seeded keys', () => {
+    expect(mergeHeaders(seeded, [{ key: 'X-Trace', value: '1' }])).toEqual({
+      Authorization: 'Bearer ghp_abc',
+      'X-Trace': '1',
+    });
+  });
+
+  it('lets a custom row override a seeded key with the same case', () => {
+    expect(mergeHeaders(seeded, [{ key: 'Authorization', value: 'token x' }])).toEqual({
+      Authorization: 'token x',
+    });
+  });
+
+  it('lets a custom row override a seeded key case-insensitively without leaving two keys', () => {
+    const out = mergeHeaders(seeded, [{ key: 'authorization', value: 'token x' }]);
+    expect(out).toEqual({ authorization: 'token x' });
+    expect(Object.keys(out)).toHaveLength(1);
+  });
+
+  it('trims custom keys and skips blank ones', () => {
+    expect(
+      mergeHeaders(seeded, [
+        { key: '  X-Trace  ', value: '1' },
+        { key: '   ', value: 'ignored' },
+      ]),
+    ).toEqual({ Authorization: 'Bearer ghp_abc', 'X-Trace': '1' });
+  });
+
+  it('applies later custom rows over earlier ones, case-insensitively', () => {
+    expect(
+      mergeHeaders({}, [
+        { key: 'X-Api-Key', value: 'a' },
+        { key: 'x-api-key', value: 'b' },
+      ]),
+    ).toEqual({ 'x-api-key': 'b' });
+  });
+
+  it('does not mutate the seeded map', () => {
+    const base = { Authorization: 'Bearer ghp_abc' };
+    mergeHeaders(base, [{ key: 'authorization', value: 'x' }]);
+    expect(base).toEqual({ Authorization: 'Bearer ghp_abc' });
+  });
+});
+
 // The modal builds its env/headers from `buildCatalogEnvAndHeaders` in both
 // the Test Connection (`buildConnectionParams`) and Add (`handleSubmit`)
 // paths, so header-typed catalog vars (GitHub PAT) reach `params.headers`.
@@ -1121,18 +1173,33 @@ describe('AddEndpointModal — catalog env/header wiring', () => {
   });
 
   it('seeds env and headers from the helper output, with custom rows applied afterwards', () => {
-    // Catalog-derived values seed the maps; the user's custom env/header rows
-    // are spread in afterwards so a custom row wins on key collision.
+    // Catalog-derived values seed the maps; the user's custom env rows are
+    // spread in afterwards, and custom header rows go through `mergeHeaders`
+    // so a custom row wins on a (case-insensitive) key collision.
     const envSeeds = addEndpointModalSource.match(
       /const env: Record<string, string> = \{ \.\.\.catalogValues\.env \};/g,
     ) ?? [];
-    const headerSeeds = addEndpointModalSource.match(
-      /const headers: Record<string, string> = \{ \.\.\.catalogValues\.headers \};/g,
+    const headerMerges = addEndpointModalSource.match(
+      /const headers = mergeHeaders\(catalogValues\.headers, headerVars\);/g,
     ) ?? [];
     expect(envSeeds.length).toBe(2);
-    expect(headerSeeds.length).toBe(2);
-    expect(addEndpointModalSource).toMatch(
-      /const headers: Record<string, string> = \{ \.\.\.catalogValues\.headers \};[\s\S]*?headers\[h\.key\.trim\(\)\] = h\.value;/,
+    expect(headerMerges.length).toBe(2);
+    // No inline case-sensitive header assignment remains.
+    expect(addEndpointModalSource).not.toMatch(/headers\[h\.key\.trim\(\)\] = h\.value;/);
+  });
+
+  it('skips the add-time OAuth probe when the catalog entry supplies header credentials', () => {
+    // The GitHub remote server advertises OAuth, so without this gate a user
+    // who entered a PAT would be shown the "supports OAuth" escalation prompt
+    // (whose "Keep unauthenticated" option misdescribes the bearer-PAT add).
+    // `catalogValues` must be computed before the probe so the gate can see
+    // the header-typed values.
+    const handleSubmitBlock = addEndpointModalSource.match(
+      /async function handleSubmit\([\s\S]*?const trimmedName = name\.trim\(\);/,
+    );
+    expect(handleSubmitBlock, 'expected the handleSubmit pre-add body').not.toBeNull();
+    expect(handleSubmitBlock![0]).toMatch(
+      /const catalogValues = selectedCatalog\s*\?\s*buildCatalogEnvAndHeaders\(selectedCatalog, catalogEnvValues\)[\s\S]*?const hasCatalogHeaderCredentials = Object\.keys\(catalogValues\.headers\)\.length > 0;[\s\S]*?if \(\s*!opts\?\.skipProbe &&\s*!hasCatalogHeaderCredentials &&\s*\(transport === 'http' \|\| transport === 'sse'\)\s*\) \{[\s\S]*?probe = await oauthProbe\(url\.trim\(\)\);/,
     );
   });
 

--- a/src/lib/components/AddEndpointModal.test.ts
+++ b/src/lib/components/AddEndpointModal.test.ts
@@ -751,10 +751,12 @@ describe('computeAddEndpointIsDirty', () => {
   });
 
   it('returns false against a catalog-prefilled baseline that is unchanged', () => {
+    // Mirrors the http GitHub catalog entry: URL prefilled, no command/args.
     const snap = makeSnapshot({
       name: 'GitHub',
-      command: 'npx',
-      args: '-y @modelcontextprotocol/server-github',
+      command: '',
+      args: '',
+      url: 'https://api.githubcopilot.com/mcp/',
       description: 'Code hosting and collaboration',
     });
     expect(computeAddEndpointIsDirty(snap, { ...snap })).toBe(false);
@@ -1083,6 +1085,74 @@ describe('buildCatalogEnvAndHeaders', () => {
     const github = CATALOG_SERVERS.find((s) => s.id === 'github')!;
     const out = buildCatalogEnvAndHeaders(github, { [github.envVars[0].name]: 'ghp_xyz' });
     expect(out).toEqual({ env: {}, headers: { Authorization: 'Bearer ghp_xyz' } });
+  });
+
+  it('produces no GITHUB_PERSONAL_ACCESS_TOKEN env var for the GitHub entry', () => {
+    const github = CATALOG_SERVERS.find((s) => s.id === 'github')!;
+    const out = buildCatalogEnvAndHeaders(github, { GITHUB_PERSONAL_ACCESS_TOKEN: 'ghp_xyz' });
+    expect(out.env).not.toHaveProperty('GITHUB_PERSONAL_ACCESS_TOKEN');
+    expect(out.headers.Authorization).toBe('Bearer ghp_xyz');
+  });
+});
+
+// The modal builds its env/headers from `buildCatalogEnvAndHeaders` in both
+// the Test Connection (`buildConnectionParams`) and Add (`handleSubmit`)
+// paths, so header-typed catalog vars (GitHub PAT) reach `params.headers`.
+// Test environment is node (not jsdom), so the assertions are on the Svelte
+// source — mirrors the static-source style used elsewhere in this suite.
+describe('AddEndpointModal — catalog env/header wiring', () => {
+  it('prefills the URL from the catalog entry in selectCatalog', () => {
+    const selectCatalogBlock = addEndpointModalSource.match(
+      /function selectCatalog\(server: CatalogServer\) \{[\s\S]*?step = 'configure';/,
+    );
+    expect(selectCatalogBlock, 'expected the selectCatalog body').not.toBeNull();
+    expect(selectCatalogBlock![0]).toMatch(/url = server\.url \?\? '';/);
+    expect(selectCatalogBlock![0]).toMatch(/command = server\.command \?\? '';/);
+    expect(selectCatalogBlock![0]).toMatch(/args = \(server\.args \?\? \[\]\)\.join\(' '\);/);
+  });
+
+  it('routes catalog values through buildCatalogEnvAndHeaders in both Test Connection and Add', () => {
+    const calls = addEndpointModalSource.match(
+      /buildCatalogEnvAndHeaders\(selectedCatalog, catalogEnvValues\)/g,
+    ) ?? [];
+    expect(calls.length).toBe(2);
+    // No inline catalog env loop remains — the helper is the single source of truth.
+    expect(addEndpointModalSource).not.toMatch(/for \(const ev of selectedCatalog\.envVars\)/);
+  });
+
+  it('seeds env and headers from the helper output, with custom rows applied afterwards', () => {
+    // Catalog-derived values seed the maps; the user's custom env/header rows
+    // are spread in afterwards so a custom row wins on key collision.
+    const envSeeds = addEndpointModalSource.match(
+      /const env: Record<string, string> = \{ \.\.\.catalogValues\.env \};/g,
+    ) ?? [];
+    const headerSeeds = addEndpointModalSource.match(
+      /const headers: Record<string, string> = \{ \.\.\.catalogValues\.headers \};/g,
+    ) ?? [];
+    expect(envSeeds.length).toBe(2);
+    expect(headerSeeds.length).toBe(2);
+    expect(addEndpointModalSource).toMatch(
+      /const headers: Record<string, string> = \{ \.\.\.catalogValues\.headers \};[\s\S]*?headers\[h\.key\.trim\(\)\] = h\.value;/,
+    );
+  });
+
+  it('keeps the container toggle and volume mounts gated on the stdio transport', () => {
+    // http catalog entries (GitHub) must not show Command/Arguments or the
+    // isolation controls; both live under the stdio branch.
+    expect(addEndpointModalSource).toMatch(
+      /\{#if transport === 'stdio'\}[\s\S]*?id="modal-ep-cmd"[\s\S]*?id="modal-ep-args"[\s\S]*?id="modal-ep-isolation"[\s\S]*?\{:else if transport === 'oauth'\}/,
+    );
+    expect(addEndpointModalSource).toMatch(
+      /let showMounts = \$derived\(transport === 'stdio' && isolationEnabled && !catalogNotContainerizable\);/,
+    );
+  });
+
+  it('still shows the API Key chip for the GitHub catalog entry', () => {
+    const github = CATALOG_SERVERS.find((s) => s.id === 'github')!;
+    expect(github.envVars.some((e) => e.required)).toBe(true);
+    expect(addEndpointModalSource).toMatch(
+      /\{#if server\.envVars\.some\(e => e\.required\)\}[\s\S]*?API Key/,
+    );
   });
 });
 

--- a/src/lib/components/AddEndpointModal.test.ts
+++ b/src/lib/components/AddEndpointModal.test.ts
@@ -1063,6 +1063,20 @@ describe('buildCatalogEnvAndHeaders', () => {
     expect(out).toEqual({ env: {}, headers: {} });
   });
 
+  it('trims the header name and skips blank header names', () => {
+    const padded = buildCatalogEnvAndHeaders(
+      { envVars: [{ ...headerVar, header: { name: '  X-Api-Key  ' } }] },
+      { PAT: 'raw' },
+    );
+    expect(padded.headers).toEqual({ 'X-Api-Key': 'raw' });
+
+    const blank = buildCatalogEnvAndHeaders(
+      { envVars: [{ ...headerVar, header: { name: '   ' } }] },
+      { PAT: 'raw' },
+    );
+    expect(blank).toEqual({ env: {}, headers: {} });
+  });
+
   it('uses an empty prefix when valuePrefix is absent', () => {
     const out = buildCatalogEnvAndHeaders(
       { envVars: [{ ...headerVar, header: { name: 'X-Api-Key' } }] },

--- a/src/lib/components/AddEndpointModal.test.ts
+++ b/src/lib/components/AddEndpointModal.test.ts
@@ -21,6 +21,7 @@ import {
   buildMountExample,
   buildOrgBoundEndpointParams,
   orgBindingApplies,
+  buildCatalogEnvAndHeaders,
   MOUNT_EXAMPLE_FALLBACK_HOST,
   type AddEndpointFieldErrors,
   type AddEndpointFormSnapshot,
@@ -1020,6 +1021,68 @@ describe('catalog containerizable flags', () => {
         expect(s.containerNote!.trim().length).toBeGreaterThan(0);
       }
     }
+  });
+});
+
+describe('buildCatalogEnvAndHeaders', () => {
+  const plainVar = { name: 'API_KEY', label: 'API Key', required: true, secret: true };
+  const headerVar = {
+    name: 'PAT',
+    label: 'Personal Access Token',
+    required: true,
+    secret: true,
+    header: { name: 'Authorization', valuePrefix: 'Bearer ' },
+  };
+
+  it('routes a header-typed var to headers with its prefix', () => {
+    const out = buildCatalogEnvAndHeaders({ envVars: [headerVar] }, { PAT: 'ghp_abc' });
+    expect(out.headers).toEqual({ Authorization: 'Bearer ghp_abc' });
+    expect(out.env).toEqual({});
+  });
+
+  it('routes a plain var to env', () => {
+    const out = buildCatalogEnvAndHeaders({ envVars: [plainVar] }, { API_KEY: 'k123' });
+    expect(out.env).toEqual({ API_KEY: 'k123' });
+    expect(out.headers).toEqual({});
+  });
+
+  it('trims values and skips empty ones', () => {
+    const out = buildCatalogEnvAndHeaders(
+      { envVars: [plainVar, headerVar] },
+      { API_KEY: '  k123  ', PAT: '   ' },
+    );
+    expect(out.env).toEqual({ API_KEY: 'k123' });
+    expect(out.headers).toEqual({});
+  });
+
+  it('skips vars with no entered value', () => {
+    const out = buildCatalogEnvAndHeaders({ envVars: [plainVar, headerVar] }, {});
+    expect(out).toEqual({ env: {}, headers: {} });
+  });
+
+  it('uses an empty prefix when valuePrefix is absent', () => {
+    const out = buildCatalogEnvAndHeaders(
+      { envVars: [{ ...headerVar, header: { name: 'X-Api-Key' } }] },
+      { PAT: 'raw' },
+    );
+    expect(out.headers).toEqual({ 'X-Api-Key': 'raw' });
+  });
+
+  it('splits a mixed set into env and headers', () => {
+    const out = buildCatalogEnvAndHeaders(
+      { envVars: [plainVar, headerVar] },
+      { API_KEY: 'k123', PAT: 'ghp_abc' },
+    );
+    expect(out).toEqual({
+      env: { API_KEY: 'k123' },
+      headers: { Authorization: 'Bearer ghp_abc' },
+    });
+  });
+
+  it('maps the catalog GitHub entry PAT to an Authorization bearer header', () => {
+    const github = CATALOG_SERVERS.find((s) => s.id === 'github')!;
+    const out = buildCatalogEnvAndHeaders(github, { [github.envVars[0].name]: 'ghp_xyz' });
+    expect(out).toEqual({ env: {}, headers: { Authorization: 'Bearer ghp_xyz' } });
   });
 });
 

--- a/src/lib/components/AddEndpointModal.test.ts
+++ b/src/lib/components/AddEndpointModal.test.ts
@@ -1159,6 +1159,23 @@ describe('mergeHeaders', () => {
     mergeHeaders(base, [{ key: 'authorization', value: 'x' }]);
     expect(base).toEqual({ Authorization: 'Bearer ghp_abc' });
   });
+
+  it('stores prototype-named keys as plain entries without polluting the prototype', () => {
+    const out = mergeHeaders(seeded, [
+      { key: '__proto__', value: 'x' },
+      { key: 'constructor', value: 'y' },
+    ]);
+    expect(Object.getPrototypeOf(out)).toBeNull();
+    expect(Object.keys(out).sort()).toEqual(['Authorization', '__proto__', 'constructor']);
+    expect(out['__proto__']).toBe('x');
+    expect(out['constructor']).toBe('y');
+    expect(({} as Record<string, unknown>)['x']).toBeUndefined();
+    expect(Object.keys(JSON.parse(JSON.stringify(out))).sort()).toEqual([
+      'Authorization',
+      '__proto__',
+      'constructor',
+    ]);
+  });
 });
 
 // The modal builds its env/headers from `buildCatalogEnvAndHeaders` in both

--- a/src/lib/components/add-endpoint-helpers.ts
+++ b/src/lib/components/add-endpoint-helpers.ts
@@ -1,4 +1,5 @@
 import type { OAuthCatalogEntry } from '$lib/data/oauth-catalog';
+import type { CatalogServer } from '$lib/catalog';
 import type { AddEndpointParams, EmaAuthConfig } from '$lib/api';
 
 export type ScopeMode = 'free' | 'checkbox';
@@ -52,6 +53,31 @@ export function buildScopesPayload(
  */
 export function shouldShowManualOAuthStar(entry: OAuthCatalogEntry): boolean {
   return entry.supportsDcr === false;
+}
+
+/**
+ * Splits the values the user entered for a catalog entry's config vars into
+ * the `env` and `headers` maps sent to the relay. Vars carrying a `header`
+ * target land in `headers` under the header name with `valuePrefix`
+ * prepended (e.g. `Authorization: Bearer <pat>`); all others land in `env`
+ * under the var name. Values are trimmed and empty ones are skipped.
+ */
+export function buildCatalogEnvAndHeaders(
+  catalog: Pick<CatalogServer, 'envVars'>,
+  values: Record<string, string>,
+): { env: Record<string, string>; headers: Record<string, string> } {
+  const env: Record<string, string> = {};
+  const headers: Record<string, string> = {};
+  for (const ev of catalog.envVars) {
+    const value = (values[ev.name] ?? '').trim();
+    if (!value) continue;
+    if (ev.header) {
+      headers[ev.header.name] = `${ev.header.valuePrefix ?? ''}${value}`;
+    } else {
+      env[ev.name] = value;
+    }
+  }
+  return { env, headers };
 }
 
 /** Total wall-clock budget for OAuth setup polling, in milliseconds. */

--- a/src/lib/components/add-endpoint-helpers.ts
+++ b/src/lib/components/add-endpoint-helpers.ts
@@ -80,6 +80,31 @@ export function buildCatalogEnvAndHeaders(
   return { env, headers };
 }
 
+/**
+ * Applies the user's custom header rows on top of catalog-seeded headers.
+ * HTTP header names are case-insensitive, so a custom row replaces any seeded
+ * key that matches ignoring case (e.g. `authorization` overrides
+ * `Authorization`) instead of adding a second, ambiguous key. Rows with a
+ * blank key are skipped.
+ */
+export function mergeHeaders(
+  base: Record<string, string>,
+  overrides: { key: string; value: string }[],
+): Record<string, string> {
+  const merged: Record<string, string> = { ...base };
+  for (const row of overrides) {
+    const key = row.key.trim();
+    if (!key) continue;
+    for (const existing of Object.keys(merged)) {
+      if (existing !== key && existing.toLowerCase() === key.toLowerCase()) {
+        delete merged[existing];
+      }
+    }
+    merged[key] = row.value;
+  }
+  return merged;
+}
+
 /** Total wall-clock budget for OAuth setup polling, in milliseconds. */
 export const OAUTH_SETUP_POLL_BUDGET_MS = 120_000;
 

--- a/src/lib/components/add-endpoint-helpers.ts
+++ b/src/lib/components/add-endpoint-helpers.ts
@@ -60,7 +60,8 @@ export function shouldShowManualOAuthStar(entry: OAuthCatalogEntry): boolean {
  * the `env` and `headers` maps sent to the relay. Vars carrying a `header`
  * target land in `headers` under the header name with `valuePrefix`
  * prepended (e.g. `Authorization: Bearer <pat>`); all others land in `env`
- * under the var name. Values are trimmed and empty ones are skipped.
+ * under the var name. Values and header names are trimmed; empty values and
+ * blank header names are skipped.
  */
 export function buildCatalogEnvAndHeaders(
   catalog: Pick<CatalogServer, 'envVars'>,
@@ -72,7 +73,9 @@ export function buildCatalogEnvAndHeaders(
     const value = (values[ev.name] ?? '').trim();
     if (!value) continue;
     if (ev.header) {
-      headers[ev.header.name] = `${ev.header.valuePrefix ?? ''}${value}`;
+      const headerName = ev.header.name.trim();
+      if (!headerName) continue;
+      headers[headerName] = `${ev.header.valuePrefix ?? ''}${value}`;
     } else {
       env[ev.name] = value;
     }

--- a/src/lib/components/add-endpoint-helpers.ts
+++ b/src/lib/components/add-endpoint-helpers.ts
@@ -59,7 +59,8 @@ export function shouldShowManualOAuthStar(entry: OAuthCatalogEntry): boolean {
  * Splits the values the user entered for a catalog entry's config vars into
  * the `env` and `headers` maps sent to the relay. Vars carrying a `header`
  * target land in `headers` under the header name with `valuePrefix`
- * prepended (e.g. `Authorization: Bearer <pat>`); all others land in `env`
+ * prepended (e.g. the GitHub PAT becomes `Authorization: Bearer ghp_...`);
+ * all others land in `env`
  * under the var name. Values and header names are trimmed; empty values and
  * blank header names are skipped.
  */
@@ -88,13 +89,15 @@ export function buildCatalogEnvAndHeaders(
  * HTTP header names are case-insensitive, so a custom row replaces any seeded
  * key that matches ignoring case (e.g. `authorization` overrides
  * `Authorization`) instead of adding a second, ambiguous key. Rows with a
- * blank key are skipped.
+ * blank key are skipped. The result is a null-prototype map so user-typed
+ * keys such as `__proto__` are stored as plain entries rather than touching
+ * the object's prototype.
  */
 export function mergeHeaders(
   base: Record<string, string>,
   overrides: { key: string; value: string }[],
 ): Record<string, string> {
-  const merged: Record<string, string> = { ...base };
+  const merged: Record<string, string> = Object.assign(Object.create(null), base);
   for (const row of overrides) {
     const key = row.key.trim();
     if (!key) continue;


### PR DESCRIPTION
## Summary

The GitHub catalog entry now points at GitHub's hosted MCP server instead of spawning the deprecated stdio package.

- **GitHub entry → remote HTTP.** The `stdio` `npx -y @modelcontextprotocol/server-github` entry is replaced by an `http` entry targeting `https://api.githubcopilot.com/mcp/`.
- **PAT sent as a bearer header.** The Personal Access Token is no longer exported as `GITHUB_PERSONAL_ACCESS_TOKEN` in the child env; it is sent as `Authorization: Bearer <pat>` on the remote connection.
- **Header-typed catalog config vars.** `CatalogEnvVar` gains an optional `header: { name, valuePrefix? }` target. `CatalogServer.command` / `args` become optional (required for `stdio`), and `url` is required for `http` / `sse` entries.
- **Modal wiring.** `AddEndpointModal` routes catalog values through a new `buildCatalogEnvAndHeaders` helper, splitting them into the `env` and `headers` maps sent to the relay, and passes `url` for remote entries instead of `command` / `args`.
- **OAuth catalog entry unchanged.** The separate GitHub OAuth entry (`oauth-catalog`) is untouched.

## Tests

- `catalog.test.ts`: remote entries carry `url` and no `command` / `args`; stdio entries carry `command` / `args`; the GitHub entry maps its PAT to `Authorization` with the `Bearer ` prefix.
- `AddEndpointModal.test.ts`: `buildCatalogEnvAndHeaders` splits env vs. header vars, applies the prefix, trims and skips empty values; the modal submits `url` + `headers` for the GitHub entry and `command` + `args` + `env` for stdio entries.
- `catalog-http.live.test.ts` updated for the optional `command` / `args` shape.
